### PR TITLE
fix(automations): prevent premature light-off and duplicate toggle in bath-lights

### DIFF
--- a/docker/automations/bots/bath-lights.js
+++ b/docker/automations/bots/bath-lights.js
@@ -247,7 +247,7 @@ module.exports = (name, {
                 }
                 const changed = toggleState !== payload.state
                 toggleState = payload.state
-                if ((toggleType === 'switch' && changed) || (toggleType === 'button' && payload.state)) {
+                if ((toggleType === 'switch' && changed) || (toggleType === 'button' && changed && payload.state)) {
                     if (lightState) {
                         if (!lockState) {
                             if (verbose) {
@@ -302,8 +302,8 @@ module.exports = (name, {
                         if (verbose) {
                             console.log(`[${name}] turning off lights from unlocked timeout`)
                         }
-                        // Check current state before turning off
-                        if (lightState !== false && !lockState) {
+                        // Check current state before turning off - toggledTimer takes priority
+                        if (lightState !== false && !lockState && !toggledTimer) {
                             smartPublish(light.commandTopic, {state: false, r: 'unl-tout'})
                         }
                         unlockedTimer = null
@@ -346,8 +346,8 @@ module.exports = (name, {
                                 if (verbose) {
                                     console.log(`[${name}] turning off lights from opened timeout`)
                                 }
-                                // Check current state before turning off
-                                if (lightState !== false && !lockState) {
+                                // Check current state before turning off - toggledTimer takes priority
+                                if (lightState !== false && !lockState && !toggledTimer) {
                                     smartPublish(light.commandTopic, {state: false, r: 'don-tout'})
                                 }
                                 openedTimer = null
@@ -370,8 +370,8 @@ module.exports = (name, {
                             if (verbose) {
                                 console.log(`[${name}] turning off lights from closed timeout`)
                             }
-                            // Check current state before turning off
-                            if (lightState !== false && !lockState) {
+                            // Check current state before turning off - toggledTimer takes priority
+                            if (lightState !== false && !lockState && !toggledTimer) {
                                 smartPublish(light.commandTopic, {state: false, r: 'doff-tout'})
                             }
                             closedTimer = null


### PR DESCRIPTION
## Summary

- **Timer ordering bug**: When a door/lock event set a `closedTimer`/`openedTimer`/`unlockedTimer` and the user then pressed the manual toggle (setting `toggledTimer`), the door/lock timers would still fire and turn the lights off prematurely. Fixed by adding `!toggledTimer` guard in the three timer callbacks so the manual override always takes priority.

- **Duplicate message bug**: MQTT QoS 1 can re-deliver the same message. For button-type toggles, the condition `payload.state` would trigger on every `{state: true}` delivery — so a duplicate would see `lightState=true` and immediately turn the lights back off. Fixed by requiring an actual state transition (false/null → true) via the `changed` flag, matching the guard already used for switch-type toggles.

## Changes

- `bath-lights.js`: Added `&& !toggledTimer` to `closedTimer`, `openedTimer`, and `unlockedTimer` callbacks; added `&& changed` to the button-type trigger condition.
- `bath-lights.test.js`: Added 4 new TDD tests (written before the fix to confirm they fail); updated 4 existing tests to use proper press→release→press sequences.

## Test plan

- [ ] All 113 unit tests pass (`npx jest bots/bath-lights.test.js`)
- [ ] Verify the 4 new tests cover the race-condition ordering scenarios and the duplicate-message scenario
- [ ] Manual test: manually switch on bath lamp — it should stay on for the full configured `toggled` timeout even if a door event occurred just before