### PR TITLE
feat: add Node-RED 4.1.2-18 base image

### DIFF
--- a/base-images/nodered/Dockerfile
+++ b/base-images/nodered/Dockerfile
@@ -1,1 +1,1 @@
-FROM nodered/node-red:3.1.15-18
+FROM nodered/node-red:4.1.2-18


### PR DESCRIPTION
This PR creates the Node-RED 4.1.2-18 base image required for PR #1106.

## Changes

Updated `base-images/nodered/Dockerfile`:
- From: `nodered/node-red:3.1.15-18`
- To: `nodered/node-red:4.1.2-18`

## Node-RED 4.0 Changes

- JSONata 2.0 upgrade (async-only API)
- CSV node RFC4180 compliance
- Requires Node.js 18+
- Security fix: on-headers CVE-2025-7339

## Workflow

1. **Merge this PR first** to trigger base image build
2. Wait for CI to publish to GHCR
3. Then merge the service update PR

Related: #1106