### PR TITLE
fix(door-alarm): stop alarm immediately when door closes

### DIFF
--- a/docker/automations/bots/door-alarm.js
+++ b/docker/automations/bots/door-alarm.js
@@ -85,7 +85,7 @@ module.exports = (name, config) => {
 
           const timer = setTimeout(async () => {
             const alarmPayload = {
-              alarm: 'ON',
+              alarm: true,
               volume: step.volume,
               duration: step.durationSec,
               melody
@@ -117,7 +117,7 @@ module.exports = (name, config) => {
 
         // Stop any currently sounding alarm
         try {
-          await mqtt.publish(alarmDevice.commandTopic, { alarm: 'OFF' })
+          await mqtt.publish(alarmDevice.commandTopic, { alarm: false })
           log('stopped alarm on door close')
         } catch (error) {
           log('failed to stop alarm on door close:', error.message)
@@ -145,7 +145,7 @@ module.exports = (name, config) => {
 
             const timer = setTimeout(async () => {
               const alarmPayload = {
-                alarm: 'ON',
+                alarm: true,
                 volume: step.volume,
                 duration: step.durationSec,
                 melody
@@ -167,7 +167,7 @@ module.exports = (name, config) => {
             log(`alarm step ${alarm.stepIndex + 1} expired during downtime, triggering immediately`)
 
             const alarmPayload = {
-              alarm: 'ON',
+              alarm: true,
               volume: step.volume,
               duration: step.durationSec,
               melody

--- a/docker/automations/bots/door-alarm.md
+++ b/docker/automations/bots/door-alarm.md
@@ -126,7 +126,7 @@ On service restart with door still open:
 ### Output Topics
 
 - `{alarmDevice.commandTopic}` - Alarm device commands
-  - Payload format: `{ alarm: 'ON', volume: string, duration: number, melody: number }`
+  - Payload format: `{ alarm: boolean, volume: string, duration: number, melody: number }`
   - Example: `z2m/house1/floor1-alarm/set`
 
 ## Device Compatibility
@@ -142,7 +142,7 @@ Commands published to the alarm device topic:
 
 ```javascript
 {
-  alarm: 'ON',         // Trigger alarm
+  alarm: true,         // Trigger alarm (true=ON, false=OFF)
   volume: 'low',       // Volume level
   duration: 10,        // Duration in seconds
   melody: 10           // Melody number

--- a/docker/automations/bots/door-alarm.test.js
+++ b/docker/automations/bots/door-alarm.test.js
@@ -299,7 +299,7 @@ describe('door-alarm bot', () => {
       expect(mockMqtt.publish).toHaveBeenCalledWith(
         'z2m/house1/floor1-alarm/set',
         {
-          alarm: 'ON',
+          alarm: true,
           volume: 'low',
           duration: 10,
           melody: 10
@@ -318,7 +318,7 @@ describe('door-alarm bot', () => {
         2,
         'z2m/house1/floor1-alarm/set',
         {
-          alarm: 'ON',
+          alarm: true,
           volume: 'medium',
           duration: 20,
           melody: 10
@@ -337,7 +337,7 @@ describe('door-alarm bot', () => {
         3,
         'z2m/house1/floor1-alarm/set',
         {
-          alarm: 'ON',
+          alarm: true,
           volume: 'high',
           duration: 60,
           melody: 10
@@ -383,7 +383,7 @@ describe('door-alarm bot', () => {
       expect(mockMqtt.publish).toHaveBeenCalledTimes(1)
       expect(mockMqtt.publish).toHaveBeenCalledWith(
         'z2m/house1/floor1-alarm/set',
-        { alarm: 'OFF' }
+        { alarm: false }
       )
     })
 
@@ -407,7 +407,7 @@ describe('door-alarm bot', () => {
       expect(mockMqtt.publish).toHaveBeenCalledTimes(1)
       expect(mockMqtt.publish).toHaveBeenCalledWith(
         'z2m/house1/floor1-alarm/set',
-        { alarm: 'OFF' }
+        { alarm: false }
       )
     })
 
@@ -463,7 +463,7 @@ describe('door-alarm bot', () => {
       // First alarm should have triggered
       expect(mockMqtt.publish).toHaveBeenCalledWith(
         'z2m/house1/floor1-alarm/set',
-        expect.objectContaining({ alarm: 'ON' })
+        expect.objectContaining({ alarm: true })
       )
 
       mockMqtt.publish.mockClear()
@@ -477,7 +477,7 @@ describe('door-alarm bot', () => {
       // Should send alarm OFF command
       expect(mockMqtt.publish).toHaveBeenCalledWith(
         'z2m/house1/floor1-alarm/set',
-        { alarm: 'OFF' }
+        { alarm: false }
       )
     })
 
@@ -691,7 +691,7 @@ describe('door-alarm bot', () => {
       // Should send alarm OFF command for each close (no alarm ON commands since timers never reached)
       expect(mockMqtt.publish).toHaveBeenCalledTimes(5)
       mockMqtt.publish.mock.calls.forEach(call => {
-        expect(call[1]).toEqual({ alarm: 'OFF' })
+        expect(call[1]).toEqual({ alarm: false })
       })
     })
 


### PR DESCRIPTION
## Summary

Fixes the door alarm bot to immediately stop any sounding alarm when the door is closed, and updates alarm command format to use boolean values per Zigbee2MQTT specification.

## Problem

Previously, when the door was closed, the bot would cancel pending alarms but leave currently sounding alarms to run until their duration expired. This could be confusing and annoying for users who expected the alarm to stop immediately when addressing the issue.

Additionally, the code used string values `'ON'`/`'OFF'` for alarm commands instead of the documented boolean format `true`/`false`.

## Solution

1. **Alarm Stop Fix**: Modified `cancelAlarms()` function to send alarm OFF command to the device
2. **Boolean Format**: Updated all alarm commands to use boolean values per NAS-AB02B0 device specification
3. **Async Support**: Made MQTT subscription callback async to support await in the alarm stop logic
4. **Comprehensive Tests**: Added test coverage for the new functionality

## Changes

**Commit 1: Alarm Stop Functionality**
- `door-alarm.js`: Added alarm OFF command in `cancelAlarms()`, made callback async
- `door-alarm.test.js`: Updated 4 existing tests, added 2 new tests for alarm stop

**Commit 2: Boolean Value Refactoring**
- `door-alarm.js`: Changed `alarm: 'ON'/'OFF'` to `alarm: true/false` (4 locations)
- `door-alarm.test.js`: Updated all test expectations to use boolean values
- `door-alarm.md`: Updated documentation to reflect boolean format

## Test Results

All 42 tests passing:
- ✅ 2 new tests for alarm stop functionality
- ✅ 4 existing tests updated to expect alarm OFF command
- ✅ All alarm command expectations updated to boolean format
- ✅ Fixed rapid cycles test expectations
- ✅ All original functionality preserved

## Behavior

**Before**: Door closes → pending alarms cancelled, current alarm continues until duration expires

**After**: Door closes → pending alarms cancelled, current alarm stops immediately

## Command Format

**Before**: `{ alarm: 'ON', volume: 'low', duration: 10, melody: 10 }`

**After**: `{ alarm: true, volume: 'low', duration: 10, melody: 10 }`

Both formats work with the NAS-AB02B0 device, but boolean is the documented standard per [Zigbee2MQTT device specification](https://www.zigbee2mqtt.io/devices/NAS-AB02B0.html).

## Related

Follows up on PR #1177 (Door Alarm Automation)