### PR TITLE
chore(vpn): upgrade wireguard base image to 1.0.20260223-r0-ls117

### DIFF
--- a/base-images/wireguard/Dockerfile
+++ b/base-images/wireguard/Dockerfile
@@ -1,1 +1,1 @@
-FROM linuxserver/wireguard:v1.0.20210914-ls1
+FROM linuxserver/wireguard:1.0.20260223-r0-ls117

--- a/docker/wireguard/Dockerfile
+++ b/docker/wireguard/Dockerfile
@@ -1,8 +1,8 @@
-FROM ghcr.io/groupsky/homy/wireguard:v1.0.20210914-ls1
+FROM ghcr.io/groupsky/homy/wireguard:1.0.20260223-r0-ls117
 
-# This linuxserver image (2021) only writes a [Peer] block for peers whose name
-# matches ^[[:alnum:]]+$, silently skipping any name containing '-' or '_'. Our
-# peers use hyphens (geno-laptop, tania-phone, ...), so every generate_confs run
+# This linuxserver image only writes a [Peer] block for peers whose name matches
+# ^[[:alnum:]]+$ (still true as of ls117), silently skipping any name containing
+# '-' or '_'. Our peers use hyphens (geno-laptop, tania-phone, ...), so every generate_confs run
 # (triggered by any PEERS change) rebuilt wg0.conf with ONLY the alphanumeric
 # peers, dropping the rest and breaking their VPN. Relax the guard to allow '-'
 # and '_'. The grep assertion fails the build if a future base-image bump moves


### PR DESCRIPTION
Security/maintenance upgrade of the WireGuard base image from the 2021 `v1.0.20210914-ls1` (Ubuntu Focal) to the current `1.0.20260223-r0-ls117` (Alpine 3.24). **Not urgent** — open for review; deploy on your schedule (see the one migration note below).

## Changes (two-step, per the base-image workflow)
1. `base-images/wireguard/Dockerfile`: mirror bump → CI Stage 2 publishes `ghcr.io/groupsky/homy/wireguard:1.0.20260223-r0-ls117`.
2. `docker/wireguard/Dockerfile`: service `FROM` bump to that GHCR tag. **The hyphenated-peer-name guard patch is retained.**

The base and service builds run in the same pipeline (bases before apps), so the new GHCR base tag exists by the time the service image builds. Target tag existence verified against Docker Hub (HTTP 200). `docker-bake.hcl` and `dependabot.yml` already cover wireguard — no change needed.

## Why the patch stays
The peer-name guard `^[[:alnum:]]+$` is **unchanged upstream even in ls117** (verified against `linuxserver/docker-wireguard` master) — hyphenated peers are still silently dropped without the patch. The patch's `grep` assertion doubles as a build-time check that the guard is still present in the new base.

## Compatibility (analyzed against our deployment)
Verified safe — **no device re-provisioning, no re-keying**:
- Custom mounted `templates/server.conf`/`peer.conf` still honored (defaults copied only if absent).
- Interface `Address` still taken verbatim from our template → stays `/32` (image injects no CIDR); per-peer `AllowedIPs = <ip>/32` unchanged.
- Env vars (`PEERS`, `INTERNAL_SUBNET`, `SERVERURL`, `SERVERPORT`, `ALLOWEDIPS`, `PEERDNS`) identical in name/semantics.
- `.donoteditthisfile` format compatible → first boot logs "No changes to parameters. Existing configs are used." (no regeneration).
- Existing `server/` + `peer_<name>/` keys reused as-is.
- Kernel module: fine on the prod host (kernel 5.15 in-kernel WireGuard, `/lib/modules` mounted, `SYS_MODULE`/`NET_ADMIN` granted). The dropped legacy DKMS path isn't used.
- (The current base is already s6-overlay v3, so there is no s6 v2→v3 jump; the patch's `sed`/`grep` target path is unchanged.)

## One behavioral change — path migration
First boot auto-migrates `/config/wg0.conf` → `/config/wg_confs/wg0.conf` (idempotent; old file deleted), and `svc-wireguard` then runs `wg-quick up` per file in `wg_confs/`. On prod that means `data/wireguard/wg0.conf` → `data/wireguard/wg_confs/wg0.conf`. Update any external references to the old path (e.g. the manual-fix runbook, the `wg0.conf.bak.*` restore procedure). Whole-directory backup/restore is unaffected.

## Deploy (when ready)
`git pull` on prod → `docker-compose pull vpn` → `docker-compose up -d --no-deps vpn` (never `--remove-orphans`). Recommend a maintenance window and keeping the previous image SHA for rollback, since a VPN blip locks out remote peers until they reconnect.

https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN