### PR TITLE
fix(ci): detect docker/ changes in ci-unified path filter

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -77,12 +77,17 @@ jobs:
 
           echo "Checking for changes between $BASE_SHA and $HEAD_SHA"
 
-          # Check if any relevant paths changed
+          # Check if any relevant paths changed.
+          # NOTE: entries must NOT have a trailing slash. The anchoring below
+          # appends `(/|$)`, so a trailing slash (e.g. "docker/") would produce
+          # `^docker/(/|$)`, which only matches the literal "docker/" or
+          # "docker//" and never a nested file like "docker/mqtt-influx/x.js" —
+          # silently skipping every Docker build. Directory names go here bare.
           RELEVANT_PATHS=(
-            "base-images/"
-            "docker/"
+            "base-images"
+            "docker"
             ".github/workflows/ci-unified.yml"
-            ".github/scripts/detect-changes/"
+            ".github/scripts/detect-changes"
           )
 
           CHANGED=false


### PR DESCRIPTION
## Problem

The unified pipeline's Stage 0 path filter (`ci-unified.yml`, "Check for relevant path changes") never detects changes under `docker/`, `base-images/`, or `.github/scripts/detect-changes/`. Each `RELEVANT_PATHS` entry is anchored with `(/|$)`:

```bash
grep -qE "^${path}(/|$)"
```

but the directory entries carried a **trailing slash**, so `"docker/"` expands to the regex `^docker/(/|$)` — which matches only the literal `docker/` or `docker//`, **never** a nested file such as `docker/mqtt-influx/index.js`.

### Impact

Any push whose changes are entirely under `docker/` (the normal case for a service change) is classified as **"No Docker-related changes — skipping build pipeline"**. Stages 1–5 are skipped, so **no images are built, tested, or tagged** for that commit — including the SHA tag `deploy.sh` pulls. This silently breaks deploys of service changes.

Observed on the `master` push for #1377 (run [29289496391](https://github.com/groupsky/homy/actions/runs/29289496391)): the merge touched 15 files under `docker/`, yet the pipeline reported "no Docker-related changes" and `BUILD/PUSH/RETAG = skipped`.

## Fix

Drop the trailing slashes from the directory entries so the `(/|$)` anchor works as intended (`^docker(/|$)` matches `docker/…` while still rejecting false positives like `dockerish/`). Added a comment documenting the constraint.

## Verification

```
# against the #1377 merge diff (6d9419d..f1c70cf, 15 docker/ files)
buggy  '^docker/(/|$)'  → NO MATCH   (pipeline skipped)
fixed  '^docker(/|$)'   → MATCH      (pipeline runs)
false-positive guard: 'dockerish/x' vs '^docker(/|$)' → no match (good)
base-images/node/Dockerfile vs '^base-images(/|$)'    → match
.github/scripts/detect-changes/index.ts vs anchor     → match
```

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-unified.yml'))"` → YAML OK.

## Follow-up

After this merges, the `mqtt-influx`/`mqtt-mongo` images from #1377 still need to be built for `master` (that merge was skipped). A `workflow_dispatch` run (or `force_rebuild`) will produce the SHA/`:latest` tags before the Ioniq services can be deployed to production.

https://claude.ai/code/session_01RZGSTfSZRayAJywLujsyJX
