### PR TITLE
Add ingress template validation to infrastructure workflow

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -41,8 +41,24 @@ jobs:
 
       - name: Validate ingress template generation
         run: |
+          echo "Creating ingress network and starting ingress container..."
+          docker compose --env-file example.env up -d ingress
+
           echo "Starting test backend services for ingress validation..."
           docker compose --env-file example.env up -d grafana ha
+
+          echo "Waiting for services to be healthy on ingress network..."
+          for i in {1..10}; do
+            if docker network inspect homy_ingress -f '{{range .Containers}}{{.Name}} {{end}}' | grep -q grafana && \
+               docker network inspect homy_ingress -f '{{range .Containers}}{{.Name}} {{end}}' | grep -q ha; then
+              echo "✓ Services connected to ingress network after $i seconds"
+              break
+            fi
+            if [ $i -eq 10 ]; then
+              echo "WARNING: Services may not be fully connected to network"
+            fi
+            sleep 1
+          done
 
           echo "Starting ingressgen to generate nginx config..."
           docker compose --env-file example.env up -d ingressgen


### PR DESCRIPTION
## Summary

Add comprehensive validation of nginx template generation to the infrastructure workflow to catch issues like empty upstream blocks before deployment.

This validation would have caught the recent docker-gen 0.16.x compatibility issue where container name matching failed and resulted in empty upstream blocks, causing a 5.5-hour production outage.

## Changes

### Validation Steps Added

1. **Create ingress network** - Starts ingress container first to ensure network exists
2. **Start test backend services** - Starts grafana and ha as upstream targets
3. **Wait for network connectivity** - Tight loop (1s intervals, max 10s) ensuring services connect to ingress network
4. **Generate nginx config** - Runs ingressgen to generate configuration from template
5. **Wait for config generation** - Tight loop (1s intervals, max 30s) waiting for config file
6. **Validate config content**:
   - Config file exists and is not empty
   - Upstream blocks are present
   - Upstream blocks contain server entries (not empty)
7. **Start nginx** - Launches nginx with generated config
8. **Wait for nginx startup** - Tight loop (1s intervals, max 15s) waiting for container
9. **Validate nginx syntax** - Runs `nginx -t` to verify configuration
10. **Check logs** - Reviews ingressgen logs for critical errors

### Implementation Details

- Uses already-built containers from infrastructure workflow
- Employs tight loops with 1-second sleep intervals for fast failure detection
- Ensures proper network connectivity before template generation (critical for docker-gen to discover services)
- Provides clear error messages and dumps relevant logs on failure
- Tests the actual failure scenario from the recent incident

### Fixes During Development

Two commits were required to make the validation work correctly:

1. **fix: use ha instead of non-existent whoami service** ([8854402](https://github.com/groupsky/homy/commit/8854402)) - Replaced non-existent whoami service with ha (Home Assistant) which has VIRTUAL_HOST configured

2. **fix: ensure services connect to ingress network before template generation** ([1656996](https://github.com/groupsky/homy/commit/1656996)) - Added network connectivity checks to prevent race condition where ingressgen runs before services join the shared network, which would result in empty upstream blocks (the exact issue we're preventing)

## Why This Matters

### Recent Incident Context

On Jan 16, Dependabot merged docker-gen upgrade from 0.15.0 to 0.16.1, which introduced breaking changes in template evaluation:
- Container name matching failed (Docker API returns names with "/" prefix)
- Missing `/etc/nginx/certs` directory caused template errors
- Result: Empty upstream blocks → nginx failed to start → 5.5 hour outage

### What This Prevents

This validation will catch:
- ✅ Empty upstream blocks
- ✅ Template syntax errors  
- ✅ Nginx configuration errors
- ✅ Container discovery failures
- ✅ Template function compatibility issues
- ✅ Network connectivity race conditions

## Testing Results

CI validation passed successfully with:
- Config generation: **1 second**
- Network connectivity: **1 second**
- Nginx startup: **1 second**
- Total validation time: **~10-15 seconds**

Example output:
```
✓ Services connected to ingress network after 1 seconds
✓ Config file generated after 1 seconds
✓ Upstream blocks found
✓ Upstream blocks contain server entries
upstream grafana.local {
    # homy-grafana-1
    server 172.22.0.3:3000 ;
}
upstream ha.local {
    # homy-ha-1
    server 172.22.0.4:8123 ;
}
✓ Nginx container started after 1 seconds
nginx: configuration file /etc/nginx/nginx.conf test is successful
✓ Ingress template validation complete
```

## Related Issues

- Template fixes: commits [8b1b63d](https://github.com/groupsky/homy/commit/8b1b63d) and [d7ac8da](https://github.com/groupsky/homy/commit/d7ac8da) (container matching and certs handling)
- Dependabot PR [#1140](https://github.com/groupsky/homy/pull/1140) (docker-gen upgrade that caused the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)