### PR TITLE
fix: update Node-RED service to use GHCR base image 4.1.2

### DIFF
--- a/docker/nodered/Dockerfile
+++ b/docker/nodered/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/groupsky/homy/nodered:3.1.15-18
+FROM ghcr.io/groupsky/homy/nodered:4.1.2-18
 
 # Copy package.json to the WORKDIR so npm builds all
 # of your added nodes modules for Node-RED


### PR DESCRIPTION
This PR updates the Node-RED service to use the new 4.1.2 base image from GHCR.

Changes:
- Update docker/nodered/Dockerfile to use ghcr.io/groupsky/homy/nodered:4.1.2-18
- Enforces GHCR-only policy
- Supports Node-RED 4.1.2 upgrade
- Includes on-headers 1.1.0 security fix

Dependencies:
IMPORTANT: This PR depends on PR #1163 being merged first.
Must wait for GHCR publication before merging this.

Fixes #1106