### PR TITLE
fix(vpn): point compose at homy/vpn image to match CI-published build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - ${INGRESSGEN_TEMPLATE_NGINX_FILE}:/etc/docker-gen/templates/nginx.tmpl:ro
 
   vpn:
-    image: ghcr.io/groupsky/homy/wireguard:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/vpn:${IMAGE_TAG:-latest}
     build: docker/wireguard
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Problem

The `vpn` service's compose image was `ghcr.io/groupsky/homy/wireguard:${IMAGE_TAG:-latest}`, but:

- `ghcr.io/groupsky/homy/wireguard` is the **base-image mirror** repo (built from `base-images/wireguard/`, tag `v1.0.20210914-ls1`). Its `:latest` is a stale Jan-2026 image.
- The ci-unified pipeline builds the **service** image and publishes it to `ghcr.io/groupsky/homy/vpn:latest` (named by the compose service `vpn`, the same convention every other service uses — `mosquitto`→`homy/mosquitto`, `mongo`→`homy/mongo`, etc.).

**Consequence:** `docker compose pull vpn` fetched the stale mirror image, so CI-built `vpn` changes never reached prod. Discovered while deploying the hyphenated-peer-name guard patch (#1379): the patch merged and CI published `homy/vpn:latest` correctly, but the running container/compose still pulled the unpatched `homy/wireguard:latest`.

## Fix

One-line change: point the `vpn` service at `ghcr.io/groupsky/homy/vpn`. The base mirror stays `ghcr.io/groupsky/homy/wireguard:<version>` (referenced by `docker/wireguard/Dockerfile`'s `FROM`, unchanged).

## Verification

- `ghcr.io/groupsky/homy/vpn:latest` confirmed to contain the #1379 patch (guard is `^[[:alnum:]_-]+$`).
- After merge: prod `git pull` + `docker-compose pull vpn` + `up -d --no-deps vpn` deploys the patched image.

https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN