### PR TITLE
fix(ci): prevent multi-line JSON in GitHub Actions output

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -354,7 +354,7 @@ jobs:
           printf '  - %s\n' "${ALL_IMAGES[@]}"
 
           # Save as JSON array for iteration
-          IMAGES_JSON=$(printf '%s\n' "${ALL_IMAGES[@]}" | jq -R . | jq -s .)
+          IMAGES_JSON=$(printf '%s\n' "${ALL_IMAGES[@]}" | jq -R . | jq -sc .)
           echo "images=$IMAGES_JSON" >> $GITHUB_OUTPUT
           echo "count=${#ALL_IMAGES[@]}" >> $GITHUB_OUTPUT
 
@@ -542,7 +542,7 @@ jobs:
           done
 
           # Save built images list as JSON
-          BUILT_JSON=$(printf '%s\n' "${BUILT_IMAGES[@]}" | jq -R . | jq -s .)
+          BUILT_JSON=$(printf '%s\n' "${BUILT_IMAGES[@]}" | jq -R . | jq -sc .)
           echo "built_images=$BUILT_JSON" >> $GITHUB_OUTPUT
 
           echo ""


### PR DESCRIPTION
## Summary

Fixes CI failures in the "Prepare Base Images" stage caused by multi-line JSON values being written to `$GITHUB_OUTPUT`.

## Problem

The `jq -s .` command outputs pretty-printed JSON by default:
```json
[
  "dockergen"
]
```

When written to `$GITHUB_OUTPUT` as `key=value`, GitHub Actions cannot parse multi-line values and fails with:
```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '  "dockergen"'
```

## Solution

Added the `-c` (compact) flag to `jq` commands to produce single-line JSON output:
```bash
# Before
IMAGES_JSON=$(printf '%s\n' "${ALL_IMAGES[@]}" | jq -R . | jq -s .)

# After
IMAGES_JSON=$(printf '%s\n' "${ALL_IMAGES[@]}" | jq -R . | jq -sc .)
```

This outputs: `["dockergen"]` instead of multi-line formatted JSON.

## Changes

- `.github/workflows/ci-unified.yml` line 357: Add `-c` flag to `jq -s .` → `jq -sc .`
- `.github/workflows/ci-unified.yml` line 545: Add `-c` flag to `jq -s .` → `jq -sc .`

## Testing

This fix resolves the CI failure in PR #1220 (dependabot dockergen update).

## Related Issues

Fixes #1220 CI failures