### PR TITLE
fix(ci): publish GHCR app images by compose image name, not service name

### DIFF
--- a/.github/scripts/detect-changes/src/index.ts
+++ b/.github/scripts/detect-changes/src/index.ts
@@ -13,7 +13,7 @@ import { Command } from 'commander';
 import { writeFileSync, readFileSync, existsSync } from 'fs';
 import * as path from 'path';
 import { discoverBaseImages, buildDirectoryToGhcrMapping } from './lib/base-images.js';
-import { discoverServicesFromCompose, filterGhcrServices } from './lib/services.js';
+import { discoverServicesFromCompose, filterGhcrServices, getImageName } from './lib/services.js';
 import { buildReverseDependencyMap, detectAffectedServices } from './lib/dependency-graph.js';
 import { detectChangedBaseImages, detectChangedServices, isTestOnlyChange } from './lib/change-detection.js';
 import { hasHealthcheck, extractFinalStageBase } from './lib/dockerfile-parser.js';
@@ -146,6 +146,7 @@ function convertToGitHubOutputs(result: DetectionResult): GitHubActionsOutputs {
     to_retag: JSON.stringify(result.to_retag),
     to_pull_for_testing: JSON.stringify(result.to_pull_for_testing),
     build_groups: JSON.stringify(result.build_groups),
+    service_image_names: JSON.stringify(result.service_image_names),
 
     // Test and verification outputs
     testable_services: JSON.stringify(result.testable_services),
@@ -292,11 +293,20 @@ async function detectChanges(options: CliOptions): Promise<DetectionResult> {
 
   // Convert to BuildGroup array
   const buildGroups: BuildGroup[] = Array.from(buildGroupsMap.entries())
-    .map(([buildPath, serviceList]) => ({
-      build_path: buildPath,
-      services: serviceList.sort(),
-      primary_service: serviceList.sort()[0],
-    }))
+    .map(([buildPath, serviceList]) => {
+      const sortedServices = serviceList.sort();
+      const primary = sortedServices[0];
+      // All services in a group share the same build context and image field,
+      // so the primary service is representative for the group's GHCR image name.
+      const primaryService = services.find((s) => s.service_name === primary);
+      const imageName = primaryService ? getImageName(primaryService) : primary;
+      return {
+        build_path: buildPath,
+        services: sortedServices,
+        primary_service: primary,
+        image_name: imageName,
+      };
+    })
     .sort((a, b) => a.build_path.localeCompare(b.build_path));
 
   console.error(`Build groups: ${buildGroups.length} (from ${toBuild.length} services)`);
@@ -358,6 +368,9 @@ async function detectChanges(options: CliOptions): Promise<DetectionResult> {
     healthcheck_services: healthcheckServices,
     version_check_services: versionCheckServices,
     build_groups: buildGroups,
+    // Map every GHCR service to its compose image name so CI can publish/pull/tag
+    // by shared image name (services sharing an image share the GHCR package).
+    service_image_names: Object.fromEntries(services.map((s) => [s.service_name, getImageName(s)])),
   };
 }
 

--- a/.github/scripts/detect-changes/src/lib/services.ts
+++ b/.github/scripts/detect-changes/src/lib/services.ts
@@ -154,6 +154,37 @@ export function extractServiceMetadata(
 }
 
 /**
+ * Derives the GHCR image name (basename of the compose `image:` field) for a service.
+ *
+ * Services can share a single GHCR package by using the same `image:` field even when
+ * they have distinct compose service names (e.g. `mqtt-mongo-history` and
+ * `mqtt-mongo-ioniq` both use `ghcr.io/groupsky/homy/mqtt-mongo`). CI must publish,
+ * pull, tag, and retag by this image name so shared services share the package.
+ *
+ * For images under `ghcr.io/groupsky/homy/`, the registry prefix and tag are stripped
+ * to yield the bare image name. Any other image (or a missing image field) falls back
+ * to the compose service name.
+ *
+ * @param service Service metadata from docker-compose discovery
+ * @returns GHCR image name, or the service name when no homy image applies
+ *
+ * @example
+ * ```typescript
+ * getImageName({ service_name: 'broker', image: 'ghcr.io/groupsky/homy/mosquitto:latest', ... }); // 'mosquitto'
+ * getImageName({ service_name: 'external-db', image: 'postgres:15', ... }); // 'external-db'
+ * ```
+ */
+export function getImageName(service: Service): string {
+  const img = service.image;
+  const prefix = 'ghcr.io/groupsky/homy/';
+  if (img && img.startsWith(prefix)) {
+    const name = img.slice(prefix.length).split(':')[0];
+    if (name) return name;
+  }
+  return service.service_name;
+}
+
+/**
  * Filters services to only those using GHCR base images or with build directives.
  *
  * This function filters the services array to include only:

--- a/.github/scripts/detect-changes/src/lib/types.ts
+++ b/.github/scripts/detect-changes/src/lib/types.ts
@@ -95,6 +95,8 @@ export interface BuildGroup {
   services: string[];
   /** Primary service name (first in alphabetical order) for display */
   primary_service: string;
+  /** GHCR image name from the compose `image:` field; shared by all services in this build context */
+  image_name: string;
 }
 
 /**
@@ -127,6 +129,8 @@ export interface DetectionResult {
   version_check_services: string[];
   /** Build groups for services sharing build contexts */
   build_groups: BuildGroup[];
+  /** Map of service name -> GHCR image name (basename of the compose image field) */
+  service_image_names: Record<string, string>;
 }
 
 /**

--- a/.github/scripts/detect-changes/tests/lib/services.test.ts
+++ b/.github/scripts/detect-changes/tests/lib/services.test.ts
@@ -24,7 +24,7 @@ jest.unstable_mockModule('child_process', () => ({
 }));
 
 // Import after mocking
-const { discoverServicesFromCompose, extractServiceMetadata, filterGhcrServices } = await import(
+const { discoverServicesFromCompose, extractServiceMetadata, filterGhcrServices, getImageName } = await import(
   '../../src/lib/services.js'
 );
 
@@ -562,6 +562,112 @@ describe('TestFilterGhcrServices', () => {
       expect(filtered).toHaveLength(1);
       expect(filtered[0].build_args).toEqual({
         GF_INSTALL_IMAGE_RENDERER_PLUGIN: 'false',
+      });
+    });
+  });
+});
+
+describe('TestGetImageName', () => {
+  describe('test_ghcr_image_with_tag', () => {
+    test('Should return image basename for GHCR image with explicit tag', () => {
+      const service: Service = {
+        service_name: 'mqtt-mongo-history',
+        image: 'ghcr.io/groupsky/homy/mqtt-mongo:latest',
+        build_context: 'docker/mqtt-mongo',
+        dockerfile_path: 'docker/mqtt-mongo/Dockerfile',
+      };
+
+      expect(getImageName(service)).toBe('mqtt-mongo');
+    });
+  });
+
+  describe('test_ghcr_image_with_variable_tag', () => {
+    test('Should strip a variable-style tag from GHCR image', () => {
+      const service: Service = {
+        service_name: 'broker',
+        image: 'ghcr.io/groupsky/homy/mosquitto:${IMAGE_TAG:-latest}',
+        build_context: 'docker/mosquitto',
+        dockerfile_path: 'docker/mosquitto/Dockerfile',
+      };
+
+      expect(getImageName(service)).toBe('mosquitto');
+    });
+  });
+
+  describe('test_ghcr_image_without_tag', () => {
+    test('Should return basename when GHCR image has no tag', () => {
+      const service: Service = {
+        service_name: 'automations',
+        image: 'ghcr.io/groupsky/homy/automations',
+        build_context: 'docker/automations',
+        dockerfile_path: 'docker/automations/Dockerfile',
+      };
+
+      expect(getImageName(service)).toBe('automations');
+    });
+  });
+
+  describe('test_no_image_field', () => {
+    test('Should fall back to service_name when image is undefined', () => {
+      const service: Service = {
+        service_name: 'local-service',
+        build_context: 'docker/local-service',
+        dockerfile_path: 'docker/local-service/Dockerfile',
+      };
+
+      expect(getImageName(service)).toBe('local-service');
+    });
+  });
+
+  describe('test_non_homy_image', () => {
+    test('Should fall back to service_name for non-homy images', () => {
+      const service: Service = {
+        service_name: 'external-db',
+        image: 'postgres:15',
+        build_context: 'docker/external-db',
+        dockerfile_path: 'docker/external-db/Dockerfile',
+      };
+
+      expect(getImageName(service)).toBe('external-db');
+    });
+  });
+
+  describe('test_shared_image_across_services', () => {
+    test('Should map multiple services to their shared GHCR image names', () => {
+      const services: Service[] = [
+        {
+          service_name: 'mqtt-mongo-ioniq',
+          image: 'ghcr.io/groupsky/homy/mqtt-mongo:${IMAGE_TAG:-latest}',
+          build_context: 'docker/mqtt-mongo',
+          dockerfile_path: 'docker/mqtt-mongo/Dockerfile',
+        },
+        {
+          service_name: 'mqtt-mongo-history',
+          image: 'ghcr.io/groupsky/homy/mqtt-mongo:${IMAGE_TAG:-latest}',
+          build_context: 'docker/mqtt-mongo',
+          dockerfile_path: 'docker/mqtt-mongo/Dockerfile',
+        },
+        {
+          service_name: 'main-power',
+          image: 'ghcr.io/groupsky/homy/modbus-serial:${IMAGE_TAG:-latest}',
+          build_context: 'docker/modbus-serial',
+          dockerfile_path: 'docker/modbus-serial/Dockerfile',
+        },
+        {
+          service_name: 'broker',
+          image: 'ghcr.io/groupsky/homy/mosquitto:${IMAGE_TAG:-latest}',
+          build_context: 'docker/mosquitto',
+          dockerfile_path: 'docker/mosquitto/Dockerfile',
+        },
+      ];
+
+      const map = Object.fromEntries(services.map((s) => [s.service_name, getImageName(s)]));
+
+      expect(map).toEqual({
+        'mqtt-mongo-ioniq': 'mqtt-mongo',
+        'mqtt-mongo-history': 'mqtt-mongo',
+        'main-power': 'modbus-serial',
+        broker: 'mosquitto',
       });
     });
   });

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -154,6 +154,8 @@ jobs:
       unused_base_images: ${{ steps.detect.outputs.unused_base_images }}
       # Build groups for services sharing build contexts
       build_groups: ${{ steps.detect.outputs.build_groups }}
+      # Map of service name -> GHCR image name (basename of the compose image field)
+      service_image_names: ${{ steps.detect.outputs.service_image_names }}
 
     steps:
       - name: Checkout code
@@ -663,14 +665,12 @@ jobs:
             exit 1
           fi
 
-          # Build tags for all services sharing this build context
-          TAGS=""
-          for SERVICE in $SERVICES; do
-            TAGS="$TAGS --tag ghcr.io/groupsky/homy/$SERVICE:$SHA"
-            TAGS="$TAGS --tag ghcr.io/groupsky/homy/$SERVICE:$SHORT_SHA"
-          done
-
-          echo "Creating tags for services: $SERVICES"
+          # Build once and tag by the group's shared GHCR image name.
+          # Services sharing a build context share a compose image field, so
+          # publishing by image name lets them share a single GHCR package.
+          IMAGE_NAME="${{ matrix.build.image_name }}"
+          TAGS="--tag ghcr.io/groupsky/homy/$IMAGE_NAME:$SHA --tag ghcr.io/groupsky/homy/$IMAGE_NAME:$SHORT_SHA"
+          echo "Creating tags for image $IMAGE_NAME (services: $SERVICES)"
 
           # Build with base images from GHCR
           # Base images are pulled automatically from GHCR as needed
@@ -808,10 +808,11 @@ jobs:
       - name: Pull image from GHCR
         env:
           SERVICE: ${{ matrix.service }}
+          IMAGE_NAME: ${{ fromJson(needs.detect-changes.outputs.service_image_names)[matrix.service] }}
           SHA: ${{ github.sha }}
         run: |
-          echo "=== Pulling image for $SERVICE ==="
-          IMAGE="ghcr.io/${{ github.repository_owner }}/homy/$SERVICE:$SHA"
+          echo "=== Pulling image for $SERVICE ($IMAGE_NAME) ==="
+          IMAGE="ghcr.io/${{ github.repository_owner }}/homy/$IMAGE_NAME:$SHA"
 
           if ! docker pull "$IMAGE"; then
             echo "::error::Failed to pull image: $IMAGE"
@@ -828,7 +829,7 @@ jobs:
 
           # Use docker inspect to get healthcheck params (robust method)
           HEALTHCHECK=$(docker inspect --format='{{json .Config.Healthcheck}}' \
-            ghcr.io/groupsky/homy/${{ matrix.service }}:${{ github.sha }})
+            ghcr.io/groupsky/homy/${{ fromJson(needs.detect-changes.outputs.service_image_names)[matrix.service] }}:${{ github.sha }})
 
           if [ -z "$HEALTHCHECK" ] || [ "$HEALTHCHECK" = "null" ]; then
             echo "::error::No HEALTHCHECK found in Dockerfile"
@@ -874,7 +875,7 @@ jobs:
           # Start container with healthcheck
           CONTAINER_ID=$(docker run -d \
             --env-file "$ENV_FILE" \
-            ghcr.io/groupsky/homy/${{ matrix.service }}:${{ github.sha }})
+            ghcr.io/groupsky/homy/${{ fromJson(needs.detect-changes.outputs.service_image_names)[matrix.service] }}:${{ github.sha }})
 
           echo "container_id=$CONTAINER_ID" >> $GITHUB_OUTPUT
           echo "Container started: $CONTAINER_ID"
@@ -969,57 +970,33 @@ jobs:
           echo "Current SHA: $SHA"
           echo ""
 
-          # Pull images for lights test dependencies
-          # Try current SHA first (for changed services)
-          # Fallback to :latest using the actual image name from docker-compose.yml
+          # Pull images for lights test dependencies by their compose IMAGE NAME.
+          # Images are published by image name (e.g. broker -> mosquitto,
+          # features -> automations), so pull ghcr.io/.../<image-name>:$SHA directly
+          # and fall back to :latest (retagged to :$SHA) when the SHA isn't present.
+          # docker compose up (with IMAGE_TAG=$SHA) then resolves these image names.
           for SERVICE in automations broker features; do
-            CURRENT_IMAGE="ghcr.io/groupsky/homy/$SERVICE:$SHA"
-
-            echo "Pulling $SERVICE..."
-
-            # Try current SHA first (service might have been built)
-            if docker pull "$CURRENT_IMAGE" 2>/dev/null; then
-              echo "✅ $SERVICE pulled from current SHA"
-              continue
-            fi
-
-            # Fallback: extract actual image name from docker-compose.yml and pull :latest
-            echo "⚠️  $SERVICE not at current SHA, trying :latest fallback"
-
             # Extract the image name from docker-compose.yml (e.g., broker -> mosquitto)
             # Parse: "image: ghcr.io/groupsky/homy/mosquitto:${IMAGE_TAG:-latest}" -> "mosquitto"
             IMAGE_NAME=$(grep -A 1 "^  $SERVICE:" docker-compose.yml | \
               grep "image:" | \
               sed 's/.*ghcr.io\/groupsky\/homy\///' | \
               sed 's/:.*$//')
+            [ -z "$IMAGE_NAME" ] && { echo "::error::Could not determine image name for $SERVICE"; exit 1; }
 
-            if [ -z "$IMAGE_NAME" ]; then
-              echo "::error::Could not determine image name for service: $SERVICE"
-              exit 1
-            fi
-
+            SHA_IMAGE="ghcr.io/groupsky/homy/$IMAGE_NAME:$SHA"
             LATEST_IMAGE="ghcr.io/groupsky/homy/$IMAGE_NAME:latest"
-            echo "Image name for $SERVICE: $IMAGE_NAME (pulling $LATEST_IMAGE)"
 
-            if docker pull "$LATEST_IMAGE" 2>/dev/null; then
-              docker tag "$LATEST_IMAGE" "$CURRENT_IMAGE"
-              echo "✅ $SERVICE retagged from $IMAGE_NAME:latest to $SERVICE:$SHA"
+            echo "Pulling $SERVICE ($IMAGE_NAME)..."
+            if docker pull "$SHA_IMAGE" 2>/dev/null; then
+              echo "✅ $SERVICE ($IMAGE_NAME) at SHA"
+            elif docker pull "$LATEST_IMAGE" 2>/dev/null; then
+              docker tag "$LATEST_IMAGE" "$SHA_IMAGE"
+              echo "✅ $SERVICE ($IMAGE_NAME) from :latest"
             else
-              echo "::error::Failed to pull $SERVICE from either current SHA or :latest"
-              echo "Current: $CURRENT_IMAGE"
-              echo "Latest: $LATEST_IMAGE"
-              exit 1
+              echo "::error::Failed to pull $IMAGE_NAME for $SERVICE"; exit 1
             fi
           done
-
-          # Retag images to match docker-compose.yml image names
-          # broker service expects mosquitto image
-          # features service expects automations image
-          echo ""
-          echo "=== Retagging images for docker-compose compatibility ==="
-
-          docker tag "ghcr.io/groupsky/homy/broker:$SHA" "ghcr.io/groupsky/homy/mosquitto:$SHA"
-          echo "✅ Retagged broker → mosquitto"
 
           echo ""
           echo "=== Available images ==="
@@ -1148,31 +1125,36 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          # Resolve the shared GHCR image name (basename of the compose image field).
+          # Multiple services sharing an image name run this job redundantly with
+          # identical tags; imagetools create is idempotent, so this is acceptable.
+          IMAGE_NAME: ${{ fromJson(needs.detect-changes.outputs.service_image_names)[matrix.service] }}
         run: |
-          echo "=== Determining tags for ${{ matrix.service }} ==="
+          echo "=== Determining tags for ${{ matrix.service }} (image: $IMAGE_NAME) ==="
 
           # Base tags: full SHA and short SHA
-          TAGS="ghcr.io/groupsky/homy/${{ matrix.service }}:${{ github.sha }}"
+          TAGS="ghcr.io/groupsky/homy/$IMAGE_NAME:${{ github.sha }}"
           SHORT_SHA="${{ github.sha }}"
-          TAGS="$TAGS ghcr.io/groupsky/homy/${{ matrix.service }}:${SHORT_SHA:0:12}"
+          TAGS="$TAGS ghcr.io/groupsky/homy/$IMAGE_NAME:${SHORT_SHA:0:12}"
 
           # Add branch or latest tag
           if [ "${{ github.ref }}" == "refs/heads/master" ]; then
-            TAGS="$TAGS ghcr.io/groupsky/homy/${{ matrix.service }}:latest"
+            TAGS="$TAGS ghcr.io/groupsky/homy/$IMAGE_NAME:latest"
             echo "Adding :latest tag (master branch)"
           else
             # Sanitize branch name for tag
             BRANCH=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///' | sed 's/[^a-zA-Z0-9_.-]/-/g' | cut -c1-100)
-            TAGS="$TAGS ghcr.io/groupsky/homy/${{ matrix.service }}:$BRANCH"
+            TAGS="$TAGS ghcr.io/groupsky/homy/$IMAGE_NAME:$BRANCH"
             echo "Adding :$BRANCH tag"
           fi
 
           # Add PR tag if applicable
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            TAGS="$TAGS ghcr.io/groupsky/homy/${{ matrix.service }}:pr-${{ github.event.pull_request.number }}"
+            TAGS="$TAGS ghcr.io/groupsky/homy/$IMAGE_NAME:pr-${{ github.event.pull_request.number }}"
             echo "Adding :pr-${{ github.event.pull_request.number }} tag"
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.pr_number }}" ]; then
-            TAGS="$TAGS ghcr.io/groupsky/homy/${{ matrix.service }}:pr-${{ github.event.inputs.pr_number }}"
+            TAGS="$TAGS ghcr.io/groupsky/homy/$IMAGE_NAME:pr-${{ github.event.inputs.pr_number }}"
             echo "Adding :pr-${{ github.event.inputs.pr_number }} tag (manual trigger)"
           fi
 
@@ -1187,8 +1169,8 @@ jobs:
         run: |
           echo "=== Creating additional tags in GHCR ==="
 
-          # Source image (already pushed by Stage 3)
-          SOURCE="ghcr.io/groupsky/homy/${{ matrix.service }}:${{ github.sha }}"
+          # Source image (already pushed by Stage 3), addressed by shared image name
+          SOURCE="ghcr.io/groupsky/homy/${{ fromJson(needs.detect-changes.outputs.service_image_names)[matrix.service] }}:${{ github.sha }}"
 
           # Create all tags at once using imagetools
           # This is more efficient than pulling/tagging/pushing
@@ -1260,10 +1242,13 @@ jobs:
           echo "sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
       - name: Retag existing image
+        env:
+          # Retag by shared GHCR image name (services sharing an image share the package).
+          IMAGE_NAME: ${{ fromJson(needs.detect-changes.outputs.service_image_names)[matrix.service] }}
         run: |
-          echo "=== Retagging existing image for ${{ matrix.service }} ==="
+          echo "=== Retagging existing image for ${{ matrix.service }} (image: $IMAGE_NAME) ==="
 
-          BASE_IMAGE="ghcr.io/groupsky/homy/${{ matrix.service }}:${{ steps.base-sha.outputs.sha }}"
+          BASE_IMAGE="ghcr.io/groupsky/homy/$IMAGE_NAME:${{ steps.base-sha.outputs.sha }}"
           echo "Base image: $BASE_IMAGE"
 
           # Determine new tag
@@ -1275,7 +1260,7 @@ jobs:
             NEW_TAG="$BRANCH"
           fi
 
-          NEW_IMAGE="ghcr.io/groupsky/homy/${{ matrix.service }}:$NEW_TAG"
+          NEW_IMAGE="ghcr.io/groupsky/homy/$IMAGE_NAME:$NEW_TAG"
           echo "New tag: $NEW_IMAGE"
 
           # Use imagetools create for manifest-only retag (no egress)


### PR DESCRIPTION
## Root cause

Deploying #1382 surfaced this: a clean `IMAGE_TAG=<sha>` pull of `ghcr.io/groupsky/homy/mqtt-mongo:<sha>` fails — that package is stale since 2026-01-25.

The **original** pipeline (`app-images.yml.disabled` L85-88) published each app image named by its docker-compose **`.image` field** basename (`sub("ghcr.io/groupsky/homy/"; "")`). The **ci-unified** rewrite builds `BuildGroup` keyed by build context but names/tags everything by **service name** (`homy/$SERVICE`), discarding the `image` field `services.ts` already parses. So for every multi-instance service (2 `mqtt-mongo`, 5 `mqtt-influx`, 8 `modbus-serial`, 2 `historian`, 3 `automations`-derived) the shared package (`mqtt-mongo`, `mqtt-influx`, …) went stale and prod has been surviving on manual `docker tag` bridges. The `lights` stage even hand-coded a `broker→mosquitto` retag to paper over it — proof the intended contract is image-name.

## Fix (CI only — no `docker-compose.yml` changes)

**`detect-changes`:**
- `getImageName(service)` — basename of the compose `image:` field (`ghcr.io/groupsky/homy/<name>:<tag>` → `<name>`), falling back to the service name for non-homy/imageless services. TDD-covered.
- `BuildGroup.image_name` added; new `service_image_names` output maps every GHCR service → its image name.

**`ci-unified.yml`:**
| Stage | Change |
|---|---|
| build-app-images | build once, tag by `matrix.build.image_name` |
| healthcheck-tests | pull/inspect by `service_image_names[matrix.service]` |
| lights-integration-test | pull by image name; **removed** the redundant `broker→mosquitto` retag |
| push-built-images (Tag Built) | tag by image name (idempotent redundancy for shared images) |
| retag-unchanged-images | retag by image name |

Result: services sharing an image share one GHCR package, exactly as `docker-compose.yml` already expresses.

## Verification
- `detect-changes`: **371 tests pass**, `tsc --noEmit` clean.
- Real compose (`docker compose config`) maps: `mqtt-mongo-{ioniq,history}→mqtt-mongo`, `mqtt-influx-primary→mqtt-influx`, `main-power→modbus-serial`, `boiler-controller→automations`, `historian-primary→historian`, `broker→mosquitto`, `ha→homeassistant`.
- `ci-unified.yml` YAML valid; grep confirms **no residual per-service app-image refs**.

## Note
This PR is a `.github`-only change, so its own CI won't rebuild services. The **first master run after merge** is the real integration test — it will republish the shared-name packages (`mqtt-mongo:<sha>`, etc.). Only then can the #1382 TTL-retention fix deploy cleanly (targeted, no bridge).

https://claude.ai/code/session_01RZGSTfSZRayAJywLujsyJX