### PR TITLE
feat: add zigbee2mqtt base image to GHCR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -178,6 +178,17 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "docker"
+    directory: "/base-images/zigbee2mqtt"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "groupsky"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+
   # Infrastructure Services - Base system components
   - package-ecosystem: "docker"
     directory: "/docker/nginx"

--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -70,6 +70,9 @@ jobs:
           - name: mongo-express
             upstream_pattern: "mongo-express:"
             ghcr_name: ghcr.io/groupsky/homy/mongo-express
+          - name: zigbee2mqtt
+            upstream_pattern: "ghcr.io/koenkk/zigbee2mqtt:"
+            ghcr_name: ghcr.io/groupsky/homy/zigbee2mqtt
 
     steps:
       - name: Checkout code

--- a/base-images/docker-bake.hcl
+++ b/base-images/docker-bake.hcl
@@ -23,7 +23,8 @@ group "default" {
     "ubuntu",
     "dockergen",
     "wireguard",
-    "mongo-express"
+    "mongo-express",
+    "zigbee2mqtt"
   ]
 }
 
@@ -105,4 +106,9 @@ target "mongo-express" {
 target "influxdb2" {
   context = "./influxdb2"
   # Tags set via workflow: ghcr.io/groupsky/homy/influxdb2:${VERSION}
+}
+
+target "zigbee2mqtt" {
+  context = "./zigbee2mqtt"
+  # Tags set via workflow: ghcr.io/groupsky/homy/zigbee2mqtt:${VERSION}
 }

--- a/base-images/zigbee2mqtt/Dockerfile
+++ b/base-images/zigbee2mqtt/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/koenkk/zigbee2mqtt:2.7.2
+
+# Healthcheck using Node.js (already available in container)
+# Checks if frontend web interface is responding
+HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=5 \
+  CMD node -e "require('http').get('http://localhost:8080/', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"


### PR DESCRIPTION
## Summary

Add Zigbee2MQTT base image mirror to GitHub Container Registry (GHCR) to eliminate Docker Hub dependency and enable two-step dependency upgrade workflow.

**This PR must be merged first** before the main zigbee2mqtt service PR, as the service depends on this base image being available.

## Base Image Configuration

- **Mirror**: `ghcr.io/groupsky/homy/zigbee2mqtt:2.7.2`
- **Upstream**: `ghcr.io/koenkk/zigbee2mqtt:2.7.2`
- **Healthcheck**: Node.js-based HTTP check on port 8080
- **Build system**: Added to `docker-bake.hcl` targets
- **CI/CD**: Added to base-images workflow matrix

## Healthcheck Implementation

Uses Node.js (already available in the upstream container):
```dockerfile
HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=5 \
  CMD node -e "require('http').get('http://localhost:8080/', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
```

**Why Node.js instead of wget?**
- No additional dependencies needed (Node.js is already in the container)
- Properly verifies HTTP 200 response, not just TCP connection
- More reliable than simple TCP checks
- 120s startup period accounts for Zigbee coordinator initialization

## Automation

- ✅ **Dependabot**: Weekly upstream version checks configured
- ✅ **CI/CD**: Automatic build and publish to GHCR on merge to master
- ✅ **Version extraction**: Dynamic from Dockerfile (no manual tag updates needed)

## Benefits

1. **Eliminates Docker Hub rate limits** - All pulls from GHCR instead
2. **Two-step upgrade workflow** - Base image updates tested separately from service
3. **Centralized control** - All dependency versions managed through base images
4. **Faster CI/CD** - Pre-built layers cached in GHCR

## Files Changed

- `base-images/zigbee2mqtt/Dockerfile` - New base image with healthcheck
- `base-images/docker-bake.hcl` - Added zigbee2mqtt target
- `.github/workflows/base-images.yml` - Added to build matrix
- `.github/dependabot.yml` - Added weekly version monitoring

## Testing

Base image builds successfully:
```bash
cd base-images && docker buildx bake zigbee2mqtt
```

## Next Steps

After this PR is merged:
1. GitHub Actions will build and publish the image to GHCR
2. The image will be available at `ghcr.io/groupsky/homy/zigbee2mqtt:2.7.2`
3. The main zigbee2mqtt service PR can be merged (depends on this base image)

## Related

- Follows project GHCR-only policy documented in `base-images/CLAUDE.md`
- Prerequisite for zigbee2mqtt service PR
- Complies with `.github/workflows/validate-docker-dependencies.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)