### PR TITLE
build(mongo): bump MongoDB service to v6.0.27

### DIFF
--- a/docker/mongo/Dockerfile
+++ b/docker/mongo/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/groupsky/homy/mongo:5.0.6
+FROM ghcr.io/groupsky/homy/mongo:6.0.27


### PR DESCRIPTION
## Summary
- Updates MongoDB service Docker image to version 6.0.27 to match the base image

## Context
The base image was already updated to MongoDB 6.0.27 in #1181, but the service Dockerfile (`docker/mongo/Dockerfile`) was still referencing version 5.0.6. This PR completes the MongoDB v6 upgrade by updating the service layer.

## Changes
- `docker/mongo/Dockerfile`: Updated FROM directive to use `ghcr.io/groupsky/homy/mongo:6.0.27`

## Test Plan
- CI validation will verify the Dockerfile builds successfully
- Service starts correctly with the new MongoDB version
- Existing MongoDB data should be compatible (MongoDB 6.0 maintains backward compatibility with 5.0 data formats)