### PR TITLE
feat(alerting): per-phase mains power outage alerts

### DIFF
--- a/config/grafana/provisioning/alerting/ac-alert.yaml
+++ b/config/grafana/provisioning/alerting/ac-alert.yaml
@@ -47,27 +47,16 @@ groups:
             datasourceUid: P3C6603E967DC8568
             model:
               alias: "min V"
-              groupBy:
-                - params: ["$__interval"]
-                  type: time
-                - params: ["null"]
-                  type: fill
+              # Exclude kitchen (faulty 0V device) AND dead phases (v=0 during an
+              # outage) so a phase dropping to 0V no longer trips this generic
+              # "voltage out of range" alert — that is now covered by the dedicated
+              # phase-power-loss / total-power-outage alerts. Genuine brown-outs
+              # (a phase sagging to e.g. 150V, still > 0) are still caught.
+              query: 'SELECT min("v") FROM "current_power" WHERE "device.name" != ''kitchen'' AND "v" > 0 AND time >= now() - 300s'
+              rawQuery: true
+              resultFormat: time_series
               intervalMs: 1000
               maxDataPoints: 43200
-              measurement: current_power
-              orderByTime: ASC
-              policy: default
-              resultFormat: time_series
-              select:
-                - - params: ["v"]
-                    type: field
-                  - params: []
-                    type: min
-              tags:
-                # Exclude kitchen meter - faulty device that occasionally returns 0V readings
-                - key: "device.name"
-                  operator: "!="
-                  value: kitchen
           - refId: A
             queryType: ''
             relativeTimeRange:

--- a/config/grafana/provisioning/alerting/phase-power-loss-alert.yaml
+++ b/config/grafana/provisioning/alerting/phase-power-loss-alert.yaml
@@ -1,0 +1,74 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Phase power loss webhook
+    folder: Webhook Alerting
+    interval: 1m
+    rules:
+      - uid: webhook-phaseloss01
+        title: Phase Power Loss (Webhook)
+        condition: B
+        data:
+          - refId: A
+            queryType: ''
+            relativeTimeRange:
+              from: 180
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              alias: "$tag_phase"
+              groupBy:
+                - params: ["$__interval"]
+                  type: time
+                - params: ["phase"]
+                  type: tag
+                - params: ["none"]
+                  type: fill
+              intervalMs: 1000
+              maxDataPoints: 43200
+              measurement: current_power
+              orderByTime: ASC
+              policy: default
+              resultFormat: time_series
+              select:
+                - - params: ["v"]
+                    type: field
+                  - params: []
+                    type: last
+              tags:
+                - key: "device.name"
+                  operator: "="
+                  value: main
+          - refId: B
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params: [50]
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+              intervalMs: 1000
+              maxDataPoints: 43200
+              type: classic_conditions
+        noDataState: OK
+        execErrState: OK
+        for: 2m
+        annotations:
+          summary: "⚡ Phase power lost"
+          description: "Phase {{ $labels.phase }} of the mains has dropped to 0 V while the meter is still reporting. One or more phases are out; the meter's own supply phase is still live."
+        labels:
+          rule_uid: webhook-phaseloss01
+          alert_type: webhook

--- a/config/grafana/provisioning/alerting/phase-power-loss-alert.yaml
+++ b/config/grafana/provisioning/alerting/phase-power-loss-alert.yaml
@@ -8,7 +8,14 @@ groups:
     rules:
       - uid: webhook-phaseloss01
         title: Phase Power Loss (Webhook)
-        condition: B
+        # Uses the reduce (B) + threshold (C) expression chain rather than
+        # classic_conditions ON PURPOSE: classic_conditions collapses the
+        # per-phase series into one unlabeled instance, which drops the `phase`
+        # tag and makes `{{ $labels.phase }}` render blank. reduce+threshold
+        # preserves per-series labels, so the alert fires one instance per dead
+        # phase, each carrying phase=A/B/C. Verified against live Grafana 9.5.
+        # Do NOT "simplify" this back to classic_conditions.
+        condition: C
         data:
           - refId: A
             queryType: ''
@@ -17,7 +24,6 @@ groups:
               to: 0
             datasourceUid: P3C6603E967DC8568
             model:
-              alias: "$tag_phase"
               groupBy:
                 - params: ["$__interval"]
                   type: time
@@ -47,22 +53,32 @@ groups:
               to: 0
             datasourceUid: __expr__
             model:
+              type: reduce
+              expression: A
+              reducer: last
               datasource:
                 type: __expr__
                 uid: __expr__
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
               conditions:
                 - evaluator:
                     params: [50]
                     type: lt
-                  operator:
-                    type: and
-                  query:
-                    params: [A]
-                  reducer:
-                    type: last
+              datasource:
+                type: __expr__
+                uid: __expr__
               intervalMs: 1000
               maxDataPoints: 43200
-              type: classic_conditions
         noDataState: OK
         execErrState: OK
         for: 2m

--- a/config/grafana/provisioning/alerting/total-power-outage-alert.yaml
+++ b/config/grafana/provisioning/alerting/total-power-outage-alert.yaml
@@ -1,0 +1,56 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Total power outage webhook
+    folder: Webhook Alerting
+    interval: 1m
+    rules:
+      - uid: webhook-totalout01
+        title: Total Power Outage (Webhook)
+        condition: B
+        data:
+          - refId: A
+            queryType: ''
+            relativeTimeRange:
+              from: 90
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: 'SELECT last("v") FROM "current_power" WHERE time >= now() - 90s'
+              rawQuery: true
+              resultFormat: time_series
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params: [-1]
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+              intervalMs: 1000
+              maxDataPoints: 43200
+              type: classic_conditions
+        noDataState: Alerting
+        execErrState: OK
+        for: 1m
+        annotations:
+          summary: "🚨 TOTAL POWER OUTAGE"
+          description: "All meters have gone silent — every phase is down (full blackout). Server running on UPS/battery."
+        labels:
+          rule_uid: webhook-totalout01
+          alert_type: webhook

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -73,9 +73,27 @@ All modbus-serial instances write directly to InfluxDB using environment-configu
 
 #### `main` Measurement
 **Source**: modbus-serial-main → Main electrical panel (SDM630)
-**Tag Structure**: `bus: "main"`, `device: "main"`
+**Note**: per-phase instantaneous voltage/current/power for the mains is in the `current_power` measurement (`bus: "primary"`, `device.name: "main"`), not here — see below.
 **Fields**: 3-phase power system metrics - voltage, current, power, frequency, power factor
 **Use Cases**: Whole-house energy consumption, electrical system monitoring
+
+#### `current_power` Measurement (from mqtt-influx bridges)
+**Source**: `mqtt-influx-primary` / `-secondary` / `-tetriary` bridges convert
+`/modbus/<bus>/<device>/reading` MQTT messages into instantaneous readings.
+**Tag Structure**: `bus` (`primary` | `secondary` | `tetriary`),
+`device.name` (e.g. `main`, `boiler`, `heat_pump`, …), `device.type`,
+`device.addr`, and `phase` (`A` | `B` | `C`, on 3-phase meters).
+**Fields** (float): `v` (phase voltage), `c` (phase current), `p` (phase power).
+
+**Mains identification**: the whole-house grid meter is `bus = primary`,
+`device.name = main` (SDM630), publishing per-phase `v`/`c`/`p` tagged
+`phase = A/B/C` at ~1 Hz.
+
+**Consumers**: the per-phase power-loss and total-power-outage alerts
+(`config/grafana/provisioning/alerting/phase-power-loss-alert.yaml`,
+`total-power-outage-alert.yaml`) and the AC voltage-range alert (`ac-alert.yaml`)
+query this measurement's `v` field. See
+`docs/superpowers/specs/2026-07-12-per-phase-power-outage-alerting-design.md`.
 
 #### `raw` Measurement (from modbus-serial-secondary)
 **Source**: modbus-serial-secondary → Individual appliance monitoring

--- a/docs/superpowers/plans/2026-07-13-per-phase-power-outage-alerting.md
+++ b/docs/superpowers/plans/2026-07-13-per-phase-power-outage-alerting.md
@@ -42,6 +42,14 @@ Each task validates its YAML and confirms Grafana provisions it without error; a
 - Consumes: InfluxDB measurement `current_power`, field `v`, tags `device.name=main`, `phase`. Datasource UID `P3C6603E967DC8568`.
 - Produces: Grafana alert rule uid `webhook-phaseloss01`, one firing instance per dead phase carrying a `phase` label.
 
+> **Post-implementation correction (verified against live Grafana 9.5):** the
+> `classic_conditions` condition shown below does NOT preserve the `phase` label —
+> it collapses the per-phase series into one unlabeled instance, so
+> `{{ $labels.phase }}` renders blank. The committed rule instead uses a
+> `reduce` (refId B, `last`) → `threshold` (refId C, `< 50`) expression chain,
+> which fires one labeled instance per dead phase. See commit `e2dc575` and the
+> in-file comment.
+
 - [ ] **Step 1: Create the alert file**
 
 Create `config/grafana/provisioning/alerting/phase-power-loss-alert.yaml` with exactly:

--- a/docs/superpowers/plans/2026-07-13-per-phase-power-outage-alerting.md
+++ b/docs/superpowers/plans/2026-07-13-per-phase-power-outage-alerting.md
@@ -1,0 +1,485 @@
+# Per-Phase Power Outage Alerting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Grafana alerts that clearly notify when any single mains phase loses power (naming the phase) and when all phases are lost (total blackout), and stop the existing `ac-alert` from firing confusing noise during outages.
+
+**Architecture:** Two new provisioned Grafana alert-rule YAML files plus one edit to an existing one, all under `config/grafana/provisioning/alerting/`, all routed through the existing `telegram-webhook` contact point → `telegram-bridge` → Telegram. Per-phase loss is detected as `v == 0` while the meter is still reporting; total blackout is detected as `NoData` across the whole `current_power` measurement. No image rebuilds — Grafana mounts these files read-only and (re)loads them on restart.
+
+**Tech Stack:** Grafana 9.5 unified alerting (provisioned YAML, `classic_conditions`), InfluxDB 1.x (InfluxQL), Docker Compose.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-per-phase-power-outage-alerting-design.md`
+
+## Global Constraints
+
+- InfluxDB datasource UID is **`P3C6603E967DC8568`** (verbatim in every data query; expression queries use `datasourceUid: __expr__`).
+- InfluxDB database is **`homy`**; measurement **`current_power`**; voltage field **`v`**; tags **`device.name`** (dotted key) and **`phase`** = `A`/`B`/`C`; the mains meter is **`device.name = main`**.
+- Alert queries MUST use **`classic_conditions`** for the condition expression (not `threshold`) — per `config/grafana/CLAUDE.md`, `threshold` causes "condition must not be empty" errors in Grafana 9.5 provisioned alerts.
+- Raw InfluxQL alert queries MUST include an explicit **`WHERE time >= now() - <duration>`** — `relativeTimeRange` does NOT filter InfluxQL in Grafana 9.5. Do NOT use `$timeFilter`.
+- Dead phase reads **exactly `0.0 V`**; live phase reads **227–241 V** (verified from the 2026-07-08 event). Threshold: `v < 50` = dead.
+- All new rules use folder **`Webhook Alerting`** and labels `alert_type: webhook` to match existing rules and route through `telegram-webhook`.
+- Grafana + InfluxDB have **no published host ports**; reach them with `docker compose --env-file example.env exec <svc> ...`. Grafana admin is `admin`/`admin` (no `[security]` override in `config/grafana/config.ini`).
+
+---
+
+## File Structure
+
+- Create: `config/grafana/provisioning/alerting/phase-power-loss-alert.yaml` — Rule 1 (per-phase loss, names the phase).
+- Create: `config/grafana/provisioning/alerting/total-power-outage-alert.yaml` — Rule 2 (total blackout via NoData).
+- Modify: `config/grafana/provisioning/alerting/ac-alert.yaml` — exclude `0 V` from the low-voltage branch.
+- Modify: `docs/influxdb-schema.md` — document the `current_power` measurement (the alert data source).
+
+Each task validates its YAML and confirms Grafana provisions it without error; a final task verifies end-to-end alert behavior against injected InfluxDB data, and the last task deploys to prod.
+
+---
+
+## Task 1: Rule 1 — Named single-phase loss
+
+**Files:**
+- Create: `config/grafana/provisioning/alerting/phase-power-loss-alert.yaml`
+
+**Interfaces:**
+- Consumes: InfluxDB measurement `current_power`, field `v`, tags `device.name=main`, `phase`. Datasource UID `P3C6603E967DC8568`.
+- Produces: Grafana alert rule uid `webhook-phaseloss01`, one firing instance per dead phase carrying a `phase` label.
+
+- [ ] **Step 1: Create the alert file**
+
+Create `config/grafana/provisioning/alerting/phase-power-loss-alert.yaml` with exactly:
+
+```yaml
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Phase power loss webhook
+    folder: Webhook Alerting
+    interval: 1m
+    rules:
+      - uid: webhook-phaseloss01
+        title: Phase Power Loss (Webhook)
+        condition: B
+        data:
+          - refId: A
+            queryType: ''
+            relativeTimeRange:
+              from: 180
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              alias: "$tag_phase"
+              groupBy:
+                - params: ["$__interval"]
+                  type: time
+                - params: ["phase"]
+                  type: tag
+                - params: ["none"]
+                  type: fill
+              intervalMs: 1000
+              maxDataPoints: 43200
+              measurement: current_power
+              orderByTime: ASC
+              policy: default
+              resultFormat: time_series
+              select:
+                - - params: ["v"]
+                    type: field
+                  - params: []
+                    type: last
+              tags:
+                - key: "device.name"
+                  operator: "="
+                  value: main
+          - refId: B
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params: [50]
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+              intervalMs: 1000
+              maxDataPoints: 43200
+              type: classic_conditions
+        noDataState: OK
+        execErrState: OK
+        for: 2m
+        annotations:
+          summary: "⚡ Phase power lost"
+          description: "Phase {{ $labels.phase }} of the mains has dropped to 0 V while the meter is still reporting. One or more phases are out; the meter's own supply phase is still live."
+        labels:
+          rule_uid: webhook-phaseloss01
+          alert_type: webhook
+```
+
+- [ ] **Step 2: Bring up Grafana + InfluxDB and confirm the rule provisions without error**
+
+Grafana validates the YAML when it loads provisioning; a malformed file or bad rule shows up as an error log line. Run:
+```bash
+docker compose --env-file example.env up -d influxdb grafana
+sleep 15
+docker compose --env-file example.env logs grafana 2>&1 | grep -iE "provision.*(error|fail)|failed to (parse|provision).*alert"
+```
+Expected: **no output** (no provisioning errors). (Optional fast pre-check if `python3`+PyYAML is present: `python3 -c 'import yaml;yaml.safe_load(open("config/grafana/provisioning/alerting/phase-power-loss-alert.yaml"))' && echo YAML_OK`.)
+
+- [ ] **Step 3: Confirm the rule is present**
+
+Run:
+```bash
+docker compose --env-file example.env exec -T grafana \
+  curl -s -u admin:admin http://localhost:3000/api/v1/provisioning/alert-rules | grep -o 'webhook-phaseloss01'
+```
+Expected: prints `webhook-phaseloss01`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/grafana/provisioning/alerting/phase-power-loss-alert.yaml
+git commit -m "feat(alerting): add named per-phase mains power-loss alert"
+```
+
+---
+
+## Task 2: Rule 2 — Total blackout (all meters silent)
+
+**Files:**
+- Create: `config/grafana/provisioning/alerting/total-power-outage-alert.yaml`
+
+**Interfaces:**
+- Consumes: InfluxDB measurement `current_power`, field `v` (any device/phase). Datasource UID `P3C6603E967DC8568`.
+- Produces: Grafana alert rule uid `webhook-totalout01`, firing via `noDataState: Alerting` when the whole measurement is silent.
+
+- [ ] **Step 1: Create the alert file**
+
+Create `config/grafana/provisioning/alerting/total-power-outage-alert.yaml` with exactly:
+
+```yaml
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Total power outage webhook
+    folder: Webhook Alerting
+    interval: 1m
+    rules:
+      - uid: webhook-totalout01
+        title: Total Power Outage (Webhook)
+        condition: B
+        data:
+          - refId: A
+            queryType: ''
+            relativeTimeRange:
+              from: 90
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: 'SELECT last("v") FROM "current_power" WHERE time >= now() - 90s'
+              rawQuery: true
+              resultFormat: time_series
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params: [-1]
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+              intervalMs: 1000
+              maxDataPoints: 43200
+              type: classic_conditions
+        noDataState: Alerting
+        execErrState: OK
+        for: 1m
+        annotations:
+          summary: "🚨 TOTAL POWER OUTAGE"
+          description: "All meters have gone silent — every phase is down (full blackout). Server running on UPS/battery."
+        labels:
+          rule_uid: webhook-totalout01
+          alert_type: webhook
+```
+
+Rationale for the `< -1` condition: it can never be true for a real voltage, so while ANY meter reports the rule sits in `Normal`. The real trigger is the query returning no data (total silence) → `noDataState: Alerting` fires. `execErrState: OK` prevents a transient InfluxDB hiccup from false-alarming.
+
+- [ ] **Step 2: Reload provisioning and confirm no errors**
+
+Grafana loads alerting provisioning at startup, so restart it to pick up the new file, then check for errors:
+```bash
+docker compose --env-file example.env restart grafana
+sleep 15
+docker compose --env-file example.env logs --since 30s grafana 2>&1 | grep -iE "provision.*(error|fail)|failed to (parse|provision).*alert"
+```
+Expected: **no output**.
+
+- [ ] **Step 3: Provision check**
+
+Run:
+```bash
+docker compose --env-file example.env exec -T grafana \
+  curl -s -u admin:admin http://localhost:3000/api/v1/provisioning/alert-rules | grep -o 'webhook-totalout01'
+```
+Expected: prints `webhook-totalout01`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/grafana/provisioning/alerting/total-power-outage-alert.yaml
+git commit -m "feat(alerting): add total power outage (all-meters-silent) alert"
+```
+
+---
+
+## Task 3: Narrow `ac-alert` to ignore dead phases
+
+**Files:**
+- Modify: `config/grafana/provisioning/alerting/ac-alert.yaml` (the `minV` query, lines 42-70)
+
+**Interfaces:**
+- Consumes: same `current_power` / `v` data. No new outputs; existing uid `webhook-3057STtVkz` unchanged.
+
+- [ ] **Step 1: Replace the `minV` query with a raw query that excludes 0 V**
+
+In `config/grafana/provisioning/alerting/ac-alert.yaml`, replace the entire `minV` block (the `refId: minV` list item, currently a builder-mode query) with:
+
+```yaml
+          - refId: minV
+            queryType: ''
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              alias: "min V"
+              # Exclude kitchen (faulty 0V device) AND dead phases (v=0 during an
+              # outage) so a phase dropping to 0V no longer trips this generic
+              # "voltage out of range" alert — that is now covered by the dedicated
+              # phase-power-loss / total-power-outage alerts. Genuine brown-outs
+              # (a phase sagging to e.g. 150V, still > 0) are still caught.
+              query: 'SELECT min("v") FROM "current_power" WHERE "device.name" != ''kitchen'' AND "v" > 0 AND time >= now() - 300s'
+              rawQuery: true
+              resultFormat: time_series
+              intervalMs: 1000
+              maxDataPoints: 43200
+```
+
+Leave the `maxV` and `refId: A` (condition) blocks unchanged.
+
+- [ ] **Step 2: Reload provisioning and confirm no errors**
+
+```bash
+docker compose --env-file example.env restart grafana
+sleep 15
+docker compose --env-file example.env logs --since 30s grafana 2>&1 | grep -iE "provision.*(error|fail)|failed to (parse|provision).*alert"
+```
+Expected: **no output**.
+
+- [ ] **Step 3: Provision check (rule still loads under its original uid)**
+
+Run:
+```bash
+docker compose --env-file example.env exec -T grafana \
+  curl -s -u admin:admin http://localhost:3000/api/v1/provisioning/alert-rules | grep -o 'webhook-3057STtVkz'
+```
+Expected: prints `webhook-3057STtVkz` (rule still present, now with the narrowed query).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/grafana/provisioning/alerting/ac-alert.yaml
+git commit -m "fix(alerting): stop ac-alert firing on dead phases (v=0)"
+```
+
+---
+
+## Task 4: End-to-end behavioral verification against injected data
+
+This task drives all three rules against a live Grafana + InfluxDB using synthetic data and confirms each reaches the right state. No file changes; this is the acceptance gate. (If any check fails, fix the offending rule file from Task 1–3 and re-run.) **Run all steps in one shell session** — Step 1 exports `$INFLUX_ADMIN`, reused by later steps.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Ensure the stack is up and note the admin InfluxDB user**
+
+Run:
+```bash
+docker compose --env-file example.env up -d influxdb grafana
+sleep 15
+INFLUX_ADMIN=$(docker compose --env-file example.env exec -T influxdb sh -c 'cat /run/secrets/influxdb_admin_user 2>/dev/null || echo admin')
+echo "influx admin user: $INFLUX_ADMIN"
+```
+Expected: prints a username (the example.env dummy admin user). Password is `secret` (example.env). Use `$INFLUX_ADMIN`/`secret` for writes below.
+
+Firing alerts appear in Grafana's Alertmanager active-alerts endpoint
+`/api/alertmanager/grafana/api/v2/alerts` — grepping for a rule's summary text there is a clean binary "is it firing" check (empty output = not firing).
+
+- [ ] **Step 2: Verify NORMAL — all three phases live → no alert firing**
+
+Write live voltages for all three phases, wait for evaluation, and confirm no power alert is firing:
+```bash
+for P in A B C; do
+  docker compose --env-file example.env exec -T influxdb \
+    influx -database homy -username "$INFLUX_ADMIN" -password secret \
+    -execute "INSERT current_power,device.name=main,phase=$P v=233"
+done
+sleep 70
+docker compose --env-file example.env exec -T grafana \
+  curl -s -u admin:admin 'http://localhost:3000/api/alertmanager/grafana/api/v2/alerts' \
+  | grep -oE 'Phase power lost|TOTAL POWER OUTAGE'
+```
+Expected: **no output** (neither power alert is active).
+
+- [ ] **Step 3: Verify PARTIAL — phase B dead → Rule 1 fires naming phase B**
+
+Write A and C live, B at 0 V, hold past the 2-minute `for` window, then check the active alert and its `phase` label:
+```bash
+for i in $(seq 1 13); do
+  docker compose --env-file example.env exec -T influxdb influx -database homy -username "$INFLUX_ADMIN" -password secret \
+    -execute 'INSERT current_power,device.name=main,phase=A v=233; INSERT current_power,device.name=main,phase=B v=0; INSERT current_power,device.name=main,phase=C v=233'
+  sleep 12
+done
+docker compose --env-file example.env exec -T grafana \
+  curl -s -u admin:admin 'http://localhost:3000/api/alertmanager/grafana/api/v2/alerts' \
+  | grep -oE 'Phase power lost|TOTAL POWER OUTAGE|"phase":"[ABC]"'
+```
+Expected: prints `Phase power lost` and `"phase":"B"`, and does NOT print `TOTAL POWER OUTAGE` (main is still reporting).
+
+- [ ] **Step 4: Verify TOTAL — stop all writes → Rule 2 (total outage) fires via NoData**
+
+Stop writing for longer than the 90 s window + 1 m `for`, then check:
+```bash
+sleep 160
+docker compose --env-file example.env exec -T grafana \
+  curl -s -u admin:admin 'http://localhost:3000/api/alertmanager/grafana/api/v2/alerts' \
+  | grep -oE 'Phase power lost|TOTAL POWER OUTAGE'
+```
+Expected: prints `TOTAL POWER OUTAGE` and does NOT print `Phase power lost` (Rule 1's `noDataState` is `OK`, so a silent meter does not trip it).
+
+If `TOTAL POWER OUTAGE` does NOT appear, the `noDataState: Alerting` + `for` path is not firing as expected in this Grafana build — fallback: set that rule's `for: 0s` and rely on the notification policy's `group_wait` (30 s) for debounce; edit `total-power-outage-alert.yaml`, `docker compose --env-file example.env restart grafana`, and re-run this step. Record the outcome.
+
+- [ ] **Step 5: Tear down the local stack**
+
+```bash
+docker compose --env-file example.env down
+```
+Expected: containers removed. (Local test data lived only in the ephemeral InfluxDB volume; no prod impact.)
+
+- [ ] **Step 6: Commit any rule fixes made during verification**
+
+Only if Steps 2–4 required edits:
+```bash
+git add config/grafana/provisioning/alerting/*.yaml
+git commit -m "fix(alerting): adjust power outage rules per behavioral verification"
+```
+
+---
+
+## Task 5: Document the `current_power` measurement in the schema doc
+
+**Files:**
+- Modify: `docs/influxdb-schema.md`
+
+**Interfaces:** none (documentation).
+
+- [ ] **Step 1: Add a `current_power` section documenting the alert data source**
+
+In `docs/influxdb-schema.md`, under the "Primary Energy Monitoring" area (near the existing `#### `main` Measurement` block around line 74), add a new subsection. The existing `main`-measurement text describes the direct modbus writer and predates the mqtt-influx bridge; add this authoritative description of what the alerts actually query:
+
+```markdown
+#### `current_power` Measurement (from mqtt-influx bridges)
+**Source**: `mqtt-influx-primary` / `-secondary` / `-tetriary` bridges convert
+`/modbus/<bus>/<device>/reading` MQTT messages into instantaneous readings.
+**Tag Structure**: `bus` (`primary` | `secondary` | `tetriary`),
+`device.name` (e.g. `main`, `boiler`, `heat_pump`, …), `device.type`,
+`device.addr`, and `phase` (`A` | `B` | `C`, on 3-phase meters).
+**Fields** (float): `v` (phase voltage), `c` (phase current), `p` (phase power).
+
+**Mains identification**: the whole-house grid meter is `bus = primary`,
+`device.name = main` (SDM630), publishing per-phase `v`/`c`/`p` tagged
+`phase = A/B/C` at ~1 Hz.
+
+**Consumers**: the per-phase power-loss and total-power-outage alerts
+(`config/grafana/provisioning/alerting/phase-power-loss-alert.yaml`,
+`total-power-outage-alert.yaml`) and the AC voltage-range alert (`ac-alert.yaml`)
+query this measurement's `v` field. See
+`docs/superpowers/specs/2026-07-12-per-phase-power-outage-alerting-design.md`.
+```
+
+Also correct the stale note at the existing `#### `main` Measurement` block: change its `**Tag Structure**: `bus: "main"`, `device: "main"`` line to a pointer: `**Note**: per-phase instantaneous voltage/current/power for the mains is in the `current_power` measurement (`bus: "primary"`, `device.name: "main"`), not here — see below.`
+
+- [ ] **Step 2: Verify the doc renders / links resolve**
+
+Run: `grep -n "current_power Measurement" docs/influxdb-schema.md`
+Expected: prints the new heading line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/influxdb-schema.md
+git commit -m "docs(influxdb): document current_power measurement (alert data source)"
+```
+
+---
+
+## Task 6: Deploy to prod and confirm live rules
+
+Config-only change (no image rebuild). Prod repo is at `ssh routy:~/homy`; Grafana mounts `config/grafana/provisioning` read-only and loads alerting provisioning on restart.
+
+**Files:** none (deployment).
+
+- [ ] **Step 1: Get the branch merged to `master`** (via the normal PR flow) so prod can pull it. Do not proceed to prod until merged.
+
+- [ ] **Step 2: Pull on prod and restart Grafana**
+
+Run:
+```bash
+ssh routy 'cd ~/homy && git pull --ff-only && docker compose restart grafana'
+```
+Expected: fast-forward pull includes the three alerting files; grafana restarts.
+
+- [ ] **Step 3: Confirm the new rules provisioned on prod**
+
+Run:
+```bash
+ssh routy 'cd ~/homy && docker compose exec -T grafana curl -s -u admin:admin http://localhost:3000/api/v1/provisioning/alert-rules | grep -oE "webhook-(phaseloss01|totalout01)"'
+```
+Expected: prints both `webhook-phaseloss01` and `webhook-totalout01`.
+
+- [ ] **Step 4: Confirm current live state is sane (all phases up → not firing)**
+
+Run:
+```bash
+ssh routy 'cd ~/homy && docker compose exec -T grafana curl -s -u admin:admin "http://localhost:3000/api/alertmanager/grafana/api/v2/alerts" | grep -oE "Phase power lost|TOTAL POWER OUTAGE"'
+```
+Expected: **no output** under normal power (neither alert active). (A real outage will flip them; the next actual event is the true end-to-end test — the resolve message will also confirm delivery when power returns.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Rule 1 (Task 1) → "notify on any phase, named"; Rule 2 (Task 2) → "notify on all phases"; ac-alert narrowing (Task 3) → removes the confusing noise the user hit; docs (Task 5) → the `docs/influxdb-schema.md` correction. The "main silent but house powered" Known gap is intentionally unimplemented per the spec's resolved decision.
+- **No placeholders:** every YAML file is given in full; every command is concrete with expected output.
+- **Verification adapted for declarative config:** because these are provisioned config files (not code), "tests" are YAML-parse validation, Grafana provisioning-API presence checks, and an end-to-end behavioral verification with injected InfluxDB data (Task 4).
+- **Key assumption flagged for empirical check:** the total-blackout rule relies on `noDataState: Alerting` + `for: 1m` firing on whole-measurement silence — Task 4 Step 4 verifies this and records a fallback if the build behaves differently.

--- a/docs/superpowers/specs/2026-07-12-per-phase-power-outage-alerting-design.md
+++ b/docs/superpowers/specs/2026-07-12-per-phase-power-outage-alerting-design.md
@@ -1,0 +1,217 @@
+# Per-Phase Power Outage Alerting — Design
+
+**Date:** 2026-07-12
+**Status:** Approved design (pending implementation plan)
+**Author:** Geno Roupsky (with Claude Code)
+
+## Problem
+
+A grid outage that left only one of the three mains phases live was hard to
+diagnose from existing alerts and data. The user wants:
+
+1. A **clear notification when power is lost on any of the three phases** (and,
+   where possible, which phase).
+2. A **distinct, clear message when power is lost on all three phases** (total
+   blackout).
+
+The existing alerting does neither:
+
+- `main-power-alert.yaml` fires only on **excess** consumption (`> 10 kW`) and
+  uses `noDataState: NoData`, so a silent meter is silently ignored.
+- `ac-alert.yaml` is a global min/max voltage rule (`< 210 V` or `> 248 V`)
+  across meters (excluding `kitchen`). A dead phase trips its low branch, but it
+  is reported as a generic "AC voltage out of range" with **no phase identity** —
+  the direct cause of the confusion during the real event.
+
+## Verified facts (from the 2026-07-08 event on prod)
+
+Confirmed by querying InfluxDB (`homy` database, `homy_influxdb_1` container) for
+the real outage on 2026-07-08 (~11:00 UTC onward). See the July timeline at the
+end of this document.
+
+- **Binary voltage signal.** A dead phase reads **exactly `0.0 V`** (not NULL, not
+  a sag); a live phase reads **227–241 V**. Any threshold in between separates
+  them with a huge margin — `v < 50` = dead, `v > 200` = live.
+- **The main meter goes fully silent when it loses its own supply.** During the
+  partial outage (phases A & B at 0 V, phase C ~233 V) the SDM630 `main` meter
+  kept publishing and reported the dead phases as `0 V`. When its supply phase
+  also died, the meter **stopped publishing entirely (a hard data gap / NoData)**,
+  rather than publishing zeros.
+  - Observed: the meter survived on phase C alone. It is **not confirmed** whether
+    the meter can also run from phase A or B alone — so the design does **not**
+    assume any specific supply phase.
+- **Sample cadence ~1 Hz.** `main` publishes roughly once per second per phase.
+  A data gap of **> 30–60 s** is unambiguously a real outage, not a comms blip.
+- **Shortest genuine state ~12 min** (a brief full-restoration island between two
+  total outages). A **1–2 min debounce (`for:`)** is safe and will not split real
+  states.
+- **`main` sits electrically upstream of every other meter** (it is the grid
+  entry / whole-house metering point; all other meters are downstream branches).
+  Consequences that drive the alert classification:
+  - Any power reaching a downstream meter must pass through main's location.
+    Therefore **`main` silent while a downstream meter still reports ⇒ power is
+    present ⇒ it is a `main`-meter fault** (Modbus/comms drop or hardware), **not**
+    a power outage.
+  - **`main` + every downstream meter silent ⇒ genuine total blackout.** This
+    invariant needs no per-meter phase mapping.
+- **Witness meters** (downstream, self-powered from their own circuit, so their
+  continued reporting proves both "power present" and "that phase live"):
+  - `stab-em` (OR-WE-516, `monitoring2`) and single-phase sub-meters (`boiler`,
+    `laundry`, `oven`, `stove`, `microwave`, `water_pump`, `dishwasher`).
+  - `heat_pump` (3-phase, `dds024mr`) went silent at the **same instant** as
+    `main` during the event → it shares `main`'s supply phase. This makes it a
+    **co-phase witness**: it can distinguish "the phase powering `main` genuinely
+    died (heat_pump also silent)" from "`main` has a comms/hardware fault
+    (heat_pump still reporting)". Useful for the edge case below.
+
+## Data source
+
+- Measurement: **`current_power`** (written by the `mqtt-influx-primary` bridge).
+- Field: **`v`** (per-phase L–N voltage, float).
+- Tags: **`device.name` = `main`**, **`phase` = `A` / `B` / `C`**, `bus = primary`.
+- Delivery: Grafana webhook contact point `telegram-webhook` →
+  `telegram-bridge` service → Telegram (unchanged; all new rules reuse it).
+
+## Design
+
+Two new Grafana alert rules plus one cleanup, all in
+`config/grafana/provisioning/alerting/`, all routed through the existing
+`telegram-webhook` contact point. The InfluxDB datasource UID is
+`P3C6603E967DC8568` (same as every other alert).
+
+### Grafana constraint that shaped this design
+
+In Grafana's provisioned unified alerting, if any query in a rule returns **no
+data**, the whole rule evaluates to `NoData` — you **cannot** express "series X is
+absent AND series Y is present" in one rule (the absent series poisons it to
+NoData). This rules out a clean "main silent AND a witness still reporting"
+condition. Consequently:
+
+- "A phase is dead" is detected as `v == 0` **while the meter is still reporting**
+  (Rule 1).
+- "Everything is silent" is detected via `NoData` on the whole measurement
+  (Rule 2, total blackout).
+- The in-between "main silent but house still powered" case (a pure main
+  comms/hardware fault, or loss of *only* the phase that powers `main`) is **not
+  separately alerted in this iteration** — see Known gaps.
+
+### Rule 1 — Named single-phase loss (meter still alive)
+
+New file: `config/grafana/provisioning/alerting/phase-power-loss-alert.yaml`.
+
+- **Query (refId `A`, builder mode, mirrors `main-power-alert.yaml`):**
+  measurement `current_power`, `SELECT last("v")`, `GROUP BY time($__interval),
+  "phase" fill(none)`, tag filter `"device.name" = main`, `alias: "$tag_phase"`,
+  `relativeTimeRange.from: 180` (3 min lookback). One series per phase A/B/C.
+- **Condition (refId `B`, `classic_conditions`):** `last(A) < 50` → firing. Because
+  the data is grouped by the `phase` tag, Grafana produces **one alert instance per
+  phase**, each carrying a `phase` label.
+- **`for`:** `2m`. **`noDataState`:** `OK` (total blackout is Rule 2's job; Rule 1
+  must stay quiet when the meter is silent). **`execErrState`:** `OK`.
+- **Message:** summary `⚡ Phase power lost`, description
+  `Phase {{ index $labels "phase" }} of the mains has dropped to 0 V while the
+  meter is still reporting. One or more phases are out; other phases are still
+  live.`
+- **Covers:** any phase the meter can still see going dead while the meter's own
+  supply phase remains up — the core "which phase is out" answer.
+
+### Rule 2 — Total blackout (all meters silent)
+
+New file: `config/grafana/provisioning/alerting/total-power-outage-alert.yaml`.
+
+- **Query (refId `A`, raw InfluxQL):** `SELECT last("v") FROM "current_power"
+  WHERE time >= now() - 90s` — any meter, any phase, across the whole measurement.
+  (`rawQuery: true`; explicit `WHERE time >= now() - 90s` per the Grafana 9.5
+  provisioned-alert rule that `relativeTimeRange` does not filter InfluxQL.)
+- **Condition (refId `B`, `classic_conditions`):** `last(A) < -1` — an evaluator
+  that is **never true for a real voltage**, so the rule sits in `Normal` whenever
+  *any* meter is reporting.
+- **The real trigger is NoData.** When the entire `current_power` measurement goes
+  silent (every meter unpowered = full blackout) the query returns no data →
+  `noDataState: Alerting` fires. **`execErrState`:** `OK` (so a transient InfluxDB
+  hiccup does not false-alarm; InfluxDB is on the same UPS-backed host).
+- **`for`:** `1m` (≫ the ~1 s sample cadence, so a comms blip cannot trip it).
+- **Message:** summary `🚨 TOTAL POWER OUTAGE`, description `All meters have gone
+  silent — every phase is down (full blackout). Server running on UPS/battery.`
+- Fires **only** on true total silence: during a partial outage `main` still
+  reports, and during a main-only fault the downstream meters still report, so in
+  both those cases the query returns data and this rule stays `Normal`.
+
+### Rule 3 (cleanup) — Narrow `ac-alert`
+
+Modify `config/grafana/provisioning/alerting/ac-alert.yaml`.
+
+- Change the `minV` query's tag filter so `0 V` readings are excluded from the
+  `< 210 V` low branch — add a second tag condition `"v" > 1` is not expressible on
+  a value in the builder, so instead exclude dead phases at the source: change the
+  low-branch **query** to select the minimum voltage **above 0** by adding a raw
+  `WHERE "v" > 0` clause (convert `minV` to `rawQuery: true`:
+  `SELECT min("v") FROM "current_power" WHERE "device.name" != 'kitchen' AND "v" > 0
+  AND time >= now() - 300s`). This stops `ac-alert` firing a vague "AC voltage out
+  of range" every time a phase drops to 0 V — that job now belongs to Rules 1–2 —
+  while it still catches genuine brown-out (a phase sagging to, say, 150 V) and
+  over-voltage.
+
+### Docs
+
+- Update `docs/influxdb-schema.md`: it currently documents the mains as
+  `bus:"main"` / `device:"main"` / measurement `main`. The real schema is
+  `bus:"primary"`, tag key `device.name = main`, measurements `current_power`
+  (instantaneous `v`/`c`/`p` with `phase` tag) and `power_meter` (cumulative kWh).
+
+## Behavior summary
+
+| Real-world state                          | `main` meter | Other meters   | Alert fired                          |
+|-------------------------------------------|--------------|----------------|--------------------------------------|
+| All phases live                           | publishing   | publishing     | none                                 |
+| One/two non-supply phases dead            | publishing, dead phase = 0 V | any | **Rule 1** — names the phase(s)      |
+| `main` silent, house still powered (main comms/hardware fault, **or** only the phase powering `main` is lost) | silent | ≥1 publishing | **none** (Known gap) |
+| All three phases dead                      | silent       | all silent     | **Rule 2** — total blackout          |
+
+Grafana sends resolve messages (`disableResolveMessage: false`) so each state also
+produces a recovery notification when it clears.
+
+## Alert tuning constants
+
+- Dead/live voltage threshold: **`v < 50`** (dead; margin to live ~227 V).
+- Total-blackout liveness window: **`now() - 90s`** (≫ the ~1 s sample cadence).
+- Debounce: **`for: 2m`** (Rule 1), **`for: 1m`** (Rule 2).
+
+## Known gaps (accepted this iteration)
+
+- **`main` silent while the house is still powered is not alerted.** This covers
+  (a) a pure `main` Modbus/comms or hardware fault with power present, and (b) loss
+  of *only* the phase that powers `main` while other phases stay up. Grafana cannot
+  cleanly express "main absent AND a witness present" (see the constraint above),
+  so no rule fires for this state. It has not been observed standalone — in the
+  July event, every time the meter's phase died it was part of a full blackout,
+  which **is** caught by Rule 2. If this case ever bites in practice, the natural
+  fix is a small `automations` bot that tracks meter liveness (deferred).
+
+## Resolved decisions
+
+- **Rule 2 "main meter fault": DROPPED this iteration.** Rules 1 (per-phase loss)
+  and the total-blackout rule fully cover the two explicit asks ("any phase" and
+  "all phases"). The main-fault / co-phase-witness detection is left as the future
+  bot enhancement noted in Known gaps.
+
+## Out of scope
+
+- Automating any recovery action (power-cycling, load shedding).
+- Changing the meter's physical wiring or adding hardware witnesses.
+- Migrating delivery off the existing webhook → telegram-bridge path.
+
+## Reference: 2026-07-08/09 event timeline (UTC)
+
+```
+JUL 8
+ 10:35:40  Phase A & B -> 0 V; C stays ~233 V   [PARTIAL begins; meter still publishing]
+ 10:35     stab-em + boiler/laundry/microwave/oven/stove/water_pump go silent (dead phases)
+ 11:00:33  Meter goes silent                     [TOTAL begins — phase C lost]   gap ~2h18m
+ 13:18:45  All 3 phases back ~232–235 V          [FULL restore, ~12 min]
+ 13:30:37  Meter goes silent                     [TOTAL again]                    gap ~2h56m
+ 16:26:31  All 3 phases back, stable thereafter
+JUL 9
+ 06:16:27  Meter goes silent                     [TOTAL — no partial captured]    gap ~1h46m
+ 08:02:46  All 3 phases back, stable thereafter
+```

--- a/docs/superpowers/specs/2026-07-12-per-phase-power-outage-alerting-design.md
+++ b/docs/superpowers/specs/2026-07-12-per-phase-power-outage-alerting-design.md
@@ -103,9 +103,12 @@ New file: `config/grafana/provisioning/alerting/phase-power-loss-alert.yaml`.
   measurement `current_power`, `SELECT last("v")`, `GROUP BY time($__interval),
   "phase" fill(none)`, tag filter `"device.name" = main`, `alias: "$tag_phase"`,
   `relativeTimeRange.from: 180` (3 min lookback). One series per phase A/B/C.
-- **Condition (refId `B`, `classic_conditions`):** `last(A) < 50` → firing. Because
-  the data is grouped by the `phase` tag, Grafana produces **one alert instance per
-  phase**, each carrying a `phase` label.
+- **Condition (reduce `B` → threshold `C`):** `reduce(last, A)` then threshold
+  `B < 50` → firing. This expression chain (NOT `classic_conditions`) is required
+  so Grafana produces **one alert instance per phase**, each carrying a `phase`
+  label. Verified against live Grafana 9.5: `classic_conditions` collapses the
+  per-phase series into a single unlabeled instance, making `{{ $labels.phase }}`
+  render blank; reduce+threshold preserves the per-series `phase` label.
 - **`for`:** `2m`. **`noDataState`:** `OK` (total blackout is Rule 2's job; Rule 1
   must stay quiet when the meter is silent). **`execErrState`:** `OK`.
 - **Message:** summary `⚡ Phase power lost`, description


### PR DESCRIPTION
## Problem

A grid outage that left only one of the three mains phases live was hard to diagnose from the existing alerts and data. The existing rules didn't help:
- `main-power-alert` only fires on **excess** consumption (>10 kW), `noDataState: NoData`.
- `ac-alert` fired a vague "AC voltage out of range" during a phase loss, with **no phase identity** — the direct cause of the confusion.

## What this adds

Grounded in the verified 2026-07-08 prod outage (dead phase = exactly **0 V**, live = ~233 V; the SDM630 mains meter is line-powered and goes **silent/NoData** when it loses its own supply; "every meter silent = full blackout"):

- **Rule 1 — `phase-power-loss-alert.yaml`**: fires one instance **per dead phase** and names it (`⚡ Phase B has dropped to 0 V …`). Uses a `reduce`+`threshold` expression chain (not `classic_conditions`) so the `phase` label is preserved in the message.
- **Rule 2 — `total-power-outage-alert.yaml`**: fires `🚨 TOTAL POWER OUTAGE` when the whole `current_power` measurement goes silent (NoData → Alerting). Server survives on UPS so the alert is deliverable.
- **`ac-alert.yaml`**: narrowed so `0 V` (dead phase) readings no longer trip its `< 210 V` branch — it goes back to catching genuine brown-out / over-voltage only.
- **`docs/influxdb-schema.md`**: documents the `current_power` measurement (the alert data source) and corrects a stale `main`/`bus:"main"` note.

Design spec and implementation plan are under `docs/superpowers/`.

## Verification (live Grafana 9.5 + InfluxDB)

Provisioned locally and driven with synthetic data:

| State | Result |
|---|---|
| All phases live | no alerts ✓ |
| Phase B = 0 V (partial) | `Phase Power Loss` fires, instance labeled `phase=B` ✓ |
| All meters silent (total) | `Total Power Outage` fires via NoData→Alerting ✓ |

This caught a real bug: `classic_conditions` dropped the per-phase label (message would render blank); switched to `reduce`+`threshold` and re-verified.

## Known gap (accepted, documented)

`main` silent while the house is still powered (a main comms/hardware fault, or loss of *only* the phase powering `main`) is **not** separately alerted — Grafana can't cleanly express "main absent AND a witness present". Not observed standalone in the event; a small automations bot is the future fix.

## Deploy

Config-only (no image rebuild): pull on prod, `docker compose restart grafana`. Not yet deployed — awaiting review/merge.

https://claude.ai/code/session_0194ybaSXGMtyYvWLL5iiYpK
