### PR TITLE
ci: add Docker Hub authentication to GitHub workflows

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md - GitHub Workflows
+
+This file provides guidance to Claude Code when working with GitHub Actions workflows in this repository.
+
+## Docker Hub Authentication
+
+**IMPORTANT**: All workflows that build or interact with Docker images MUST include Docker Hub login before any Docker operations.
+
+### Required Login Step
+
+Always add the following step before building, pulling, or pushing Docker images:
+
+```yaml
+- name: Login to Docker Hub
+  uses: docker/login-action@v3
+  with:
+    username: ${{ secrets.DOCKER_HUB_USERNAME }}
+    password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+```
+
+### When to Add Docker Hub Login
+
+Add Docker Hub login to workflows that:
+- Build Docker images (`docker build`)
+- Use docker compose with build operations
+- Pull from private Docker repositories
+- Push images to Docker Hub
+- Run Docker containers that may need private image access
+
+### Required Secrets
+
+Ensure these secrets are configured in the repository settings:
+- `DOCKER_HUB_USERNAME` - Docker Hub username
+- `DOCKER_HUB_ACCESS_TOKEN` - Docker Hub access token (not password)
+
+### Example Workflow Structure
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5.0.0
+        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        
+      - name: Build Docker image
+        run: docker build -t my-image .
+```
+
+## Workflow Standards
+
+- Use `actions/checkout@v5.0.0` for consistency
+- Place Docker Hub login immediately after checkout
+- Use meaningful job and step names
+- Include proper error handling and cleanup steps

--- a/.github/workflows/automations-tests.yml
+++ b/.github/workflows/automations-tests.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
         
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        
       - name: Build Docker image
         run: |
           docker build -t automations-test docker/automations/

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -11,5 +11,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5.0.0
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Build all containers
         run: docker compose --env-file example.env --file docker-compose.yml up --build --force-recreate --no-start

--- a/.github/workflows/lights-test.yml
+++ b/.github/workflows/lights-test.yml
@@ -11,6 +11,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5.0.0
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Run containers
         run: |
           sudo chown -R 1000:1000 data/nodered

--- a/.github/workflows/modbus-serial-tests.yml
+++ b/.github/workflows/modbus-serial-tests.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
         
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        
       - name: Build Docker image
         run: |
           docker build -t modbus-serial-test docker/modbus-serial/

--- a/.github/workflows/telegram-bridge-tests.yml
+++ b/.github/workflows/telegram-bridge-tests.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
         
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        
       - name: Build Docker image
         run: |
           docker build -t telegram-bridge-test docker/telegram-bridge/


### PR DESCRIPTION
- Add Docker Hub login step to all workflows that build Docker images
- Include login in telegram-bridge-tests, automations-tests, modbus-serial-tests workflows
- Add authentication to infrastructure and lights-test workflows
- Create .github/workflows/CLAUDE.md with mandatory Docker Hub login guidelines
- Ensures workflows can access private repositories and push images when needed

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
