### PR TITLE
feat: add 6 new GHCR base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,6 +101,72 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "docker"
+    directory: "/base-images/alpine"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "groupsky"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/base-images/nginx"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "groupsky"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/base-images/ubuntu"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "groupsky"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/base-images/dockergen"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "groupsky"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/base-images/wireguard"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "groupsky"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/base-images/mongo-express"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "groupsky"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+
   # Infrastructure Services - Base system components
   - package-ecosystem: "docker"
     directory: "/docker/nginx"

--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -49,6 +49,24 @@ jobs:
           - name: telegraf
             upstream_pattern: "telegraf:"
             ghcr_name: ghcr.io/groupsky/homy/telegraf
+          - name: alpine
+            upstream_pattern: "alpine:"
+            ghcr_name: ghcr.io/groupsky/homy/alpine
+          - name: nginx
+            upstream_pattern: "nginx:"
+            ghcr_name: ghcr.io/groupsky/homy/nginx
+          - name: ubuntu
+            upstream_pattern: "ubuntu:"
+            ghcr_name: ghcr.io/groupsky/homy/ubuntu
+          - name: dockergen
+            upstream_pattern: "jwilder/docker-gen:"
+            ghcr_name: ghcr.io/groupsky/homy/dockergen
+          - name: wireguard
+            upstream_pattern: "linuxserver/wireguard:"
+            ghcr_name: ghcr.io/groupsky/homy/wireguard
+          - name: mongo-express
+            upstream_pattern: "mongo-express:"
+            ghcr_name: ghcr.io/groupsky/homy/mongo-express
 
     steps:
       - name: Checkout code

--- a/base-images/alpine/Dockerfile
+++ b/base-images/alpine/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.22.1

--- a/base-images/docker-bake.hcl
+++ b/base-images/docker-bake.hcl
@@ -16,7 +16,13 @@ group "default" {
     "mosquitto",
     "mongo",
     "nodered",
-    "telegraf"
+    "telegraf",
+    "alpine",
+    "nginx",
+    "ubuntu",
+    "dockergen",
+    "wireguard",
+    "mongo-express"
   ]
 }
 
@@ -63,4 +69,34 @@ target "node-ubuntu" {
 target "nodered" {
   context = "./nodered"
   # Tags set via workflow: ghcr.io/groupsky/homy/nodered:${VERSION}
+}
+
+target "alpine" {
+  context = "./alpine"
+  # Tags set via workflow: ghcr.io/groupsky/homy/alpine:${VERSION}
+}
+
+target "nginx" {
+  context = "./nginx"
+  # Tags set via workflow: ghcr.io/groupsky/homy/nginx:${VERSION}
+}
+
+target "ubuntu" {
+  context = "./ubuntu"
+  # Tags set via workflow: ghcr.io/groupsky/homy/ubuntu:${VERSION}
+}
+
+target "dockergen" {
+  context = "./dockergen"
+  # Tags set via workflow: ghcr.io/groupsky/homy/dockergen:${VERSION}
+}
+
+target "wireguard" {
+  context = "./wireguard"
+  # Tags set via workflow: ghcr.io/groupsky/homy/wireguard:${VERSION}
+}
+
+target "mongo-express" {
+  context = "./mongo-express"
+  # Tags set via workflow: ghcr.io/groupsky/homy/mongo-express:${VERSION}
 }

--- a/base-images/dockergen/Dockerfile
+++ b/base-images/dockergen/Dockerfile
@@ -1,0 +1,1 @@
+FROM jwilder/docker-gen:0.15.0

--- a/base-images/mongo-express/Dockerfile
+++ b/base-images/mongo-express/Dockerfile
@@ -1,0 +1,1 @@
+FROM mongo-express:1-18

--- a/base-images/nginx/Dockerfile
+++ b/base-images/nginx/Dockerfile
@@ -1,0 +1,1 @@
+FROM nginx:1.29.1-alpine

--- a/base-images/ubuntu/Dockerfile
+++ b/base-images/ubuntu/Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:24.04

--- a/base-images/wireguard/Dockerfile
+++ b/base-images/wireguard/Dockerfile
@@ -1,0 +1,1 @@
+FROM linuxserver/wireguard:v1.0.20210914-ls1


### PR DESCRIPTION
## Summary

Add 6 new GHCR base images to complete the infrastructure for eliminating Docker Hub dependencies.

**Follow-up:** #1134 migrates all services to use these base images

## New Base Images

Creates GHCR mirrors for all remaining external Docker dependencies:

- `alpine:3.22.1` → `ghcr.io/groupsky/homy/alpine:3.22.1`
- `nginx:1.29.1-alpine` → `ghcr.io/groupsky/homy/nginx:1.29.1-alpine`  
- `ubuntu:24.04` → `ghcr.io/groupsky/homy/ubuntu:24.04`
- `jwilder/docker-gen:0.15.0` → `ghcr.io/groupsky/homy/dockergen:0.15.0`
- `linuxserver/wireguard:v1.0.20210914-ls1` → `ghcr.io/groupsky/homy/wireguard:v1.0.20210914-ls1`
- `mongo-express:1-18` → `ghcr.io/groupsky/homy/mongo-express:1-18`

## Changes

### Base Image Dockerfiles
- Created 6 new base image directories in `base-images/`
- Each contains a simple Dockerfile mirroring the upstream image
- All follow the same pure mirror pattern as existing base images

### Infrastructure Updates
- Updated `base-images/docker-bake.hcl` with 6 new targets
- Extended `.github/workflows/base-images.yml` matrix
- Added Dependabot monitoring in `.github/dependabot.yml`

### Build & Publish Process
When merged to master:
1. Base-images workflow triggers automatically
2. Pulls each upstream image from Docker Hub (one-time)
3. Publishes to GHCR at `ghcr.io/groupsky/homy/*`
4. Images become available for services to use

## Impact

**Current State:**
- Total base images: 15 (9 original + 6 new)
- All base images defined and configured
- Ready to build and publish on merge

**After Merge:**
- Base images published to GHCR
- Services can migrate to use them (#1134)
- Docker Hub rate limits completely eliminated

## Testing

- ✅ `validate-base-images` workflow passes
- ✅ `validate-coverage` confirms Dependabot configured
- ✅ docker-bake.hcl syntax valid
- ✅ All Dockerfiles valid

## CI Status

Base images workflow successfully builds all 15 images in PR context (not pushed). On merge to master, images will be published to GHCR.

**Expected behavior:**
- ✅ Base images build successfully
- ⏳ Not pushed to GHCR (PR builds don't publish)
- ✅ Service builds will succeed after base images are published

## Next Steps

1. **Merge this PR** → Publishes base images to GHCR
2. **Wait ~5 minutes** → Base-images workflow completes
3. **Merge #1134** → Migrates all services to use GHCR base images