### PR TITLE
fix(ci): Fix force_rebuild to actually build all images

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -234,15 +234,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Run the detection script
-          # If force_rebuild is enabled, use HEAD as base (everything changed)
+          # If force_rebuild is enabled, use empty tree as base (everything changed)
           BASE_REF="${{ steps.base-ref.outputs.base_ref }}"
           if [ "${{ inputs.force_rebuild }}" == "true" ]; then
-            echo "Force rebuild enabled - using HEAD as base ref"
-            BASE_REF="HEAD"
+            echo "Force rebuild enabled - comparing against empty tree"
+            # Use git's empty tree hash to make all files appear as changed
+            BASE_REF="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
           fi
 
-          # Get the actual SHA for base ref
-          BASE_SHA=$(git rev-parse "$BASE_REF")
+          # Get the actual SHA for base ref (for image tagging)
+          # For force rebuild, use the original base ref SHA for tagging
+          if [ "${{ inputs.force_rebuild }}" == "true" ]; then
+            BASE_SHA=$(git rev-parse "${{ steps.base-ref.outputs.base_ref }}")
+          else
+            BASE_SHA=$(git rev-parse "$BASE_REF")
+          fi
           echo "Base SHA for image tags: $BASE_SHA"
 
           # Run detection using absolute paths


### PR DESCRIPTION
## Problem

When `workflow_dispatch` was triggered with `force_rebuild=true`, the workflow would **not build any images** despite the flag being set. This made forced rebuilds completely non-functional.

### Root Cause

The bug was in `.github/workflows/ci-unified.yml` at lines 239-242:

```yaml
if [ "${{ inputs.force_rebuild }}" == "true" ]; then
  echo "Force rebuild enabled - using HEAD as base ref"
  BASE_REF="HEAD"  # ❌ BUG HERE
fi
```

This caused the change detection to run:
```bash
git diff HEAD HEAD  # Comparing HEAD to itself = no changes!
```

**Result:** All detection arrays were empty:
- `changed_services: []`
- `to_build: []`
- `changed_base_images: []`

## Solution

Use git's **empty tree hash** as the base ref when force rebuild is enabled:

```yaml
if [ "${{ inputs.force_rebuild }}" == "true" ]; then
  echo "Force rebuild enabled - comparing against empty tree"
  BASE_REF="4b825dc642cb6eb9a060e54bf8d69288fbee4904"  # Empty tree
fi
```

This makes `git diff` treat **all tracked files as changed**, triggering builds for:
- ✅ All base images
- ✅ All services
- ✅ All tests

### Additional Fix

Preserve the original base ref SHA for image tagging:
```yaml
# For force rebuild, use the original base ref SHA for tagging
if [ "${{ inputs.force_rebuild }}" == "true" ]; then
  BASE_SHA=$(git rev-parse "${{ steps.base-ref.outputs.base_ref }}")
else
  BASE_SHA=$(git rev-parse "$BASE_REF")
fi
```

This ensures images are tagged with meaningful `:sha` tags instead of the empty tree hash.

## Testing Evidence

**Before this fix (workflow run #23708682129):**
```
Force rebuild: true
Changed services: []
To build: []
To retag: []
Result: All stages skipped
```

**Expected after this fix:**
```
Force rebuild: true
Changed services: [all services]
To build: [all services]
Changed base images: [all base images]
Result: Full rebuild of entire stack
```

## Impact

- ✅ Fixes force rebuild functionality completely
- ✅ No impact on normal PR/push workflows (force_rebuild defaults to false)
- ✅ Preserves correct SHA tagging for images
- ✅ Makes manual rebuild workflows functional

## Related Issues

Discovered while investigating PR #1261 where forced rebuild was attempted but did nothing.