### PR TITLE
build(base-images): bump MongoDB from 5.0.6 to 6.0.27

### DIFF
--- a/base-images/mongo/Dockerfile
+++ b/base-images/mongo/Dockerfile
@@ -1,1 +1,1 @@
-FROM mongo:5.0.6
+FROM mongo:6.0.27


### PR DESCRIPTION
## Summary

- Updates MongoDB base image from 5.0.6 to 6.0.27
- Includes critical security fix for MongoBleed vulnerability (CVE-2025-14847)
- Follows two-step upgrade workflow: base image first, services later via Dependabot

## Changes

- `base-images/mongo/Dockerfile`: MongoDB 5.0.6 → 6.0.27

## Impact

- When merged, GitHub Actions will build and publish the new base image to GHCR
- Service Dockerfiles (`docker/mongo/Dockerfile`) remain on 5.0.6 until updated separately
- Dependabot will create follow-up PRs to update services to reference 6.0.27
- Services using MongoDB: historian, mqtt-mongo, modbus-serial (via modbus-serial integration)

## Compatibility Research

Two subagents analyzed:
1. **Breaking changes from MongoDB 5→6**: Minimal impact, mostly compatible
2. **Our MongoDB usage**: Simple operations (find, insertOne, sort), already using compatible driver 7.0.0

Key finding: One deprecated API (`cursor.count()`) in historian service should be fixed before upgrading services, but not blocking base image update.

## Test Plan

- [x] Base image Dockerfile updated to 6.0.27
- [ ] CI builds base image successfully
- [ ] Base image published to GHCR
- [ ] Dependabot detects new version and creates service update PR
- [ ] Services rebuild and connect to MongoDB 6 successfully
- [ ] MongoDB data compatibility verified

## References

- [MongoDB 6.0.26 Release](https://www.mongodb.com/community/forums/t/mongodb-6-0-26-is-released/327872)
- [MongoDB Lifecycle Schedules](https://www.mongodb.com/legal/support-policy/lifecycles)