### PR TITLE
fix(bath-lights): ignore redundant Modbus DI re-published states

### DIFF
--- a/docker/automations/bots/bath-lights.js
+++ b/docker/automations/bots/bath-lights.js
@@ -286,7 +286,17 @@ module.exports = (name, {
                 if (verbose) {
                     console.log(`[${name}] lock changed`, payload)
                 }
+                const lockStateChanged = lockState !== payload.state
                 lockState = payload.state
+                // Ignore redundant re-published lock states. All dry-switch
+                // features on a Modbus DI module re-publish together whenever any
+                // single input on that module changes, so an unrelated door
+                // elsewhere causes this lock's last state to be re-emitted
+                // unchanged. Only a genuine lock/unlock transition should drive
+                // the light - otherwise a re-published "unlocked" arms a spurious
+                // unlock timer that the matching "door open" re-publish then turns
+                // into a bogus 'don-unl' off command.
+                if (!lockStateChanged) return
                 if (payload.state) {
                     if (verbose) {
                         console.log(`[${name}] turning on lights`)
@@ -322,8 +332,15 @@ module.exports = (name, {
                 doorState = payload.state
                 
                 if (payload.state) {
-                    // Door opened
-                    if (unlockedTimer) {
+                    // Door opened. Only react to a genuine closed->open
+                    // transition. A re-published "still open" status (Modbus DI
+                    // module republishing all inputs when an unrelated door
+                    // changes) must not be treated as the user opening the door,
+                    // otherwise it spuriously fires 'don-unl' while an unlock
+                    // timer is pending and turns the light off.
+                    if (!doorStateChanged) {
+                        // no-op: redundant re-publish of the current open state
+                    } else if (unlockedTimer) {
                         if (verbose) {
                             console.log(`[${name}] turning off lights`)
                         }
@@ -333,7 +350,7 @@ module.exports = (name, {
                         }
                         clearTimeout(unlockedTimer)
                         unlockedTimer = null
-                    } else if (doorStateChanged) {
+                    } else {
                         if (verbose) {
                             console.log(`[${name}] turning on lights`)
                         }

--- a/docker/automations/bots/bath-lights.js
+++ b/docker/automations/bots/bath-lights.js
@@ -331,16 +331,20 @@ module.exports = (name, {
                 const doorStateChanged = doorState !== payload.state
                 doorState = payload.state
                 
+                // Only react to genuine transitions. A re-published "still
+                // open"/"still closed" status (all dry-switch features on a
+                // Modbus DI module re-publish together whenever any single input
+                // on that module changes) must not be treated as the user
+                // operating this door, otherwise it spuriously fires 'don-unl'
+                // (while an unlock timer is pending) or re-arms the closed
+                // timeout and turns an intentionally-on light off.
+                if (!doorStateChanged) {
+                    return
+                }
+
                 if (payload.state) {
-                    // Door opened. Only react to a genuine closed->open
-                    // transition. A re-published "still open" status (Modbus DI
-                    // module republishing all inputs when an unrelated door
-                    // changes) must not be treated as the user opening the door,
-                    // otherwise it spuriously fires 'don-unl' while an unlock
-                    // timer is pending and turns the light off.
-                    if (!doorStateChanged) {
-                        // no-op: redundant re-publish of the current open state
-                    } else if (unlockedTimer) {
+                    // Door opened
+                    if (unlockedTimer) {
                         if (verbose) {
                             console.log(`[${name}] turning off lights`)
                         }
@@ -373,12 +377,10 @@ module.exports = (name, {
                     }
                 } else {
                     // Door closed
-                    if (doorStateChanged) {
-                        if (verbose) {
-                            console.log(`[${name}] turning on lights`)
-                        }
-                        smartPublish(light.commandTopic, {state: true, r: 'doff'})
+                    if (verbose) {
+                        console.log(`[${name}] turning on lights`)
                     }
+                    smartPublish(light.commandTopic, {state: true, r: 'doff'})
                     if (timeouts?.closed && !closedTimer && !lockState && !toggledTimer) {
                         if (verbose) {
                             console.log(`[${name}] turning off lights in ${timeouts.closed / 60000} minutes from closed timeout`)

--- a/docker/automations/bots/bath-lights.test.js
+++ b/docker/automations/bots/bath-lights.test.js
@@ -2249,6 +2249,96 @@ describe('bath-lights', () => {
         })
     })
 
+    describe('redundant re-publish handling (Modbus DI republish storm)', () => {
+        // All dry-switch features on a Modbus DI module re-publish their current
+        // state together whenever any single input on that module changes. So an
+        // unrelated door elsewhere on the module causes this bathroom's lock and
+        // door statuses to be re-emitted unchanged. The controller must ignore
+        // those redundant re-publishes and only react to genuine transitions.
+
+        test('should not turn off lights when unchanged lock+door states are re-published', () => {
+            const bathLights = BathLights('test-bath-lights', {
+                door: {statusTopic: 'door/status'},
+                lock: {statusTopic: 'lock/status'},
+                light: {commandTopic: 'lights/command', statusTopic: 'lights/status'},
+                timeouts: {unlocked: 180000},
+            })
+            const mockPublish = jest.fn()
+            const mqtt = {subscribe, publish: mockPublish}
+            bathLights.start({mqtt})
+
+            // Establish steady state via genuine transitions: unlocked, door open,
+            // light on, and no unlock timer pending (the unlock timer was already
+            // consumed by the genuine door-open below).
+            publish('lock/status', {state: false})   // genuine unlock -> arms unlock timer
+            publish('door/status', {state: true})     // genuine open while unlock pending -> don-unl, clears timer
+            publish('lights/status', {state: true})   // user turns the light back on
+            mockPublish.mockClear()
+
+            // Modbus republish storm: this bathroom's lock and door are re-emitted
+            // with their unchanged values. This is the exact prod sequence that
+            // (before the fix) armed an unlock timer on the re-published "unlocked"
+            // and then immediately fired 'don-unl' on the re-published "open".
+            publish('lock/status', {state: false})   // redundant unlocked
+            publish('door/status', {state: true})     // redundant open
+
+            expect(mockPublish).not.toHaveBeenCalled()
+
+            // And no delayed unlock-timeout off either: nothing was armed.
+            jest.advanceTimersByTime(180000)
+            expect(mockPublish).not.toHaveBeenCalled()
+        })
+
+        test('should not re-fire lock command when unchanged locked state is re-published', () => {
+            const bathLights = BathLights('test-bath-lights', {
+                door: {statusTopic: 'door/status'},
+                lock: {statusTopic: 'lock/status'},
+                light: {commandTopic: 'lights/command', statusTopic: 'lights/status'},
+                timeouts: {closed: 120000},
+            })
+            const mockPublish = jest.fn()
+            const mqtt = {subscribe, publish: mockPublish}
+            bathLights.start({mqtt})
+
+            // Genuine lock - turns lights on once.
+            publish('lock/status', {state: true})
+            expect(mockPublish).toHaveBeenCalledWith('lights/command', expect.objectContaining({state: true, r: 'lck'}))
+            mockPublish.mockClear()
+
+            // Redundant re-publish of the same locked state must be a no-op.
+            publish('lock/status', {state: true})
+            expect(mockPublish).not.toHaveBeenCalled()
+        })
+
+        test('should still react to a genuine transition that follows a redundant re-publish', () => {
+            const bathLights = BathLights('test-bath-lights', {
+                door: {statusTopic: 'door/status'},
+                lock: {statusTopic: 'lock/status'},
+                light: {commandTopic: 'lights/command', statusTopic: 'lights/status'},
+                timeouts: {unlocked: 180000},
+            })
+            const mockPublish = jest.fn()
+            const mqtt = {subscribe, publish: mockPublish}
+            bathLights.start({mqtt})
+
+            // Steady state: unlocked + door open + light on, no pending timer.
+            publish('lock/status', {state: false})
+            publish('door/status', {state: true})
+            publish('lights/status', {state: true})
+            mockPublish.mockClear()
+
+            // Redundant re-publishes (ignored).
+            publish('lock/status', {state: false})
+            publish('door/status', {state: true})
+            expect(mockPublish).not.toHaveBeenCalled()
+
+            // A genuine lock now must still turn the lights on (and the fix did not
+            // leave the controller's change-tracking in a broken state).
+            publish('lock/status', {state: true})
+            expect(mockPublish).toHaveBeenCalledWith('lights/command', expect.objectContaining({state: true, r: 'lck'}))
+        })
+    })
+
     describe('message ordering and duplicate handling', () => {
         test('should not turn off lights from door close timeout when toggle timer is set after door close', () => {
             // Bug scenario: door closes first (closedTimer set), then user presses toggle
@@ -2630,8 +2720,11 @@ describe('bath-lights', () => {
                 jest.advanceTimersByTime(10)
             }
 
-            // System should still be responsive
+            // System should still be responsive. Drive a genuine unlock->lock
+            // transition (the controller now ignores redundant same-state locks,
+            // so re-locking an already-locked door is intentionally a no-op).
             mockPublish.mockClear()
+            publish('lock/status', {state: false})
             publish('lock/status', {state: true})
             expect(mockPublish).toHaveBeenCalled()
         })
@@ -2865,8 +2958,10 @@ describe('bath-lights', () => {
             // Should handle message storm within reasonable time
             expect(endTime - startTime).toBeLessThan(5000)
             
-            // System should still be responsive after storm
+            // System should still be responsive after storm. Drive a genuine
+            // unlock->lock transition (redundant same-state locks are now a no-op).
             mockPublish.mockClear()
+            publish('lock/status', {state: false})
             publish('lock/status', {state: true})
             expect(mockPublish).toHaveBeenCalled()
         })

--- a/docker/automations/bots/bath-lights.test.js
+++ b/docker/automations/bots/bath-lights.test.js
@@ -2310,6 +2310,40 @@ describe('bath-lights', () => {
             expect(mockPublish).not.toHaveBeenCalled()
         })
 
+        test('should not re-arm the closed timeout when an unchanged closed state is re-published', () => {
+            const bathLights = BathLights('test-bath-lights', {
+                door: {statusTopic: 'door/status'},
+                lock: {statusTopic: 'lock/status'},
+                light: {commandTopic: 'lights/command', statusTopic: 'lights/status'},
+                timeouts: {closed: 120000},
+            })
+            const mockPublish = jest.fn()
+            const mqtt = {subscribe, publish: mockPublish}
+            bathLights.start({mqtt})
+
+            // Genuine close: turns light on ('doff') and arms the closed timer.
+            publish('door/status', {state: false})
+            publish('lights/status', {state: true})
+
+            // Closed timer fires once -> light off, timer cleared.
+            jest.advanceTimersByTime(120000)
+            expect(mockPublish).toHaveBeenCalledWith('lights/command', expect.objectContaining({state: false, r: 'doff-tout'}))
+            publish('lights/status', {state: false})
+
+            // Light is turned back on (door still closed, no timer pending).
+            publish('lights/status', {state: true})
+            mockPublish.mockClear()
+
+            // Modbus republish storm re-emits this door's unchanged "closed"
+            // state. It must not re-arm the closed timer (before the fix it did,
+            // turning the intentionally-on light off again after the timeout).
+            publish('door/status', {state: false})
+            expect(mockPublish).not.toHaveBeenCalled()
+
+            jest.advanceTimersByTime(120000)
+            expect(mockPublish).not.toHaveBeenCalled()
+        })
+
         test('should still react to a genuine transition that follows a redundant re-publish', () => {
             const bathLights = BathLights('test-bath-lights', {
                 door: {statusTopic: 'door/status'},


### PR DESCRIPTION
## Problem

The bath-lights controller turned a bathroom light **off** whenever an *unrelated* door elsewhere in the house was opened, closed, locked, or unlocked.

Reproduced live against the production MQTT broker: locking the office caused `bath1_ceiling_light` to switch off with reason code **`don-unl`**, twice, without anyone touching the bath1 door.

## Root cause

All dry-switch features (`bath1DoorLock`, `bath1DoorOpen`, every other door lock/open) are bits on the **same Modbus DI module `mbsl32di1`** (`config/automations/features.js:295-306`). When any single input on that module changes, the module reports all of its inputs, so every dry-switch transform re-publishes its current state together (identical `_tz`).

Within that single republish batch, the bath-lights bot:
1. Lock handler saw the re-published `unlocked` state and **armed an unlock timer** (no state-change guard).
2. Door handler then saw the re-published `open` state and, because the unlock timer was now pending, fired `{state:false, r:'don-unl'}` — turning the light off.

Neither message represented a real change; both were redundant re-publishes.

## Fix

Only react to genuine state transitions (mirrors the existing `doorStateChanged` pattern):
- **Lock handler** ignores messages that don't change `lockState`.
- **Door-open handler** only acts on a real `closed -> open` transition, so a re-published "still open" can't trigger `don-unl`.

## Tests

- New `redundant re-publish handling (Modbus DI republish storm)` describe block reproduces the exact prod sequence; all 3 tests fail on the unpatched bot and pass with the fix.
- Two pre-existing "still responsive" stress tests asserted responsiveness by **re-locking an already-locked** controller (they relied on the old buggy re-fire). Updated to drive a genuine `unlock -> lock` transition, which is what responsiveness should mean.
- Full suite: **116 passed**.