### PR TITLE
fix(compose): point multi-instance services at their per-service GHCR images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,7 +211,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
 
   main-power:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/main-power:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -251,7 +251,7 @@ services:
         max-file: "3"
 
   secondary-power:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/secondary-power:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -291,7 +291,7 @@ services:
         max-file: "3"
 
   tetriary-power:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/tetriary-power:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -332,7 +332,7 @@ services:
         max-file: "3"
 
   monitoring:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/monitoring:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -374,7 +374,7 @@ services:
         max-file: "3"
 
   monitoring2:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/monitoring2:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -416,7 +416,7 @@ services:
         max-file: "3"
 
   dry-switches:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/dry-switches:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -457,7 +457,7 @@ services:
         max-file: "3"
 
   solar:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/solar:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -499,7 +499,7 @@ services:
         max-file: "3"
 
   inverter:
-    image: ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/inverter:${IMAGE_TAG:-latest}
     build: docker/modbus-serial
     depends_on:
       - broker
@@ -639,7 +639,7 @@ services:
         max-file: "3"
 
   mqtt-mongo-history:
-    image: ghcr.io/groupsky/homy/mqtt-mongo:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/mqtt-mongo-history:${IMAGE_TAG:-latest}
     build: docker/mqtt-mongo
     depends_on:
       - broker
@@ -666,7 +666,7 @@ services:
         max-file: "3"
 
   mqtt-mongo-ioniq:
-    image: ghcr.io/groupsky/homy/mqtt-mongo:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/mqtt-mongo-ioniq:${IMAGE_TAG:-latest}
     build: docker/mqtt-mongo
     depends_on:
       - broker
@@ -695,7 +695,7 @@ services:
         max-file: "3"
 
   mqtt-influx-primary:
-    image: ghcr.io/groupsky/homy/mqtt-influx:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/mqtt-influx-primary:${IMAGE_TAG:-latest}
     build: docker/mqtt-influx
     depends_on:
       - broker
@@ -724,7 +724,7 @@ services:
         max-file: "3"
 
   mqtt-influx-secondary:
-    image: ghcr.io/groupsky/homy/mqtt-influx:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/mqtt-influx-secondary:${IMAGE_TAG:-latest}
     build: docker/mqtt-influx
     depends_on:
       - broker
@@ -753,7 +753,7 @@ services:
         max-file: "3"
 
   mqtt-influx-tetriary:
-    image: ghcr.io/groupsky/homy/mqtt-influx:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/mqtt-influx-tetriary:${IMAGE_TAG:-latest}
     build: docker/mqtt-influx
     depends_on:
       - broker
@@ -782,7 +782,7 @@ services:
         max-file: "3"
 
   mqtt-influx-dry-switches:
-    image: ghcr.io/groupsky/homy/mqtt-influx:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/mqtt-influx-dry-switches:${IMAGE_TAG:-latest}
     build: docker/mqtt-influx
     depends_on:
       - broker
@@ -807,7 +807,7 @@ services:
       - TAGS={"bus":"dry-switches"}
 
   mqtt-influx-ioniq:
-    image: ghcr.io/groupsky/homy/mqtt-influx:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/mqtt-influx-ioniq:${IMAGE_TAG:-latest}
     build: docker/mqtt-influx
     depends_on:
       - broker
@@ -940,7 +940,7 @@ services:
         max-file: "3"
 
   boiler-controller:
-    image: ghcr.io/groupsky/homy/automations:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/boiler-controller:${IMAGE_TAG:-latest}
     build: docker/automations
     depends_on:
       - broker
@@ -967,7 +967,7 @@ services:
         max-file: "3"
 
   features:
-    image: ghcr.io/groupsky/homy/automations:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/features:${IMAGE_TAG:-latest}
     build: docker/automations
     depends_on:
       - broker
@@ -988,7 +988,7 @@ services:
       - ${CONFIG_PATH}/automations/features.js:/etc/config.js:ro
 
   ha_discovery:
-    image: ghcr.io/groupsky/homy/automations:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/ha_discovery:${IMAGE_TAG:-latest}
     build: docker/automations
     depends_on:
       - broker
@@ -1011,7 +1011,7 @@ services:
   # Manualy run with
   # dc run historian-primary node index.js
   historian-primary:
-    image: ghcr.io/groupsky/homy/historian:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/historian-primary:${IMAGE_TAG:-latest}
     build: docker/historian
     depends_on:
       - broker
@@ -1041,7 +1041,7 @@ services:
   # Manualy run with
   # dc run historian-secondary node index.js
   historian-secondary:
-    image: ghcr.io/groupsky/homy/historian:${IMAGE_TAG:-latest}
+    image: ghcr.io/groupsky/homy/historian-secondary:${IMAGE_TAG:-latest}
     build: docker/historian
     depends_on:
       - broker


### PR DESCRIPTION
## Why

While deploying #1382 (the mqtt-mongo TTL fix), a clean `IMAGE_TAG=<sha>` pull of `ghcr.io/groupsky/homy/mqtt-mongo:<sha>` failed — that package has been **stale since 2026-01-25**. Root cause: the unified CI pipeline publishes **one image per compose service name** (`ci-unified.yml` loops over every service sharing a build context and tags `ghcr.io/groupsky/homy/$SERVICE`), but 20 multi-instance services still reference the **shared build-context name**. Those shared packages stopped updating at the ci-unified migration; prod has been running on manual `docker tag` bridges.

Verified against GHCR: every per-service package (`main-power`, `mqtt-influx-primary`, `boiler-controller`, `historian-primary`, `mqtt-mongo-ioniq`, …) is fresh; the shared names (`modbus-serial`, `mqtt-influx`, `automations`, `historian`, `mqtt-mongo`) are all stale (2026-01-25).

## What

Point each of the 20 multi-instance services at its own per-service GHCR package. CI tags all services in a build context from a single build, so the content is **identical** — this is a pure, behaviour-preserving name correction (diff is 20 `image:` lines, nothing else).

| Build context | Services repointed |
|---|---|
| `docker/modbus-serial` | main-power, secondary-power, tetriary-power, monitoring, monitoring2, dry-switches, solar, inverter |
| `docker/mqtt-mongo` | mqtt-mongo-history, mqtt-mongo-ioniq |
| `docker/mqtt-influx` | mqtt-influx-primary, -secondary, -tetriary, -dry-switches, -ioniq |
| `docker/historian` | historian-primary, historian-secondary |
| `docker/automations` | boiler-controller, features, ha_discovery |

## Explicitly NOT touched (needs separate review)

The 5 single-service contexts whose `image:` name is a **base image**, where renaming switches base→app image and is *not* guaranteed behaviour-preserving:

`ingress`→nginx, `ingressgen`→dockergen, `broker`→mosquitto, `ha`→homeassistant, `z2m-home1`→zigbee2mqtt

These deserve a per-context look (does the app Dockerfile add content that must run?) and are out of scope here.

## Verification

- `yaml.safe_load` parses; parser confirms **only** the 5 excluded services remain as image/name mismatches.
- Every changed line is an `image:` line (20 insertions / 20 deletions).
- All 20 target per-service packages confirmed present and fresh in GHCR.

https://claude.ai/code/session_01RZGSTfSZRayAJywLujsyJX