### PR TITLE
fix(automations): handle initial null state in door-alarm bot

### DIFF
--- a/docker/automations/bots/door-alarm.js
+++ b/docker/automations/bots/door-alarm.js
@@ -206,17 +206,18 @@ module.exports = (name, config) => {
           return
         }
 
-        if (newDoorState && !doorState) {
-          // Door opened
+        // Update state
+        doorState = newDoorState
+        persistedCache.doorState = newDoorState
+
+        // React to new state
+        if (newDoorState) {
+          // Door is now open (from closed or initial null state)
           log('door opened, scheduling alarms')
-          doorState = true
-          persistedCache.doorState = true
           scheduleAlarms()
-        } else if (!newDoorState && doorState) {
-          // Door closed
+        } else {
+          // Door is now closed (from open or initial null state)
           log('door closed, cancelling alarms and stopping alarm')
-          doorState = false
-          persistedCache.doorState = false
           await cancelAlarms()
         }
       })

--- a/docker/automations/bots/door-alarm.md
+++ b/docker/automations/bots/door-alarm.md
@@ -97,9 +97,10 @@ Using the default configuration:
 ### Edge Cases
 
 - **Rapid open/close cycles**: Timers reset on each door state change
-- **Duplicate messages**: Duplicate door state messages are ignored to prevent multiple timer sets
+- **Duplicate messages**: Duplicate door state messages are ignored to prevent multiple timer sets, even when same message is received multiple times
 - **Service restart with door open**: Timers are restored from persisted state, expired alarms trigger immediately
-- **Door already open on startup**: Starts monitoring from first state message received
+- **Initial state handling**: First message initializes the door state correctly, whether door starts open or closed
+- **Message republishing**: Sensors that republish the same state multiple times are handled correctly through duplicate detection
 - **Door closes after some alarms**: Only cancels pending alarms, doesn't stop currently sounding alarm
 
 ### State Persistence
@@ -286,9 +287,11 @@ Monitor bot health through:
 
 ### State Management
 
-- **No persistent cache**: State is ephemeral, resets on service restart
-- **Local variables**: `isDoorOpen` boolean and `timers` array
-- **Timer management**: All timers cleared on door close or new door open
+- **Persistent cache**: Door state and pending alarms are persisted to survive service restarts
+- **State tracking**: `doorState` boolean (null/true/false) tracks current door state
+- **Timer restoration**: Timers are automatically restored after service restart if door was left open
+- **Reactive state handling**: State updates react to the new state value, not the transition, ensuring correct behavior from any initial state
+- **Timer management**: All timers cleared on door close, new timers scheduled on door open
 
 ### Dependencies
 


### PR DESCRIPTION
## Summary
- Fixes door alarm incorrectly triggering when door is open
- Handles initial `null` state correctly
- Prevents duplicate message processing
- Changes from transition-based to state-based logic

## Problem
The door alarm bot had a critical bug where it only handled `true↔false` state transitions, missing `null→false` transitions. This caused:
- Initial state `null` not recognized as different from `false`
- Duplicate messages not properly detected
- Potential false alarms when door opens after initial closed message

## Solution
Changed from checking specific state transitions to unconditionally updating state and reacting to the new value:
- Explicitly handles initial `null` state
- Compares new state with current state for duplicate detection
- Always updates state regardless of previous value
- Logs duplicate messages for debugging

## Tests
Added 6 comprehensive tests following TDD approach:
- Initial state null with first message being closed
- Duplicate closed messages from initial null state
- Null→false→true→false sequence
- Duplicate open messages don't schedule duplicate alarms
- Duplicate closed messages don't cancel alarms multiple times
- Interleaved duplicate messages during state transitions

All 48 tests passing.

## Files Changed
- `docker/automations/bots/door-alarm.js` - Core state handling logic
- `docker/automations/bots/door-alarm.test.js` - 6 new tests
- `docker/automations/bots/door-alarm.md` - Updated edge cases documentation