### PR TITLE
ci: add GitHub Actions workflow for modbus-serial tests

### DIFF
--- a/.github/workflows/modbus-serial-tests.yml
+++ b/.github/workflows/modbus-serial-tests.yml
@@ -1,0 +1,107 @@
+name: Modbus Serial Tests
+
+on:
+  push:
+    paths:
+      - 'docker/modbus-serial/**'
+      - '.github/workflows/modbus-serial-tests.yml'
+  pull_request:
+    paths:
+      - 'docker/modbus-serial/**'
+      - '.github/workflows/modbus-serial-tests.yml'
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      node-version: ${{ steps.nvmrc.outputs.node-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+        
+      - name: Read Node version from .nvmrc
+        id: nvmrc
+        run: |
+          NODE_VERSION=$(cat docker/modbus-serial/.nvmrc)
+          echo "node-version=$NODE_VERSION" >> $GITHUB_OUTPUT
+          echo "Node version from .nvmrc: $NODE_VERSION"
+          
+      - name: Check Node version consistency
+        run: |
+          NODE_VERSION=$(cat docker/modbus-serial/.nvmrc)
+          DOCKERFILE_VERSION=$(grep "FROM node:" docker/modbus-serial/Dockerfile | cut -d: -f2 | cut -d- -f1)
+          WORKFLOW_VERSION=$(grep -A 10 "node-version-file:" .github/workflows/modbus-serial-tests.yml | head -1 | grep -o "[0-9]*" || echo "$NODE_VERSION")
+          
+          echo "Node version in .nvmrc: $NODE_VERSION"
+          echo "Node version in Dockerfile: $DOCKERFILE_VERSION"
+          echo "Expected workflow version: $NODE_VERSION"
+          
+          if [ "$NODE_VERSION" != "$DOCKERFILE_VERSION" ]; then
+            echo "ERROR: Node version mismatch between .nvmrc ($NODE_VERSION) and Dockerfile ($DOCKERFILE_VERSION)"
+            exit 1
+          fi
+          
+          echo "✅ All Node versions are consistent"
+
+  test:
+    runs-on: ubuntu-latest
+    needs: version-check
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+        
+      - name: Setup Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'docker/modbus-serial/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'docker/modbus-serial/package-lock.json'
+          
+      - name: Install dependencies
+        working-directory: docker/modbus-serial
+        run: npm ci
+        
+      - name: Run tests
+        working-directory: docker/modbus-serial
+        run: npm test
+        
+      - name: Run test coverage
+        working-directory: docker/modbus-serial
+        run: npm test -- --coverage
+        
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: docker/modbus-serial/coverage/lcov.info
+          directory: docker/modbus-serial/coverage
+          flags: modbus-serial
+          name: modbus-serial-coverage
+          fail_ci_if_error: false
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [version-check, test]
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+        
+      - name: Build Docker image
+        run: |
+          docker build -t modbus-serial-test docker/modbus-serial/
+          
+      - name: Verify Docker image was built successfully
+        run: |
+          # Check that the image exists
+          docker images modbus-serial-test
+          
+          # Verify the image can be inspected
+          docker inspect modbus-serial-test > /dev/null
+          
+          echo "✅ Docker image built successfully"
+          
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rmi modbus-serial-test || true


### PR DESCRIPTION
Add CI workflow to test modbus-serial service including:
- Node.js version consistency checks between .nvmrc and Dockerfile
- Unit tests with Jest
- Test coverage reporting to Codecov
- Docker image build verification

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
