### PR TITLE
Fix mosquitto healthcheck

### DIFF
--- a/docker/mosquitto/Dockerfile
+++ b/docker/mosquitto/Dockerfile
@@ -1,3 +1,4 @@
 FROM eclipse-mosquitto:1.6.12
 
-HEALTHCHECK CMD timeout -t 5 mosquitto_sub -t '$SYS/#' -C 1 | grep -v Error || exit 1
+HEALTHCHECK --interval=10s --timeout=10s --retries=6 \
+  CMD timeout 5 mosquitto_sub -t '$SYS/#' -C 1 | grep -v Error || exit 1


### PR DESCRIPTION
Busybox's timeout switched to bash compatible arguments.