### PR TITLE
feat(ioniq): phase-2 EV monitoring — Grafana alerts, DTC bot, routing

### DIFF
--- a/config/automations/config.js
+++ b/config/automations/config.js
@@ -476,6 +476,14 @@ module.exports = {
       outputTopic: tvLivingIrTopic,
       outputContent: 'plain',
     },
+
+    ioniqDtc: {
+      type: 'ioniq-dtc',
+      storedTopic: 'ioniq/parsed/dtc/stored',
+      pendingTopic: 'ioniq/parsed/dtc/pending',
+      outputTopic: 'ioniq/parsed/derived/dtc_count',
+      telegramWebhookUrl: 'http://telegram-bridge:3000/webhook',
+    },
   },
   gates: {
     mqtt: {

--- a/config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml
@@ -1,0 +1,81 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq 12V Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-12v-low-parked
+        title: "🚗 Ioniq 12V Low (parked)"
+        condition: A
+        data:
+          - refId: v12
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("aux_12v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND "state"='parked' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [12.2] }
+                  operator: { type: and }
+                  query: { params: [v12] }
+                  reducer: { type: last }
+                  type: query
+              expression: v12
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: warning, device: ioniq, subsystem: 12v }
+        annotations:
+          summary: "🚗 12V battery below 12.2 V while parked"
+          description: "Aux 12V is dropping at rest. Charge/replace before the next lock cycle — a dead 12V strands the car."
+
+      - uid: ioniq-12v-critical-parked
+        title: "🚗 Ioniq 12V Critical (parked)"
+        condition: A
+        data:
+          - refId: v12
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("aux_12v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND "state"='parked' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [11.8] }
+                  operator: { type: and }
+                  query: { params: [v12] }
+                  reducer: { type: last }
+                  type: query
+              expression: v12
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: critical, device: ioniq, subsystem: 12v }
+        annotations:
+          summary: "🚗 12V battery below 11.8 V while parked"
+          description: "Aux 12V critically low at rest. Charge/replace now to avoid stranding."

--- a/config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml
@@ -1,0 +1,391 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq Battery Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-isolation-low
+        title: "🚗 Ioniq HV Isolation Low"
+        condition: A
+        data:
+          - refId: iso
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("isolation_kohm") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [500] }
+                  operator: { type: and }
+                  query: { params: [iso] }
+                  reducer: { type: last }
+                  type: query
+              expression: iso
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 HV isolation resistance below 500 kΩ"
+          description: "Possible HV leak to chassis. Investigate before driving if it keeps falling."
+
+      - uid: ioniq-isolation-critical
+        title: "🚗 Ioniq HV Isolation Critical"
+        condition: A
+        data:
+          - refId: iso
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("isolation_kohm") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [100] }
+                  operator: { type: and }
+                  query: { params: [iso] }
+                  reducer: { type: last }
+                  type: query
+              expression: iso
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 HV isolation resistance below 100 kΩ"
+          description: "HV isolation at/under the rated minimum. Do not fast-charge; book HV inspection."
+
+      - uid: ioniq-cell-min-low
+        title: "🚗 Ioniq Min Cell Voltage Low"
+        condition: A
+        data:
+          - refId: cmin
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("cell_min_v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 5m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [3.0] }
+                  operator: { type: and }
+                  query: { params: [cmin] }
+                  reducer: { type: last }
+                  type: query
+              expression: cmin
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Minimum cell voltage below 3.0 V"
+          description: "A cell is running low. Monitor; read a full cell dump if it persists."
+
+      - uid: ioniq-cell-min-critical
+        title: "🚗 Ioniq Min Cell Voltage Critical"
+        condition: A
+        data:
+          - refId: cmin
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("cell_min_v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 5m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [2.5] }
+                  operator: { type: and }
+                  query: { params: [cmin] }
+                  reducer: { type: last }
+                  type: query
+              expression: cmin
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Minimum cell voltage below 2.5 V"
+          description: "Cell under-voltage. Stop charging/driving; read DTC + cell dump; service."
+
+      - uid: ioniq-cell-max-critical
+        title: "🚗 Ioniq Max Cell Voltage Critical"
+        condition: A
+        data:
+          - refId: cmax
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("cell_max_v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 5m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [4.15] }
+                  operator: { type: and }
+                  query: { params: [cmax] }
+                  reducer: { type: last }
+                  type: query
+              expression: cmax
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Maximum cell voltage above 4.15 V"
+          description: "Cell over-voltage. Stop charging; read DTC + cell dump; service."
+
+      - uid: ioniq-pack-temp-high
+        title: "🚗 Ioniq Pack Temperature High"
+        condition: A
+        data:
+          - refId: tmax
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("temp_max") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [45] }
+                  operator: { type: and }
+                  query: { params: [tmax] }
+                  reducer: { type: last }
+                  type: query
+              expression: tmax
+        noDataState: OK
+        execErrState: Alerting
+        for: 5m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Pack temperature above 45 °C"
+          description: "Battery running hot. Avoid fast-charging until it cools."
+
+      - uid: ioniq-pack-temp-critical
+        title: "🚗 Ioniq Pack Temperature Critical"
+        condition: A
+        data:
+          - refId: tmax
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("temp_max") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [55] }
+                  operator: { type: and }
+                  query: { params: [tmax] }
+                  reducer: { type: last }
+                  type: query
+              expression: tmax
+        noDataState: OK
+        execErrState: Alerting
+        for: 5m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Pack temperature above 55 °C"
+          description: "Pack over-temp. Stop charging/driving; investigate cooling."
+
+      - uid: ioniq-soh-step
+        title: "🚗 Ioniq State of Health Reduced"
+        condition: A
+        data:
+          - refId: soh
+            relativeTimeRange: { from: 86400, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("soh") FROM "ioniq"
+                WHERE "group"='bms/2105' AND time >= now() - 24h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [98] }
+                  operator: { type: and }
+                  query: { params: [soh] }
+                  reducer: { type: last }
+                  type: query
+              expression: soh
+        noDataState: OK
+        execErrState: Alerting
+        for: 1h
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Battery SoH dropped below 98%"
+          description: "Capacity fade step. Log and compare against warranty threshold over time."
+
+      - uid: ioniq-soh-critical
+        title: "🚗 Ioniq State of Health Critical"
+        condition: A
+        data:
+          - refId: soh
+            relativeTimeRange: { from: 86400, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("soh") FROM "ioniq"
+                WHERE "group"='bms/2105' AND time >= now() - 24h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [85] }
+                  operator: { type: and }
+                  query: { params: [soh] }
+                  reducer: { type: last }
+                  type: query
+              expression: soh
+        noDataState: OK
+        execErrState: Alerting
+        for: 1h
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Battery SoH below 85%"
+          description: "Significant capacity fade. Compare to warranty replacement threshold."
+
+      - uid: ioniq-avail-dis-derate
+        title: "🚗 Ioniq Available Discharge Derated"
+        condition: A
+        data:
+          - refId: disq
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("avail_dis") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: socq
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("soc") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [70] }
+                  operator: { type: and }
+                  query: { params: [disq] }
+                  reducer: { type: last }
+                  type: query
+                - evaluator: { type: gt, params: [30] }
+                  operator: { type: and }
+                  query: { params: [socq] }
+                  reducer: { type: last }
+                  type: query
+              expression: disq
+        noDataState: OK
+        execErrState: Alerting
+        for: 15m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Available discharge power derated below 70 kW"
+          description: "BMS is limiting discharge while SoC is healthy (>30%). Watch for a developing pack fault."

--- a/config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml
@@ -1,0 +1,44 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq DTC Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-dtc-present
+        title: "🚗 Ioniq Diagnostic Trouble Code"
+        condition: A
+        data:
+          - refId: dtc
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/dtc_count' AND time >= now() - 1h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [dtc] }
+                  reducer: { type: last }
+                  type: query
+              expression: dtc
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: critical, device: ioniq, subsystem: dtc }
+        annotations:
+          summary: "🚗 Diagnostic trouble code(s) present: {{ $values.dtc.Value }} active"
+          description: "The car reported one or more DTCs. The Telegram flag from the ioniq-dtc bot names the specific code(s); decode and act by code."

--- a/config/grafana/provisioning/alerting/notification-policies.yaml
+++ b/config/grafana/provisioning/alerting/notification-policies.yaml
@@ -9,3 +9,25 @@ policies:
     group_wait: 30s
     group_interval: 5m
     repeat_interval: 4h
+    routes:
+      - receiver: telegram-webhook
+        matchers:
+          - device = ioniq
+          - severity = critical
+        group_wait: 10s
+        group_interval: 1m
+        repeat_interval: 1h
+      - receiver: telegram-webhook
+        matchers:
+          - device = ioniq
+          - severity = warning
+        group_wait: 1m
+        group_interval: 5m
+        repeat_interval: 12h
+      - receiver: telegram-webhook
+        matchers:
+          - device = ioniq
+          - severity = info
+        group_wait: 5m
+        group_interval: 30m
+        repeat_interval: 24h

--- a/docker/automations/bots/ioniq-dtc.js
+++ b/docker/automations/bots/ioniq-dtc.js
@@ -1,11 +1,36 @@
 // ioniq-dtc: reduces the Ioniq DTC arrays (stored + pending) to a numeric
-// derived/dtc_count signal for Grafana, and (Task 2) direct-flags new codes to Telegram.
+// derived/dtc_count signal for Grafana, and direct-flags newly-appeared codes
+// to Telegram via telegram-bridge.
 async function defaultHttpPost (url, body) {
   return fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   })
+}
+
+// Escape the few characters that would corrupt a telegram-bridge HTML message
+// (parse_mode: HTML). DTC codes are normally alphanumeric, but a malformed code
+// must never break the message and silently suppress a critical alert.
+function escapeHtml (value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+// The logger publishes `codes` as a JSON array; tolerate a JSON-string form too
+// so a delivery quirk can't silently zero out the whole feature.
+function parseCodes (raw) {
+  let codes = raw
+  if (typeof codes === 'string') {
+    try {
+      codes = JSON.parse(codes)
+    } catch (err) {
+      codes = []
+    }
+  }
+  return Array.isArray(codes) ? codes : []
 }
 
 module.exports = function createIoniqDtc (name, config) {
@@ -17,18 +42,17 @@ module.exports = function createIoniqDtc (name, config) {
   const httpPost = config.httpPost || defaultHttpPost
   const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
 
-  const keyOf = (codes) => codes.slice().sort().join(',')
-
   return {
     persistedCache: {
       version: 1,
-      default: { stored: [], pending: [], flaggedKey: '' }
+      // `flagged` is the set of codes already direct-flagged in the current
+      // fault episode; it resets only when all codes clear (union empty).
+      default: { stored: [], pending: [], flagged: [] }
     },
 
     start: async ({ mqtt, persistedCache }) => {
       const handle = (which) => async (payload) => {
-        const codes = Array.isArray(payload && payload.codes) ? payload.codes : []
-        persistedCache[which] = codes
+        persistedCache[which] = parseCodes(payload && payload.codes)
 
         const union = [...new Set([...persistedCache.stored, ...persistedCache.pending])]
         mqtt.publish(outputTopic, {
@@ -40,16 +64,22 @@ module.exports = function createIoniqDtc (name, config) {
           codes: union
         })
 
+        // All codes cleared: reset so a genuinely new episode flags again.
         if (union.length === 0) {
-          persistedCache.flaggedKey = ''
+          persistedCache.flagged = []
           return
         }
 
-        const key = keyOf(union)
-        if (flagOnEdge && key !== persistedCache.flaggedKey) {
-          persistedCache.flaggedKey = key
-          const parts = union.map((code) =>
-            `${code} (${persistedCache.stored.includes(code) ? 'stored' : 'pending'})`)
+        // Flag only codes not already flagged this episode — never on removal,
+        // and never re-nag a code that merely persists or reappears while
+        // other codes remain present.
+        const flaggedSet = new Set(persistedCache.flagged)
+        const newCodes = union.filter((code) => !flaggedSet.has(code))
+        persistedCache.flagged = [...new Set([...persistedCache.flagged, ...union])]
+
+        if (flagOnEdge && newCodes.length > 0) {
+          const parts = newCodes.map((code) =>
+            `${escapeHtml(code)} (${persistedCache.stored.includes(code) ? 'stored' : 'pending'})`)
           const message = `🚗 <b>DTC present</b>: ${parts.join(', ')}`
           try {
             await httpPost(telegramWebhookUrl, { message })

--- a/docker/automations/bots/ioniq-dtc.js
+++ b/docker/automations/bots/ioniq-dtc.js
@@ -1,0 +1,42 @@
+// ioniq-dtc: reduces the Ioniq DTC arrays (stored + pending) to a numeric
+// derived/dtc_count signal for Grafana, and (Task 2) direct-flags new codes to Telegram.
+async function defaultHttpPost (url, body) {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+}
+
+module.exports = function createIoniqDtc (name, config) {
+  const storedTopic = config.storedTopic || 'ioniq/parsed/dtc/stored'
+  const pendingTopic = config.pendingTopic || 'ioniq/parsed/dtc/pending'
+  const outputTopic = config.outputTopic || 'ioniq/parsed/derived/dtc_count'
+
+  return {
+    persistedCache: {
+      version: 1,
+      default: { stored: [], pending: [], flaggedKey: '' }
+    },
+
+    start: async ({ mqtt, persistedCache }) => {
+      const handle = (which) => (payload) => {
+        const codes = Array.isArray(payload && payload.codes) ? payload.codes : []
+        persistedCache[which] = codes
+
+        const union = [...new Set([...persistedCache.stored, ...persistedCache.pending])]
+        mqtt.publish(outputTopic, {
+          _type: 'ioniq',
+          group: 'derived/dtc_count',
+          state: payload && payload.state,
+          ts: payload && payload.ts,
+          value: union.length,
+          codes: union
+        })
+      }
+
+      await mqtt.subscribe(storedTopic, handle('stored'))
+      await mqtt.subscribe(pendingTopic, handle('pending'))
+    }
+  }
+}

--- a/docker/automations/bots/ioniq-dtc.js
+++ b/docker/automations/bots/ioniq-dtc.js
@@ -12,6 +12,12 @@ module.exports = function createIoniqDtc (name, config) {
   const storedTopic = config.storedTopic || 'ioniq/parsed/dtc/stored'
   const pendingTopic = config.pendingTopic || 'ioniq/parsed/dtc/pending'
   const outputTopic = config.outputTopic || 'ioniq/parsed/derived/dtc_count'
+  const telegramWebhookUrl = config.telegramWebhookUrl || 'http://telegram-bridge:3000/webhook'
+  const flagOnEdge = config.flagOnEdge !== false
+  const httpPost = config.httpPost || defaultHttpPost
+  const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
+
+  const keyOf = (codes) => codes.slice().sort().join(',')
 
   return {
     persistedCache: {
@@ -20,7 +26,7 @@ module.exports = function createIoniqDtc (name, config) {
     },
 
     start: async ({ mqtt, persistedCache }) => {
-      const handle = (which) => (payload) => {
+      const handle = (which) => async (payload) => {
         const codes = Array.isArray(payload && payload.codes) ? payload.codes : []
         persistedCache[which] = codes
 
@@ -33,6 +39,24 @@ module.exports = function createIoniqDtc (name, config) {
           value: union.length,
           codes: union
         })
+
+        if (union.length === 0) {
+          persistedCache.flaggedKey = ''
+          return
+        }
+
+        const key = keyOf(union)
+        if (flagOnEdge && key !== persistedCache.flaggedKey) {
+          persistedCache.flaggedKey = key
+          const parts = union.map((code) =>
+            `${code} (${persistedCache.stored.includes(code) ? 'stored' : 'pending'})`)
+          const message = `🚗 <b>DTC present</b>: ${parts.join(', ')}`
+          try {
+            await httpPost(telegramWebhookUrl, { message })
+          } catch (err) {
+            log('direct-flag POST failed:', err && err.message)
+          }
+        }
       }
 
       await mqtt.subscribe(storedTopic, handle('stored'))

--- a/docker/automations/bots/ioniq-dtc.test.js
+++ b/docker/automations/bots/ioniq-dtc.test.js
@@ -78,3 +78,66 @@ describe('ioniq-dtc bot — derived signal', () => {
     expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, expect.objectContaining({ value: 0, codes: [] }))
   })
 })
+
+describe('ioniq-dtc bot — direct flag', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(() => {
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    config.httpPost = jest.fn().mockResolvedValue({ ok: true })
+    config.telegramWebhookUrl = 'http://telegram-bridge:3000/webhook'
+    bot = createIoniqDtc('ioniq-dtc', config)
+  })
+
+  it('flags once when a DTC appears, naming the code and source', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    expect(config.httpPost).toHaveBeenCalledTimes(1)
+    expect(config.httpPost).toHaveBeenCalledWith(
+      'http://telegram-bridge:3000/webhook',
+      { message: '🚗 <b>DTC present</b>: P0AA6 (stored)' }
+    )
+  })
+
+  it('does not re-flag the same code set on repeated samples', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 2, codes: ['P0AA6'] })
+    expect(config.httpPost).toHaveBeenCalledTimes(1)
+  })
+
+  it('flags again after the codes clear and a new DTC appears', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 2, codes: [] })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 3, codes: ['P0AA6'] })
+    expect(config.httpPost).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not re-flag a code set already flagged before restart', async () => {
+    persistedCache.stored = ['P0AA6']
+    persistedCache.flaggedKey = 'P0AA6'
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 5, codes: ['P0AA6'] })
+    expect(config.httpPost).not.toHaveBeenCalled()
+  })
+
+  it('still publishes the derived signal when the HTTP flag fails', async () => {
+    config.httpPost = jest.fn().mockRejectedValue(new Error('bridge down'))
+    bot = createIoniqDtc('ioniq-dtc', config)
+    await bot.start({ mqtt, persistedCache })
+    await expect(
+      mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    ).resolves.not.toThrow()
+    expect(mqtt.publish).toHaveBeenCalledWith(OUTPUT, expect.objectContaining({ value: 1 }))
+  })
+
+  it('never flags when flagOnEdge is false', async () => {
+    config.flagOnEdge = false
+    bot = createIoniqDtc('ioniq-dtc', config)
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    expect(config.httpPost).not.toHaveBeenCalled()
+    delete config.flagOnEdge
+  })
+})

--- a/docker/automations/bots/ioniq-dtc.test.js
+++ b/docker/automations/bots/ioniq-dtc.test.js
@@ -20,7 +20,7 @@ function makeMqtt () {
 }
 
 function makeCache () {
-  return { stored: [], pending: [], flaggedKey: '' }
+  return { stored: [], pending: [], flagged: [] }
 }
 
 const config = {
@@ -116,10 +116,51 @@ describe('ioniq-dtc bot — direct flag', () => {
 
   it('does not re-flag a code set already flagged before restart', async () => {
     persistedCache.stored = ['P0AA6']
-    persistedCache.flaggedKey = 'P0AA6'
+    persistedCache.flagged = ['P0AA6']
     await bot.start({ mqtt, persistedCache })
     await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 5, codes: ['P0AA6'] })
     expect(config.httpPost).not.toHaveBeenCalled()
+  })
+
+  it('flags only the newly-appeared code, not the whole set', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    await mqtt._trigger(PENDING, { group: 'dtc/pending', state: 'active', ts: 2, codes: ['C1611'] })
+    expect(config.httpPost).toHaveBeenCalledTimes(2)
+    expect(config.httpPost).toHaveBeenNthCalledWith(1,
+      'http://telegram-bridge:3000/webhook',
+      { message: '🚗 <b>DTC present</b>: P0AA6 (stored)' })
+    expect(config.httpPost).toHaveBeenNthCalledWith(2,
+      'http://telegram-bridge:3000/webhook',
+      { message: '🚗 <b>DTC present</b>: C1611 (pending)' })
+  })
+
+  it('does not spuriously flag when one code clears while another persists', async () => {
+    await bot.start({ mqtt, persistedCache })
+    // stored A persists; pending B flaps in and out
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['A'] })
+    await mqtt._trigger(PENDING, { group: 'dtc/pending', state: 'active', ts: 2, codes: ['B'] })
+    await mqtt._trigger(PENDING, { group: 'dtc/pending', state: 'active', ts: 3, codes: [] })
+    await mqtt._trigger(PENDING, { group: 'dtc/pending', state: 'active', ts: 4, codes: ['B'] })
+    // Exactly two flags: A on appearance, B on appearance. No flag on B's
+    // removal (ts 3) and no re-flag of B on reappearance while A persists (ts 4).
+    expect(config.httpPost).toHaveBeenCalledTimes(2)
+  })
+
+  it('escapes HTML-special characters in codes so the message cannot be broken', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['<b>&x'] })
+    expect(config.httpPost).toHaveBeenCalledWith(
+      'http://telegram-bridge:3000/webhook',
+      { message: '🚗 <b>DTC present</b>: &lt;b&gt;&amp;x (stored)' }
+    )
+  })
+
+  it('accepts codes delivered as a JSON string', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: '["P0AA6"]' })
+    expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, expect.objectContaining({ value: 1, codes: ['P0AA6'] }))
+    expect(config.httpPost).toHaveBeenCalledTimes(1)
   })
 
   it('still publishes the derived signal when the HTTP flag fails', async () => {

--- a/docker/automations/bots/ioniq-dtc.test.js
+++ b/docker/automations/bots/ioniq-dtc.test.js
@@ -1,0 +1,80 @@
+const { afterEach, beforeEach, describe, expect, it, jest } = require('@jest/globals')
+const createIoniqDtc = require('./ioniq-dtc')
+
+const STORED = 'ioniq/parsed/dtc/stored'
+const PENDING = 'ioniq/parsed/dtc/pending'
+const OUTPUT = 'ioniq/parsed/derived/dtc_count'
+
+function makeMqtt () {
+  const mqtt = {
+    _callbacks: {},
+    subscribe: jest.fn().mockImplementation((topic, cb) => {
+      mqtt._callbacks[topic] = cb
+      return Promise.resolve()
+    }),
+    publish: jest.fn().mockResolvedValue(),
+    _trigger: (topic, message) =>
+      mqtt._callbacks[topic] ? mqtt._callbacks[topic](message) : undefined
+  }
+  return mqtt
+}
+
+function makeCache () {
+  return { stored: [], pending: [], flaggedKey: '' }
+}
+
+const config = {
+  storedTopic: STORED,
+  pendingTopic: PENDING,
+  outputTopic: OUTPUT,
+  httpPost: jest.fn().mockResolvedValue({ ok: true })
+}
+
+describe('ioniq-dtc bot — derived signal', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(() => {
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    config.httpPost = jest.fn().mockResolvedValue({ ok: true })
+    bot = createIoniqDtc('ioniq-dtc', config)
+  })
+
+  it('subscribes to both dtc topics', async () => {
+    await bot.start({ mqtt, persistedCache })
+    expect(mqtt.subscribe).toHaveBeenCalledWith(STORED, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(PENDING, expect.any(Function))
+  })
+
+  it('publishes value 0 with empty codes and no flag', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'parked', ts: 100, codes: [] })
+    expect(mqtt.publish).toHaveBeenCalledWith(OUTPUT, {
+      _type: 'ioniq', group: 'derived/dtc_count', state: 'parked', ts: 100, value: 0, codes: []
+    })
+    expect(config.httpPost).not.toHaveBeenCalled()
+  })
+
+  it('publishes the count and union of codes when a DTC appears', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 200, codes: ['P0AA6'] })
+    expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, {
+      _type: 'ioniq', group: 'derived/dtc_count', state: 'active', ts: 200, value: 1, codes: ['P0AA6']
+    })
+  })
+
+  it('unions stored and pending, de-duplicating shared codes', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 300, codes: ['P0AA6', 'P1B76'] })
+    await mqtt._trigger(PENDING, { group: 'dtc/pending', state: 'active', ts: 301, codes: ['P1B76', 'C1611'] })
+    expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, {
+      _type: 'ioniq', group: 'derived/dtc_count', state: 'active', ts: 301, value: 3,
+      codes: ['P0AA6', 'P1B76', 'C1611']
+    })
+  })
+
+  it('treats a missing codes field as empty', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'parked', ts: 400 })
+    expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, expect.objectContaining({ value: 0, codes: [] }))
+  })
+})

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -9,6 +9,9 @@ This directory contains technical documentation for the home automation system.
   - **[Water System Diagram](water_system_diagram.mermaid)** - Visual flow diagram of water circuits and components
   - **IMPORTANT**: Always keep the specification and diagram synchronized when making changes
 
+### Vehicle Telemetry
+- **[Ioniq EV Monitoring & Alerting](ioniq-monitoring-alerting-spec.md)** - Monitoring and alerting specification for the Hyundai Ioniq Electric (battery / 12 V / tires / DTC alerts, Grafana rules, and automations bots over the OBD-logger telemetry)
+
 ### Component Documentation
 
 #### HVAC and Climate Control

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -189,11 +189,11 @@ query this measurement's `v` field. See
 **Source**: `mqtt-influx-ioniq` → `ioniq/parsed/#` (converter `converters/ioniq.js`, `_type: "ioniq"`)
 **Tag Structure**:
 - `group`: decoded frame group (e.g. `bms/2101`, `tpms`), from `payload.group`
+  - `derived/dtc_count` — a bot-produced `group` value (not from the logger): the `ioniq-dtc`
+    automations bot publishes it with field `value` = count of active DTCs (union of `dtc/stored`
+    + `dtc/pending`) and field `codes` = JSON-stringified array of the code strings. Grafana's
+    `ioniq-dtc-present` rule alerts on `value > 0`.
 - `state`: vehicle state (`active` / `parked` / `charging` / …), from `payload.state` — low-cardinality, what dashboards filter/group by
-- **`derived/dtc_count`** (tag `group`) — produced by the `ioniq-dtc` automations bot, not the
-  logger. Field `value` = count of active DTCs (union of `dtc/stored` + `dtc/pending`); field
-  `codes` = JSON-stringified array of the code strings. Grafana's `ioniq-dtc-present` rule alerts
-  on `value > 0`.
 **Timestamp**: `payload.ts` (epoch ms), written at `ms` precision
 **Fields**: every payload key except `_type`, `group`, `state`, `ts`:
 - numbers → float (uniformly, even integers, to avoid InfluxDB int/float type conflicts)

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -190,6 +190,10 @@ query this measurement's `v` field. See
 **Tag Structure**:
 - `group`: decoded frame group (e.g. `bms/2101`, `tpms`), from `payload.group`
 - `state`: vehicle state (`active` / `parked` / `charging` / …), from `payload.state` — low-cardinality, what dashboards filter/group by
+- **`derived/dtc_count`** (tag `group`) — produced by the `ioniq-dtc` automations bot, not the
+  logger. Field `value` = count of active DTCs (union of `dtc/stored` + `dtc/pending`); field
+  `codes` = JSON-stringified array of the code strings. Grafana's `ioniq-dtc-present` rule alerts
+  on `value > 0`.
 **Timestamp**: `payload.ts` (epoch ms), written at `ms` precision
 **Fields**: every payload key except `_type`, `group`, `state`, `ts`:
 - numbers → float (uniformly, even integers, to avoid InfluxDB int/float type conflicts)

--- a/docs/ioniq-monitoring-alerting-spec.md
+++ b/docs/ioniq-monitoring-alerting-spec.md
@@ -1,0 +1,301 @@
+# Ioniq EV — Monitoring & Alerting Specification
+
+Status: draft for review · Target: `homy` repo (Grafana provisioning + automations bots) · Vehicle: 2017 Hyundai Ioniq Electric (28 kWh, 96S) · Data source: OBD logger telemetry in InfluxDB (`ioniq`) + MongoDB (`homy.ioniq`).
+
+Thresholds below are derived from the 2026-07-14 baseline session and 2017 Ioniq Electric specs; every one is marked **baseline** (observed) or **spec** (rated limit) and is tunable once more history accrues. Nothing here modifies the logger — it consumes what the logger already publishes, plus a small set of computed "derived" signals.
+
+---
+
+## 0. Goals & non-goals
+
+**Goals**
+- Detect developing faults early (pack, 12 V, tires, DTCs) and notify over the existing Telegram channel with severity-appropriate urgency.
+- Detect loss of telemetry (logger offline / stale data) *without* false-firing on the car's normal power-cycling.
+- Provide operational dashboards for battery health, 12 V, tires, trips/charging, and pipeline health.
+
+**Non-goals**
+- No new notification transport (reuse `telegram-webhook` → `telegram-bridge`).
+- No logger-side changes (tracked separately in `ioniq-logger` issues #5–#13).
+- No alerting on signals that aren't yet decoded/queryable (those are prerequisites, §2, or logger work).
+
+---
+
+## 1. Architecture
+
+```
+logger ──MQTT──> mqtt-influx-ioniq ──> InfluxDB "ioniq"  ──> Grafana rules ─┐
+       (ioniq/parsed/#)                (parsed only)                        │
+                                                                            ├─> telegram-webhook ─> telegram-bridge ─> Telegram
+automations bots (compute) ──MQTT──> ioniq/parsed/derived/* ──> InfluxDB ───┘
+       (subscribe ioniq/parsed/#, ioniq/#)   (via same bridge)   Grafana rules
+```
+
+**Division of labour**
+- **Grafana rules** own everything expressible as a threshold/staleness query over a single InfluxDB field: `isolation_kohm`, `soh`, `temp_max`, `cell_min_v`/`cell_max_v`, `aux_12v` (state-filtered), `avail_dis`, per-wheel pressure, and all data-liveness checks. Grafana also owns **all notification delivery, dedup, grouping, and silencing**.
+- **Automations bots** own conditions Grafana/InfluxQL express poorly: **array logic** (DTC `codes[]`), **cross-field/cross-topic math** not in InfluxDB (96-cell rest spread, 12-sensor thermal spread, cold-normalized tire pressure, cross-wheel outliers), and **stateful/edge** logic (charge-stalled, SoC-at-park, LDC-not-charging). Each bot **reduces its condition to a clean numeric signal** published to `ioniq/parsed/derived/<name>` so it lands in InfluxDB and Grafana alerts on it with a trivial threshold. This keeps one notification path and one place to silence.
+  - Exception: a bot MAY also flag immediately, but default is "bot computes → Grafana alerts" (worst-case added latency = Grafana eval interval, set to 1 m for the derived group).
+
+---
+
+## 2. Prerequisites (P0 — must land before alerts are trustworthy)
+
+These are the gaps the analysis surfaced; alerts silently mislead without them.
+
+| # | Prerequisite | Why it blocks alerting | Owner |
+|---|---|---|---|
+| P0-1 | **Promote needed raw signals to `parsed/` so they reach InfluxDB.** At minimum `bcm_b00e.charge_connector`, `obc.dc_*`. | Grafana can only see `ioniq/parsed/#`; raw groups are Mongo-only. Charge alerts need charge-connector + DC power. | logger #7 (& #5) |
+| P0-2 | **Fix Mongo TTL retention.** Prod index `ttl__ts` targets a non-existent top-level `_ts`; 0/N docs match → retention never fires. Deploy fix #1382 (indexes `payload._ts`) to routy **and** manually `dropIndex("ttl__ts")` (createIndex won't remove the stale one). | Unbounded Mongo growth; not an alert per se but an ops must-fix. | homy ops |
+| P0-3 | **Bound InfluxDB retention / downsample.** `autogen` RP = infinite (`duration 0s`); fast tier writes at ~2 Hz. Add a finite RP for raw high-rate groups + a CQ downsample (e.g. 1 m means) for dashboards/trends. | Unbounded Influx growth; long-range dashboards get slow. | homy ops |
+| P0-4 | **Derived-signals convention.** Bots publish computed alert inputs to `ioniq/parsed/derived/<name>` with `{group:"derived/<name>", state, ts, value, …}` so the existing `mqtt-influx-ioniq` bridge writes them to measurement `ioniq`, tag `group=derived/<name>`. | Enables the "bot computes → Grafana alerts" pattern. | this spec |
+
+> Note on split-brain (§for context): if the team prefers not to promote raw groups, an alternative is a second `mqtt-influx` bridge on `ioniq/raw/#`, but promoting the specific decoded fields (P0-1) is cleaner and already ticketed.
+
+---
+
+## 3. Severity model & notification routing
+
+Three severities on a `severity` label, plus a `device: ioniq` label on every rule.
+
+| Severity | Meaning | Examples | Delivery target |
+|---|---|---|---|
+| `critical` | Safety / imminent immobilisation / active fault | HV isolation low, cell over/under-V, pack over-temp, **any DTC**, 12 V critically low | Immediate, short repeat |
+| `warning` | Developing problem, act within days | rising cell spread, SoH step, tire low, LDC not charging, charge stalled, low SoC at park, **logger offline (unexpected)** | Grouped, medium repeat |
+| `info` | FYI / trend / hygiene | reduced-rate AC charge, connectivity flapping, module thermal spread nudging up | Digest, long repeat |
+
+**Notification policy** (`config/grafana/provisioning/alerting/notification-policies.yaml`) — replace the single flat route with nested routes matched on `severity`, all still terminating at `telegram-webhook`:
+
+```yaml
+policies:
+  - orgId: 1
+    receiver: telegram-webhook
+    group_by: [grafana_folder, alertname]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    routes:
+      - receiver: telegram-webhook
+        matchers: ['severity = critical']
+        group_wait: 10s
+        group_interval: 1m
+        repeat_interval: 1h        # nag until acknowledged/resolved
+      - receiver: telegram-webhook
+        matchers: ['severity = warning']
+        group_wait: 1m
+        group_interval: 5m
+        repeat_interval: 12h
+      - receiver: telegram-webhook
+        matchers: ['severity = info']
+        group_wait: 5m
+        group_interval: 30m
+        repeat_interval: 24h
+```
+
+**Optional dedicated channel:** to separate car alerts from house alerts, add a second contact point `telegram-webhook-ioniq` (same `telegram-bridge` webhook, distinct `title:` e.g. "🚗 Ioniq Alert"; if a different Telegram chat is wanted, `telegram-bridge` must support a per-webhook chat id — verify before relying on it) and point the three routes above at it. Default for v1: reuse `telegram-webhook` with the `🚗` title prefix in each rule's `summary`.
+
+---
+
+## 4. Alert catalog
+
+Columns: **Signal/source** · **Condition** · **Threshold** (baseline/spec) · **Sev** · **`for:`** · **Platform**. All Grafana queries use `classic_conditions` + explicit `WHERE time >= now() - <window>` (per repo Grafana rules; no `$timeFilter`). `group`/dotted fields are double-quoted; string literals single-quoted.
+
+### 4.1 HV traction battery / BMS
+
+| Signal | Condition | Threshold | Sev | for | Platform |
+|---|---|---|---|---|---|
+| HV isolation `isolation_kohm` (bms/2101) | value low (normally pinned 1000) | `<500` / `<100` (spec: ≥100 Ω/V min) | warning / **critical** | 10m | Grafana |
+| Min cell `cell_min_v` (bms/2101) | under-voltage | `<3.0` warn / `<2.5` crit (spec NMC) | warning / **critical** | 1m | Grafana |
+| Max cell `cell_max_v` (bms/2101) | over-voltage | `>4.15` (spec) | **critical** | 1m | Grafana |
+| Pack temp `temp_max` (bms/2101) | over-temp | `>45` warn / `>55` crit (spec) | warning / **critical** | 5m | Grafana |
+| SoH `soh` (bms/2105) | capacity fade | drop `>2%` from 30-day baseline warn; `<85%` crit | warning / **critical** | 1h | Grafana (baseline via subquery or bot) |
+| Available discharge `avail_dis` (bms/2101) | BMS derate | `<70 kW` while `soc>30` (baseline 98) | warning | 15m | Grafana |
+| **Rest cell spread** (96 cells, `cells/1|33|65`) | imbalance at rest | `>50 mV` warn / `>100 mV` crit (baseline 20 mV); **state≠active** | warning / **critical** | 10m | **Bot** `ioniq-cell-health` → `derived/cell_spread_mv` |
+| **Module thermal spread** (12 sensors, bms/2101+2105) | hot module/coolant | `>8 °C` warn / `>15 °C` crit (baseline 2 °C) | warning / **critical** | 10m | **Bot** → `derived/module_temp_spread_c` |
+
+Notes: SoH baseline — simplest v1 is a static `<98%` step + `<85%` crit; a rolling baseline needs a bot or a CQ. `cell_v_dev` field is deadbanded to 0 — **do not** alert on it; compute spread from the arrays.
+
+### 4.2 Auxiliary 12 V / LDC
+
+| Signal | Condition | Threshold | Sev | for | Platform |
+|---|---|---|---|---|---|
+| `aux_12v`, `state='parked'` | dying 12 V at rest | `<12.2` warn / `<11.8` crit | warning / **critical** | 30s (sustained) | Grafana (state tag filter) |
+| `aux_12v` vs ignition/load | **LDC not charging** | `max(aux_12v) < 13.2 V` while `ignition=1` and a recent low-`hv_kw` sample, ≥60 s | warning | 60s | **Bot** `ioniq-12v-ldc` → `derived/ldc_ok` (0/1) |
+| `aux_12v` fast delta | sag / shorted cell | drop `≥0.8 V / 5 s`, or `≥0.3 V/min` while parked | warning | — | **Bot** → `derived/aux12v_drop` |
+
+Suppress "low voltage" firing while `hv_kw` is high — 12.9 V float under heavy traction is normal LDC load-priority, not a fault (the bot encodes this).
+
+### 4.3 Tires (TPMS)
+
+Cold-normalize each wheel to 15 °C before thresholding: `psi_cold = psi − 0.18·(temp − 15)`. TPMS only refreshes on wheel rotation, so evaluate on **fresh, `state=active` samples only** (dedupe parked duplicates).
+
+| Signal | Condition | Threshold | Sev | for | Platform |
+|---|---|---|---|---|---|
+| Per-wheel `psi_cold` | under-inflation | `<30` warn / `<26` crit (placard 36; no spare → stranding risk) | warning / **critical** | — | **Bot** `ioniq-tpms` → `derived/tire_<w>_psi_cold` (+ Grafana threshold) |
+| Inter-wheel `psi_cold` | developing imbalance/leak | max−min `>3 psi` (baseline 1.2) | warning | — | **Bot** → `derived/tire_spread_psi` |
+| Per-wheel temp | brake drag / bearing | wheel `> others_mean + 8 °C`, ≥2 samples, active | warning | — | **Bot** → `derived/tire_<w>_temp_excess` |
+| Over-inflation `psi_cold` | hard ride/over-pressure | `>42 psi` | info | — | **Bot**/Grafana |
+| TPMS freshness | dead sensor / gap | no changed TPMS value in `>72 h driving` | info | — | Grafana staleness |
+
+### 4.4 Faults (DTC)
+
+| Signal | Condition | Threshold | Sev | for | Platform |
+|---|---|---|---|---|---|
+| `dtc/stored.codes[]`, `dtc/pending.codes[]` | any DTC present | `codes.length > 0` (baseline empty) | **critical** | — | **Bot** `ioniq-dtc` → `derived/dtc_count`; Grafana `>0` |
+
+The bot includes the actual code list in the derived payload so the Telegram message can name the code(s).
+
+### 4.5 Connectivity / data liveness
+
+The box legitimately powers off ~60 s after the car locks, so naive LWT-offline alerts are noise. Two-layer approach:
+
+| Signal | Condition | Threshold | Sev | for | Platform |
+|---|---|---|---|---|---|
+| Fast-tier freshness `count(hv_v) FROM ioniq WHERE "group"='bms/2101'` | data gap **during a session** | count `<1` in 15 m window | warning | 15m | Grafana (count<1, long `for:`) |
+| Prolonged silence | logger offline beyond any plausible park | count `<1` in 30 m | warning | 30m | Grafana |
+| `ioniq/status` offline transitions | flapping BLE/OBD | `≥3` offline transitions / rolling 1 h | info | — | Grafana count on status, or **Bot** counter |
+
+Keying: use ingest `time` (Influx) / `_ts` (Mongo) for liveness — the LWT payload's own `ts` is stale (buffered). Consider gating the offline alert with a "car recently active" condition so it only fires when telemetry *should* be flowing.
+
+### 4.6 Usage / charging
+
+| Signal | Condition | Threshold | Sev | for | Platform |
+|---|---|---|---|---|---|
+| SoC at active→parked edge | low charge, get-home risk | `soc < 30%` at park | warning | — | **Bot** `ioniq-charge-guard` (state-edge) → `derived/soc_at_park` |
+| Charge relay on, low power | **charge stalled/interrupted** | `charging=1 & |hv_kw|<0.3 kW` for `>10 m` | warning | 10m | **Bot** (timeout-emit style) → `derived/charge_stalled` |
+| AC charge power | reduced-rate charge | `ac_port=1 & |hv_kw|<3 kW` sustained (this session was ~1 kW granny) | info | 10m | **Bot** → `derived/charge_reduced_rate` |
+| SoC slope while parked | parasitic drain | `> 2%/day` across parked spans | warning | — | **Bot**/Grafana `derivative` |
+
+Cross-reference: AC-side charge energy is available from the household **`charger` ORNO meter** (monitoring bus) — verify it's live (see Open Items) and, if so, use it for charge kWh/efficiency rather than decoding the OBC AC side.
+
+---
+
+## 5. Automations bots (new/reused)
+
+All bots follow the repo pattern (`module.exports = (name, config) => ({ persistedCache, start })`), receive parsed objects from `mqtt.subscribe`, publish objects via `mqtt.publish`, and write only to `ioniq/parsed/derived/*`. Add unit tests (Jest, mocked MQTT) per repo standard.
+
+| Bot | Type | Subscribes | Emits (`ioniq/parsed/derived/…`) | Core logic |
+|---|---|---|---|---|
+| `ioniq-cell-health` | new | `ioniq/parsed/cells/1\|33\|65`, `…/bms/2101`, `…/bms/2105` | `cell_spread_mv`, `module_temp_spread_c` | Reassemble 96-cell array (3 topics) → max−min (skip when `state='active'`); merge 12 module temps across two frames → max−min. |
+| `ioniq-12v-ldc` | new | `…/bms/2101` | `ldc_ok` (0/1), `aux12v_drop` | Rolling window of `aux_12v`,`ignition`,`hv_kw`; flag LDC-not-charging under the low-load rule; compute drop rate. |
+| `ioniq-charge-guard` | new | `…/bms/2101`, `…/bcm` (charge_connector), `…/obc` | `soc_at_park`, `charge_stalled`, `charge_reduced_rate` | State-edge SoC capture; stalled = relay on + low power (reuse `timeout-emit` semantics); reduced-rate classifier. |
+| `ioniq-dtc` | new (thin) | `ioniq/parsed/dtc/#` | `dtc_count` (+ `codes`) | `codes.length`; pass code list through for the message. Could be a `mqtt-transform` config rather than bespoke code. |
+| `ioniq-tpms` | new | `ioniq/parsed/tpms`, `…/ambient` | `tire_<w>_psi_cold`, `tire_spread_psi`, `tire_<w>_temp_excess` | Cold-normalize; dedupe non-active/frozen; cross-wheel outliers. |
+
+Wire them in `config/automations/config.js` alongside existing bots. Where a generic bot fits (`timeout-emit` for charge-stalled, `stateful-counter`/`mqtt-transform` for DTC), prefer configuration over new code.
+
+---
+
+## 6. Grafana implementation
+
+- **Folder:** new `Ioniq EV` folder for all rules (drives `group_by: grafana_folder`).
+- **Datasource UID:** `P3C6603E967DC8568` (InfluxDB v1, db `homy`).
+- **Contact point:** `telegram-webhook` (existing) — no change needed for v1.
+- **Rule files:** one YAML per domain under `config/grafana/provisioning/alerting/`, mirroring existing naming:
+  - `ioniq-battery-alerts.yaml`, `ioniq-12v-alerts.yaml`, `ioniq-tpms-alerts.yaml`, `ioniq-dtc-alerts.yaml`, `ioniq-connectivity-alerts.yaml`, `ioniq-usage-alerts.yaml`.
+- **Rule template** (clone of `sunseeker-connectivity-alerts.yaml`; the canonical working shape in this repo):
+
+```yaml
+- uid: ioniq-isolation-low
+  title: "🚗 Ioniq HV Isolation Low"
+  condition: A
+  data:
+    - refId: iso
+      relativeTimeRange: { from: 600, to: 0 }
+      datasourceUid: P3C6603E967DC8568
+      model:
+        query: |
+          SELECT last("isolation_kohm") FROM "ioniq"
+          WHERE "group"='bms/2101' AND time >= now() - 10m
+        rawQuery: true
+        resultFormat: time_series
+    - refId: A
+      datasourceUid: __expr__
+      model:
+        type: classic_conditions
+        conditions:
+          - evaluator: { type: lt, params: [500] }
+            operator: { type: and }
+            query: { params: [iso] }
+            reducer: { type: last }
+            type: query
+        expression: iso
+  noDataState: NoData
+  execErrState: Alerting
+  for: 10m
+  labels: { severity: warning, device: ioniq, subsystem: battery }
+  annotations:
+    summary: "🚗 HV isolation resistance dropped below 500 kΩ"
+    description: "Possible HV leak to chassis. Investigate before driving if it keeps falling."
+```
+
+**Repo-specific gotchas (baked in):**
+- Use `classic_conditions`, never `threshold`; always explicit `WHERE time >= now() - <window>`; never `$timeFilter` (Grafana 9.5+ provisioned-alert bug).
+- `classic_conditions` **drops `GROUP BY` tag labels** — if a rule ever groups by a tag and needs `{{ $labels.x }}`, use a `reduce`→`threshold` expression pair instead (see repo memory). For Ioniq most rules are single-series (one car), so this mainly matters if per-wheel/per-cell rules are ever expressed with `GROUP BY`.
+- Deleting a provisioned rule requires a `delete-*.yaml` `deleteRules:` file (can't delete via UI).
+
+---
+
+## 7. Dashboards
+
+New `Ioniq EV` dashboard family (JSON under `config/grafana/dashboards/`, provider already configured). Follow repo dashboard standards (stat/timeseries/gauge, 24 h overview / 6 h detail defaults).
+
+| Dashboard | Panels |
+|---|---|
+| **Overview** | SoC + SoC_display gauge; pack V/A/kW; 12 V (color-banded); current DTC status; connectivity/last-seen stat; odometer; current tire pressures (4 stats); active alert list. |
+| **Battery health** | SoC & SoH trend; cell max/min/spread (derived) timeseries; 12-module temp heatmap + spread; isolation; available charge/discharge envelope; cumulative Ah/kWh + derived usable-Ah and round-trip efficiency. |
+| **12 V / LDC** | `aux_12v` timeseries banded by state; per-drive LDC on-voltage ceiling; parked resting-voltage trend (daily min/median); derived `ldc_ok`. |
+| **Tires** | Per-wheel `psi_cold` trend; inter-wheel spread; per-wheel temp vs ambient; over/under-inflation bands. |
+| **Trips & charging** | State timeline (active/charging/parked); per-trip distance/energy/efficiency (kWh/100 km); regen recovery %; charge sessions (AC/DC, kWh, avg power); SoC-at-park distribution; charger-meter AC power overlay (if live). |
+| **Pipeline health** | Samples/min per group; per-group last-seen; connectivity transitions; Influx/Mongo growth; DTC history. |
+
+Link the family with a dashboard-links row (overview ↔ detail), per repo navigation standard.
+
+---
+
+## 8. Runbook (per-alert response)
+
+Each rule's `annotations.description` should carry the first action. Summary table:
+
+| Alert | First response |
+|---|---|
+| HV isolation low | Don't fast-charge; if trending down, book HV inspection (coolant/harness). |
+| Cell over/under-V, pack over-temp | Stop charging/driving; read full DTC + cell dump; service. |
+| Rising cell spread | Note outlier cell index; monitor; balance/service if >100 mV persists. |
+| SoH step / low | Log; compare to warranty threshold (Ioniq ~ replaceable <65–70%). |
+| 12 V low at rest | Charge/replace 12 V before next lock cycle; it strands the car. |
+| LDC not charging | DC-DC converter suspect; verify with a drive; service if repeats. |
+| Tire low / outlier | Top up (FR first per baseline); if it recurs, inspect for leak/nail. |
+| Tire temp outlier | Check for dragging brake / seizing bearing on that corner. |
+| **DTC present** | Read code(s) from the message; decode; act by code. |
+| Logger offline (unexpected) | Check box power/BLE; distinguish from normal post-lock power-off. |
+| Charge stalled / reduced-rate | Check cable/EVSE; confirm target SoC reached. |
+| Low SoC at park | Plug in; charge for next trip. |
+
+---
+
+## 9. Rollout phases
+
+1. **P0 prerequisites** (§2): promote raw→parsed (#7/#5), fix retention (P0-2/3), establish `derived/*` convention.
+2. **Grafana-native alerts** (§4.1 non-derived, §4.2 parked-12 V, §4.5 connectivity, §4.4 DTC via a thin bot): highest value, lowest effort. Ship the `Ioniq EV` folder + notification routing (§3).
+3. **Computation bots** (§5) + their derived-signal Grafana rules: cell spread, thermal spread, LDC, tires, charge-guard.
+4. **Dashboards** (§7).
+5. **Tune** thresholds against 2–4 weeks of real history; convert static SoH/parked-drain baselines to rolling ones.
+
+> **Implementation status (2026-07-14):** Phase 2 is implemented on branch
+> `feat/ioniq-monitoring-phase2` — Grafana battery (§4.1 non-derived), parked-12 V (§4.2), and
+> DTC (§4.4) alert rules; the `ioniq-dtc` bot (derived `dtc_count` + direct-flag); the `Ioniq EV`
+> folder; and Ioniq-scoped notification routing (§3, scoped to `device = ioniq` rather than the
+> house-wide reroute). Connectivity/liveness (§4.5) is deferred to phase 3: a `count()`-based
+> Grafana rule cannot express it (empty window returns no row, not 0) and NoData would fire on
+> every normal park, so it needs a session-aware bot. See
+> `docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase2-design.md`.
+
+---
+
+## 10. Open items / dependencies
+
+- **Verify the `charger` ORNO meter is live.** It's configured (monitoring bus, `or-we-526`) but no current readings were found under the expected Influx tags; needed for AC-side charge energy/efficiency. (OVMS, which previously covered this, is dead as of ~2025-09-24.)
+- **`brakes_on` is unreliable** (logger #9) — don't build braking alerts on it; use `brake_lamp`.
+- **New signals unlock new alerts** once logger tickets land: motor/inverter over-temp (#5), cabin over-temp / preconditioning verify (#6), direct LDC current/temp (#8), body/security (door-left-unlocked, window-open) (#13).
+- **Decide** dedicated vs shared Telegram channel (§3) before wide rollout.
+- **Retention/downsampling numbers** (P0-3) to be chosen with the team (measurement growth rate × desired horizon).
+```

--- a/docs/superpowers/plans/2026-07-14-ioniq-monitoring-phase2.md
+++ b/docs/superpowers/plans/2026-07-14-ioniq-monitoring-phase2.md
@@ -13,6 +13,7 @@
 ## Global Constraints
 
 - **Grafana alert rules:** `classic_conditions` only (never `threshold`); explicit `WHERE … AND time >= now() - <window>` in every InfluxQL query (never `$timeFilter`); datasource UID `P3C6603E967DC8568`; queries written as YAML block scalars (`query: |`) so inner `"…"`/`'…'` are literal; `noDataState: OK` on every rule; `execErrState: Alerting`; group `interval: 1m`; group header `folder: Ioniq EV`; `🚗` prefix in every `title` and `summary`; labels `severity` + `device: ioniq` + `subsystem`; no annotation may reference `{{ $labels.* }}` (classic_conditions drops GROUP BY labels — all rules here are single-series so use static text or `{{ $values.<refId>.Value }}`).
+- **Expression-node shape (proven repo shape — every working rule includes these):** each `__expr__` `refId: A` node's `model` MUST include `datasource: { type: __expr__, uid: __expr__ }`, `intervalMs: 1000`, `maxDataPoints: 43200`, `refId: A`, `hide: false`, alongside `type: classic_conditions`, `conditions`, and `expression`. Omitting them parses fine but can fail at provisioning (the YAML validators won't catch it) — copy the block verbatim from the rules below.
 - **Verified prod facts (2026-07-14):** InfluxDB measurement `ioniq`, tags `group` + `state` (values `active`/`charging`/`parked`). Fields (bms/2101): `isolation_kohm`, `cell_min_v`, `cell_max_v`, `temp_max`, `avail_dis`, `soc`, `aux_12v`. Field (bms/2105): `soh`. DTC topics: `ioniq/parsed/dtc/stored`, `ioniq/parsed/dtc/pending`, each payload `{_type:'ioniq', group, state, ts, codes:[]}`.
 - **Bot pattern:** `module.exports = (name, config) => ({ persistedCache?, start })`; `start: async ({ mqtt, persistedCache })`; `mqtt.subscribe(topic, cb)` delivers already-parsed objects; `mqtt.publish(topic, obj)` takes an object (framework adds `_bot`/`_tz` and serializes). Bot subscriptions are **exact-match** (no wildcards). Derived publishes MUST include `_type:'ioniq'` so the `mqtt-influx-ioniq` bridge accepts them.
 - **Tests:** Jest via `cd docker/automations && npm test`; import globals from `@jest/globals`; mock MQTT with the `_triggerMessage`/`_callbacks` harness (see `bots/stateful-counter.test.js`); no real credentials/URLs beyond the internal service name.
@@ -476,6 +477,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [500] }
                   operator: { type: and }
@@ -508,6 +514,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [100] }
                   operator: { type: and }
@@ -540,6 +551,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [3.0] }
                   operator: { type: and }
@@ -572,6 +588,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [2.5] }
                   operator: { type: and }
@@ -604,6 +625,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: gt, params: [4.15] }
                   operator: { type: and }
@@ -636,6 +662,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: gt, params: [45] }
                   operator: { type: and }
@@ -668,6 +699,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: gt, params: [55] }
                   operator: { type: and }
@@ -700,6 +736,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [98] }
                   operator: { type: and }
@@ -732,6 +773,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [85] }
                   operator: { type: and }
@@ -773,6 +819,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [70] }
                   operator: { type: and }
@@ -812,6 +863,9 @@ for r in rules:
     assert r['labels']['device']=='ioniq', r['uid']
     assert r['condition']=='A', r['uid']
     assert r['title'].startswith('🚗'), r['uid']
+    amodel=[d for d in r['data'] if d['refId']=='A'][0]['model']
+    assert amodel['datasource']=={'type':'__expr__','uid':'__expr__'}, r['uid']
+    assert amodel['intervalMs']==1000 and amodel['maxDataPoints']==43200, r['uid']
 uids={r['uid'] for r in rules}
 assert 'ioniq-avail-dis-derate' in uids
 # multi-condition rule has two conditions
@@ -881,6 +935,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [12.2] }
                   operator: { type: and }
@@ -913,6 +972,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: lt, params: [11.8] }
                   operator: { type: and }
@@ -1007,6 +1071,11 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
               conditions:
                 - evaluator: { type: gt, params: [0] }
                   operator: { type: and }
@@ -1219,7 +1288,7 @@ MSG
 - [ ] Run the full automations test suite: `cd docker/automations && npm test` — all pass.
 - [ ] Confirm all 4 new/modified Grafana YAML files parse (Tasks 4–7 validation steps).
 - [ ] `git log --oneline` shows one commit per task, all on `feat/ioniq-monitoring-phase2`.
-- [ ] Optional live smoke test (needs a running Grafana): provision the folder and confirm the multi-condition `ioniq-avail-dis-derate` rule loads without a "condition must not be empty" error, since multi-condition `classic_conditions` is new to this repo.
+- [ ] **Strongly recommended before deploy** — live Grafana smoke test: provision the `Ioniq EV` folder and confirm **all** rule files load without a "condition must not be empty" / datasource error. Pay special attention to the multi-condition `ioniq-avail-dis-derate` rule (multi-condition `classic_conditions` is new to this repo) and confirm the expression-node `datasource`/`intervalMs`/`maxDataPoints` fields provision cleanly. This is the one risk the offline YAML validators cannot catch.
 
 ## Notes for the executor
 

--- a/docs/superpowers/plans/2026-07-14-ioniq-monitoring-phase2.md
+++ b/docs/superpowers/plans/2026-07-14-ioniq-monitoring-phase2.md
@@ -1,0 +1,1229 @@
+# Ioniq EV Monitoring — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship phase-2 Ioniq EV monitoring — Grafana alert rules (battery, parked 12 V, DTC), the thin `ioniq-dtc` automations bot, an `Ioniq EV` Grafana folder, and Ioniq-scoped notification routing.
+
+**Architecture:** Grafana owns threshold queries + notification delivery over the InfluxDB `ioniq` measurement. The `ioniq-dtc` bot handles the one array-logic condition (DTC `codes[]`): it publishes a clean numeric `derived/dtc_count` for Grafana to threshold, and additionally direct-flags a Telegram message (naming the codes) to `telegram-bridge` on a DTC edge. Connectivity/liveness is deferred to phase 3 (needs stateful session logic).
+
+**Tech Stack:** Node.js 18 (automations bot, Jest tests, injected `fetch` for HTTP), Grafana provisioned alerting YAML (InfluxDB v1 / InfluxQL, `classic_conditions`), Alertmanager notification-policy YAML.
+
+**Design doc:** `docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase2-design.md`
+
+## Global Constraints
+
+- **Grafana alert rules:** `classic_conditions` only (never `threshold`); explicit `WHERE … AND time >= now() - <window>` in every InfluxQL query (never `$timeFilter`); datasource UID `P3C6603E967DC8568`; queries written as YAML block scalars (`query: |`) so inner `"…"`/`'…'` are literal; `noDataState: OK` on every rule; `execErrState: Alerting`; group `interval: 1m`; group header `folder: Ioniq EV`; `🚗` prefix in every `title` and `summary`; labels `severity` + `device: ioniq` + `subsystem`; no annotation may reference `{{ $labels.* }}` (classic_conditions drops GROUP BY labels — all rules here are single-series so use static text or `{{ $values.<refId>.Value }}`).
+- **Verified prod facts (2026-07-14):** InfluxDB measurement `ioniq`, tags `group` + `state` (values `active`/`charging`/`parked`). Fields (bms/2101): `isolation_kohm`, `cell_min_v`, `cell_max_v`, `temp_max`, `avail_dis`, `soc`, `aux_12v`. Field (bms/2105): `soh`. DTC topics: `ioniq/parsed/dtc/stored`, `ioniq/parsed/dtc/pending`, each payload `{_type:'ioniq', group, state, ts, codes:[]}`.
+- **Bot pattern:** `module.exports = (name, config) => ({ persistedCache?, start })`; `start: async ({ mqtt, persistedCache })`; `mqtt.subscribe(topic, cb)` delivers already-parsed objects; `mqtt.publish(topic, obj)` takes an object (framework adds `_bot`/`_tz` and serializes). Bot subscriptions are **exact-match** (no wildcards). Derived publishes MUST include `_type:'ioniq'` so the `mqtt-influx-ioniq` bridge accepts them.
+- **Tests:** Jest via `cd docker/automations && npm test`; import globals from `@jest/globals`; mock MQTT with the `_triggerMessage`/`_callbacks` harness (see `bots/stateful-counter.test.js`); no real credentials/URLs beyond the internal service name.
+- **Commits:** selective staging only (never `git add .` / `git add -A`). End each commit message body with `Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN`.
+
+---
+
+## File Structure
+
+- `docker/automations/bots/ioniq-dtc.js` — the DTC bot (create).
+- `docker/automations/bots/ioniq-dtc.test.js` — its Jest tests (create).
+- `config/automations/config.js` — register the `ioniqDtc` bot instance (modify).
+- `config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml` — §4.1 non-derived battery rules (create).
+- `config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml` — §4.2 parked-12 V rules (create).
+- `config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml` — §4.4 DTC rule (create).
+- `config/grafana/provisioning/alerting/notification-policies.yaml` — add Ioniq-scoped routes (modify).
+- `docs/influxdb-schema.md` — document the `derived/dtc_count` group (modify).
+- `docs/ioniq-monitoring-alerting-spec.md` — mark phase-2 implementation status (modify).
+
+---
+
+## Task 1: `ioniq-dtc` bot — derived `dtc_count` signal
+
+Compute the DTC count (union of stored+pending codes) and publish it as a clean numeric derived signal. No Telegram yet (Task 2).
+
+**Files:**
+- Create: `docker/automations/bots/ioniq-dtc.js`
+- Test: `docker/automations/bots/ioniq-dtc.test.js`
+
+**Interfaces:**
+- Consumes: MQTT messages on `config.storedTopic` / `config.pendingTopic`, each an object `{ group, state, ts, codes: string[] }`.
+- Produces: factory `createIoniqDtc(name, config) => ({ persistedCache, start })`. Publishes to `config.outputTopic` the object `{ _type:'ioniq', group:'derived/dtc_count', state, ts, value:<number>, codes:<string[]> }`. `persistedCache` shape `{ version:1, default:{ stored:[], pending:[], flaggedKey:'' } }`. Config keys: `storedTopic`, `pendingTopic`, `outputTopic` (all with the defaults shown in Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `docker/automations/bots/ioniq-dtc.test.js`:
+
+```javascript
+const { afterEach, beforeEach, describe, expect, it, jest } = require('@jest/globals')
+const createIoniqDtc = require('./ioniq-dtc')
+
+const STORED = 'ioniq/parsed/dtc/stored'
+const PENDING = 'ioniq/parsed/dtc/pending'
+const OUTPUT = 'ioniq/parsed/derived/dtc_count'
+
+function makeMqtt () {
+  const mqtt = {
+    _callbacks: {},
+    subscribe: jest.fn().mockImplementation((topic, cb) => {
+      mqtt._callbacks[topic] = cb
+      return Promise.resolve()
+    }),
+    publish: jest.fn().mockResolvedValue(),
+    _trigger: (topic, message) =>
+      mqtt._callbacks[topic] ? mqtt._callbacks[topic](message) : undefined
+  }
+  return mqtt
+}
+
+function makeCache () {
+  return { stored: [], pending: [], flaggedKey: '' }
+}
+
+const config = {
+  storedTopic: STORED,
+  pendingTopic: PENDING,
+  outputTopic: OUTPUT,
+  httpPost: jest.fn().mockResolvedValue({ ok: true })
+}
+
+describe('ioniq-dtc bot — derived signal', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(() => {
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    config.httpPost = jest.fn().mockResolvedValue({ ok: true })
+    bot = createIoniqDtc('ioniq-dtc', config)
+  })
+
+  it('subscribes to both dtc topics', async () => {
+    await bot.start({ mqtt, persistedCache })
+    expect(mqtt.subscribe).toHaveBeenCalledWith(STORED, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(PENDING, expect.any(Function))
+  })
+
+  it('publishes value 0 with empty codes and no flag', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'parked', ts: 100, codes: [] })
+    expect(mqtt.publish).toHaveBeenCalledWith(OUTPUT, {
+      _type: 'ioniq', group: 'derived/dtc_count', state: 'parked', ts: 100, value: 0, codes: []
+    })
+    expect(config.httpPost).not.toHaveBeenCalled()
+  })
+
+  it('publishes the count and union of codes when a DTC appears', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 200, codes: ['P0AA6'] })
+    expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, {
+      _type: 'ioniq', group: 'derived/dtc_count', state: 'active', ts: 200, value: 1, codes: ['P0AA6']
+    })
+  })
+
+  it('unions stored and pending, de-duplicating shared codes', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 300, codes: ['P0AA6', 'P1B76'] })
+    await mqtt._trigger(PENDING, { group: 'dtc/pending', state: 'active', ts: 301, codes: ['P1B76', 'C1611'] })
+    expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, {
+      _type: 'ioniq', group: 'derived/dtc_count', state: 'active', ts: 301, value: 3,
+      codes: ['P0AA6', 'P1B76', 'C1611']
+    })
+  })
+
+  it('treats a missing codes field as empty', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'parked', ts: 400 })
+    expect(mqtt.publish).toHaveBeenLastCalledWith(OUTPUT, expect.objectContaining({ value: 0, codes: [] }))
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd docker/automations && npx jest bots/ioniq-dtc.test.js`
+Expected: FAIL — `Cannot find module './ioniq-dtc'`.
+
+- [ ] **Step 3: Write the minimal bot implementation**
+
+Create `docker/automations/bots/ioniq-dtc.js`:
+
+```javascript
+// ioniq-dtc: reduces the Ioniq DTC arrays (stored + pending) to a numeric
+// derived/dtc_count signal for Grafana, and (Task 2) direct-flags new codes to Telegram.
+async function defaultHttpPost (url, body) {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+}
+
+module.exports = function createIoniqDtc (name, config) {
+  const storedTopic = config.storedTopic || 'ioniq/parsed/dtc/stored'
+  const pendingTopic = config.pendingTopic || 'ioniq/parsed/dtc/pending'
+  const outputTopic = config.outputTopic || 'ioniq/parsed/derived/dtc_count'
+
+  return {
+    persistedCache: {
+      version: 1,
+      default: { stored: [], pending: [], flaggedKey: '' }
+    },
+
+    start: async ({ mqtt, persistedCache }) => {
+      const handle = (which) => (payload) => {
+        const codes = Array.isArray(payload && payload.codes) ? payload.codes : []
+        persistedCache[which] = codes
+
+        const union = [...new Set([...persistedCache.stored, ...persistedCache.pending])]
+        mqtt.publish(outputTopic, {
+          _type: 'ioniq',
+          group: 'derived/dtc_count',
+          state: payload && payload.state,
+          ts: payload && payload.ts,
+          value: union.length,
+          codes: union
+        })
+      }
+
+      await mqtt.subscribe(storedTopic, handle('stored'))
+      await mqtt.subscribe(pendingTopic, handle('pending'))
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd docker/automations && npx jest bots/ioniq-dtc.test.js`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/automations/bots/ioniq-dtc.js docker/automations/bots/ioniq-dtc.test.js
+git commit -m "$(cat <<'MSG'
+feat(automations): add ioniq-dtc bot deriving dtc_count signal
+
+Subscribes to ioniq/parsed/dtc/{stored,pending}, unions the code
+arrays, and publishes a numeric ioniq/parsed/derived/dtc_count for
+Grafana to threshold.
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Task 2: `ioniq-dtc` bot — direct-flag new DTCs to Telegram
+
+Add the "both notify" direct-flag: on a DTC edge (a new non-empty code set), POST a code-naming message to `telegram-bridge`, deduped across restarts via `persistedCache.flaggedKey`.
+
+**Files:**
+- Modify: `docker/automations/bots/ioniq-dtc.js`
+- Test: `docker/automations/bots/ioniq-dtc.test.js`
+
+**Interfaces:**
+- Consumes: same MQTT messages as Task 1, plus config `telegramWebhookUrl` (default `http://telegram-bridge:3000/webhook`), `flagOnEdge` (default `true`), and injectable `httpPost(url, body)` (default `defaultHttpPost`, used in prod; tests pass a mock).
+- Produces: on a 0→N or N→different-set transition, one `httpPost(telegramWebhookUrl, { message })` where `message` is `🚗 <b>DTC present</b>: <code> (stored|pending), …`. Resets the dedupe key when the set returns to empty. HTTP failures are caught and never crash the bot.
+
+- [ ] **Step 1: Add the failing direct-flag tests**
+
+Append to `docker/automations/bots/ioniq-dtc.test.js` (new `describe` block):
+
+```javascript
+describe('ioniq-dtc bot — direct flag', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(() => {
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    config.httpPost = jest.fn().mockResolvedValue({ ok: true })
+    config.telegramWebhookUrl = 'http://telegram-bridge:3000/webhook'
+    bot = createIoniqDtc('ioniq-dtc', config)
+  })
+
+  it('flags once when a DTC appears, naming the code and source', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    expect(config.httpPost).toHaveBeenCalledTimes(1)
+    expect(config.httpPost).toHaveBeenCalledWith(
+      'http://telegram-bridge:3000/webhook',
+      { message: '🚗 <b>DTC present</b>: P0AA6 (stored)' }
+    )
+  })
+
+  it('does not re-flag the same code set on repeated samples', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 2, codes: ['P0AA6'] })
+    expect(config.httpPost).toHaveBeenCalledTimes(1)
+  })
+
+  it('flags again after the codes clear and a new DTC appears', async () => {
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 2, codes: [] })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 3, codes: ['P0AA6'] })
+    expect(config.httpPost).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not re-flag a code set already flagged before restart', async () => {
+    persistedCache.stored = ['P0AA6']
+    persistedCache.flaggedKey = 'P0AA6'
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 5, codes: ['P0AA6'] })
+    expect(config.httpPost).not.toHaveBeenCalled()
+  })
+
+  it('still publishes the derived signal when the HTTP flag fails', async () => {
+    config.httpPost = jest.fn().mockRejectedValue(new Error('bridge down'))
+    bot = createIoniqDtc('ioniq-dtc', config)
+    await bot.start({ mqtt, persistedCache })
+    await expect(
+      mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    ).resolves.not.toThrow()
+    expect(mqtt.publish).toHaveBeenCalledWith(OUTPUT, expect.objectContaining({ value: 1 }))
+  })
+
+  it('never flags when flagOnEdge is false', async () => {
+    config.flagOnEdge = false
+    bot = createIoniqDtc('ioniq-dtc', config)
+    await bot.start({ mqtt, persistedCache })
+    await mqtt._trigger(STORED, { group: 'dtc/stored', state: 'active', ts: 1, codes: ['P0AA6'] })
+    expect(config.httpPost).not.toHaveBeenCalled()
+    delete config.flagOnEdge
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify the new ones fail**
+
+Run: `cd docker/automations && npx jest bots/ioniq-dtc.test.js`
+Expected: the Task-1 tests still PASS; the six new direct-flag tests FAIL (`httpPost` never called / no dedupe).
+
+- [ ] **Step 3: Implement the direct-flag logic**
+
+Replace the body of `module.exports` in `docker/automations/bots/ioniq-dtc.js` with:
+
+```javascript
+module.exports = function createIoniqDtc (name, config) {
+  const storedTopic = config.storedTopic || 'ioniq/parsed/dtc/stored'
+  const pendingTopic = config.pendingTopic || 'ioniq/parsed/dtc/pending'
+  const outputTopic = config.outputTopic || 'ioniq/parsed/derived/dtc_count'
+  const telegramWebhookUrl = config.telegramWebhookUrl || 'http://telegram-bridge:3000/webhook'
+  const flagOnEdge = config.flagOnEdge !== false
+  const httpPost = config.httpPost || defaultHttpPost
+  const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
+
+  const keyOf = (codes) => codes.slice().sort().join(',')
+
+  return {
+    persistedCache: {
+      version: 1,
+      default: { stored: [], pending: [], flaggedKey: '' }
+    },
+
+    start: async ({ mqtt, persistedCache }) => {
+      const handle = (which) => async (payload) => {
+        const codes = Array.isArray(payload && payload.codes) ? payload.codes : []
+        persistedCache[which] = codes
+
+        const union = [...new Set([...persistedCache.stored, ...persistedCache.pending])]
+        mqtt.publish(outputTopic, {
+          _type: 'ioniq',
+          group: 'derived/dtc_count',
+          state: payload && payload.state,
+          ts: payload && payload.ts,
+          value: union.length,
+          codes: union
+        })
+
+        if (union.length === 0) {
+          persistedCache.flaggedKey = ''
+          return
+        }
+
+        const key = keyOf(union)
+        if (flagOnEdge && key !== persistedCache.flaggedKey) {
+          persistedCache.flaggedKey = key
+          const parts = union.map((code) =>
+            `${code} (${persistedCache.stored.includes(code) ? 'stored' : 'pending'})`)
+          const message = `🚗 <b>DTC present</b>: ${parts.join(', ')}`
+          try {
+            await httpPost(telegramWebhookUrl, { message })
+          } catch (err) {
+            log('direct-flag POST failed:', err && err.message)
+          }
+        }
+      }
+
+      await mqtt.subscribe(storedTopic, handle('stored'))
+      await mqtt.subscribe(pendingTopic, handle('pending'))
+    }
+  }
+}
+```
+
+(Keep the `defaultHttpPost` helper at the top of the file from Task 1.)
+
+- [ ] **Step 4: Run the full bot test file to verify all pass**
+
+Run: `cd docker/automations && npx jest bots/ioniq-dtc.test.js`
+Expected: PASS (all 10 tests).
+
+- [ ] **Step 5: Run the whole automations suite to check for regressions**
+
+Run: `cd docker/automations && npm test`
+Expected: PASS (existing suite unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker/automations/bots/ioniq-dtc.js docker/automations/bots/ioniq-dtc.test.js
+git commit -m "$(cat <<'MSG'
+feat(automations): ioniq-dtc direct-flags new DTCs to telegram-bridge
+
+On a DTC edge (new non-empty code set) POST a code-naming message to
+telegram-bridge, deduped across restarts via persistedCache.flaggedKey.
+HTTP uses an injectable poster (default fetch); failures are caught so
+the derived publish always happens.
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Task 3: Register the `ioniq-dtc` bot in config
+
+Wire the bot instance so it runs in production.
+
+**Files:**
+- Modify: `config/automations/config.js`
+
+**Interfaces:**
+- Consumes: the `createIoniqDtc` factory (resolved by `index.js` from `type: 'ioniq-dtc'`).
+- Produces: a running `ioniqDtc` bot instance with the verified topics.
+
+- [ ] **Step 1: Add the bot registration**
+
+In `config/automations/config.js`, add this entry inside the `bots: { … }` object (place it alongside the other bot instances, before the object's closing brace):
+
+```javascript
+    ioniqDtc: {
+      type: 'ioniq-dtc',
+      storedTopic: 'ioniq/parsed/dtc/stored',
+      pendingTopic: 'ioniq/parsed/dtc/pending',
+      outputTopic: 'ioniq/parsed/derived/dtc_count',
+      telegramWebhookUrl: 'http://telegram-bridge:3000/webhook',
+    },
+```
+
+- [ ] **Step 2: Verify the config file still parses**
+
+Run: `cd docker/automations && node -e "const c = require('../../config/automations/config.js'); if (!c.bots.ioniqDtc) throw new Error('ioniqDtc missing'); if (c.bots.ioniqDtc.type !== 'ioniq-dtc') throw new Error('wrong type'); console.log('config OK: ioniqDtc registered')"`
+Expected: prints `config OK: ioniqDtc registered` and exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/automations/config.js
+git commit -m "$(cat <<'MSG'
+feat(automations): register ioniq-dtc bot instance
+
+Wire ioniqDtc with the prod-verified dtc topics and the telegram-bridge
+webhook URL.
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Task 4: Grafana battery alert rules (§4.1 non-derived)
+
+**Files:**
+- Create: `config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml`
+
+**Interfaces:**
+- Consumes: InfluxDB `ioniq` measurement fields `isolation_kohm`, `cell_min_v`, `cell_max_v`, `temp_max` (group `bms/2101`), `soh` (group `bms/2105`), and the two-query pair `avail_dis`+`soc` (group `bms/2101`).
+- Produces: 10 alert rules in folder `Ioniq EV`, group `Ioniq Battery Alerts`.
+
+- [ ] **Step 1: Write the rule file**
+
+Create `config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml`:
+
+```yaml
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq Battery Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-isolation-low
+        title: "🚗 Ioniq HV Isolation Low"
+        condition: A
+        data:
+          - refId: iso
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("isolation_kohm") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [500] }
+                  operator: { type: and }
+                  query: { params: [iso] }
+                  reducer: { type: last }
+                  type: query
+              expression: iso
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 HV isolation resistance below 500 kΩ"
+          description: "Possible HV leak to chassis. Investigate before driving if it keeps falling."
+
+      - uid: ioniq-isolation-critical
+        title: "🚗 Ioniq HV Isolation Critical"
+        condition: A
+        data:
+          - refId: iso
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("isolation_kohm") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [100] }
+                  operator: { type: and }
+                  query: { params: [iso] }
+                  reducer: { type: last }
+                  type: query
+              expression: iso
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 HV isolation resistance below 100 kΩ"
+          description: "HV isolation at/under the rated minimum. Do not fast-charge; book HV inspection."
+
+      - uid: ioniq-cell-min-low
+        title: "🚗 Ioniq Min Cell Voltage Low"
+        condition: A
+        data:
+          - refId: cmin
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("cell_min_v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 5m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [3.0] }
+                  operator: { type: and }
+                  query: { params: [cmin] }
+                  reducer: { type: last }
+                  type: query
+              expression: cmin
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Minimum cell voltage below 3.0 V"
+          description: "A cell is running low. Monitor; read a full cell dump if it persists."
+
+      - uid: ioniq-cell-min-critical
+        title: "🚗 Ioniq Min Cell Voltage Critical"
+        condition: A
+        data:
+          - refId: cmin
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("cell_min_v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 5m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [2.5] }
+                  operator: { type: and }
+                  query: { params: [cmin] }
+                  reducer: { type: last }
+                  type: query
+              expression: cmin
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Minimum cell voltage below 2.5 V"
+          description: "Cell under-voltage. Stop charging/driving; read DTC + cell dump; service."
+
+      - uid: ioniq-cell-max-critical
+        title: "🚗 Ioniq Max Cell Voltage Critical"
+        condition: A
+        data:
+          - refId: cmax
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("cell_max_v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 5m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: gt, params: [4.15] }
+                  operator: { type: and }
+                  query: { params: [cmax] }
+                  reducer: { type: last }
+                  type: query
+              expression: cmax
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Maximum cell voltage above 4.15 V"
+          description: "Cell over-voltage. Stop charging; read DTC + cell dump; service."
+
+      - uid: ioniq-pack-temp-high
+        title: "🚗 Ioniq Pack Temperature High"
+        condition: A
+        data:
+          - refId: tmax
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("temp_max") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: gt, params: [45] }
+                  operator: { type: and }
+                  query: { params: [tmax] }
+                  reducer: { type: last }
+                  type: query
+              expression: tmax
+        noDataState: OK
+        execErrState: Alerting
+        for: 5m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Pack temperature above 45 °C"
+          description: "Battery running hot. Avoid fast-charging until it cools."
+
+      - uid: ioniq-pack-temp-critical
+        title: "🚗 Ioniq Pack Temperature Critical"
+        condition: A
+        data:
+          - refId: tmax
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("temp_max") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: gt, params: [55] }
+                  operator: { type: and }
+                  query: { params: [tmax] }
+                  reducer: { type: last }
+                  type: query
+              expression: tmax
+        noDataState: OK
+        execErrState: Alerting
+        for: 5m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Pack temperature above 55 °C"
+          description: "Pack over-temp. Stop charging/driving; investigate cooling."
+
+      - uid: ioniq-soh-step
+        title: "🚗 Ioniq State of Health Reduced"
+        condition: A
+        data:
+          - refId: soh
+            relativeTimeRange: { from: 86400, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("soh") FROM "ioniq"
+                WHERE "group"='bms/2105' AND time >= now() - 24h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [98] }
+                  operator: { type: and }
+                  query: { params: [soh] }
+                  reducer: { type: last }
+                  type: query
+              expression: soh
+        noDataState: OK
+        execErrState: Alerting
+        for: 1h
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Battery SoH dropped below 98%"
+          description: "Capacity fade step. Log and compare against warranty threshold over time."
+
+      - uid: ioniq-soh-critical
+        title: "🚗 Ioniq State of Health Critical"
+        condition: A
+        data:
+          - refId: soh
+            relativeTimeRange: { from: 86400, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("soh") FROM "ioniq"
+                WHERE "group"='bms/2105' AND time >= now() - 24h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [85] }
+                  operator: { type: and }
+                  query: { params: [soh] }
+                  reducer: { type: last }
+                  type: query
+              expression: soh
+        noDataState: OK
+        execErrState: Alerting
+        for: 1h
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Battery SoH below 85%"
+          description: "Significant capacity fade. Compare to warranty replacement threshold."
+
+      - uid: ioniq-avail-dis-derate
+        title: "🚗 Ioniq Available Discharge Derated"
+        condition: A
+        data:
+          - refId: disq
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("avail_dis") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: socq
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("soc") FROM "ioniq"
+                WHERE "group"='bms/2101' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [70] }
+                  operator: { type: and }
+                  query: { params: [disq] }
+                  reducer: { type: last }
+                  type: query
+                - evaluator: { type: gt, params: [30] }
+                  operator: { type: and }
+                  query: { params: [socq] }
+                  reducer: { type: last }
+                  type: query
+              expression: disq
+        noDataState: OK
+        execErrState: Alerting
+        for: 15m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Available discharge power derated below 70 kW"
+          description: "BMS is limiting discharge while SoC is healthy (>30%). Watch for a developing pack fault."
+```
+
+- [ ] **Step 2: Validate the YAML parses and has the expected rules**
+
+Run:
+```bash
+cd /home/groupsky/src/homy && python3 -c "
+import yaml, sys
+d = yaml.safe_load(open('config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml'))
+g = d['groups'][0]
+assert g['folder']=='Ioniq EV', g['folder']
+assert g['interval']=='1m'
+rules = g['rules']
+assert len(rules)==10, len(rules)
+for r in rules:
+    assert r['noDataState']=='OK', r['uid']
+    assert r['execErrState']=='Alerting', r['uid']
+    assert r['labels']['device']=='ioniq', r['uid']
+    assert r['condition']=='A', r['uid']
+    assert r['title'].startswith('🚗'), r['uid']
+uids={r['uid'] for r in rules}
+assert 'ioniq-avail-dis-derate' in uids
+# multi-condition rule has two conditions
+mc=[r for r in rules if r['uid']=='ioniq-avail-dis-derate'][0]
+conds=[d for d in mc['data'] if d['refId']=='A'][0]['model']['conditions']
+assert len(conds)==2, len(conds)
+print('battery YAML OK:', len(rules), 'rules')
+"
+```
+Expected: `battery YAML OK: 10 rules`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml
+git commit -m "$(cat <<'MSG'
+feat(grafana): add Ioniq battery alert rules
+
+HV isolation, min/max cell voltage, pack temperature, static SoH steps,
+and an available-discharge derate rule (multi-condition avail_dis<70 AND
+soc>30) in the new Ioniq EV folder. noDataState OK throughout so a
+sleeping car does not alert.
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Task 5: Grafana parked-12 V alert rules (§4.2)
+
+**Files:**
+- Create: `config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml`
+
+**Interfaces:**
+- Consumes: InfluxDB `ioniq` field `aux_12v` (group `bms/2101`) with the `state='parked'` tag filter.
+- Produces: 2 alert rules in folder `Ioniq EV`, group `Ioniq 12V Alerts`.
+
+- [ ] **Step 1: Write the rule file**
+
+Create `config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml`:
+
+```yaml
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq 12V Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-12v-low-parked
+        title: "🚗 Ioniq 12V Low (parked)"
+        condition: A
+        data:
+          - refId: v12
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("aux_12v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND "state"='parked' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [12.2] }
+                  operator: { type: and }
+                  query: { params: [v12] }
+                  reducer: { type: last }
+                  type: query
+              expression: v12
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: warning, device: ioniq, subsystem: 12v }
+        annotations:
+          summary: "🚗 12V battery below 12.2 V while parked"
+          description: "Aux 12V is dropping at rest. Charge/replace before the next lock cycle — a dead 12V strands the car."
+
+      - uid: ioniq-12v-critical-parked
+        title: "🚗 Ioniq 12V Critical (parked)"
+        condition: A
+        data:
+          - refId: v12
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("aux_12v") FROM "ioniq"
+                WHERE "group"='bms/2101' AND "state"='parked' AND time >= now() - 15m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: lt, params: [11.8] }
+                  operator: { type: and }
+                  query: { params: [v12] }
+                  reducer: { type: last }
+                  type: query
+              expression: v12
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        labels: { severity: critical, device: ioniq, subsystem: 12v }
+        annotations:
+          summary: "🚗 12V battery below 11.8 V while parked"
+          description: "Aux 12V critically low at rest. Charge/replace now to avoid stranding."
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+Run:
+```bash
+cd /home/groupsky/src/homy && python3 -c "
+import yaml
+d = yaml.safe_load(open('config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml'))
+g = d['groups'][0]
+assert g['folder']=='Ioniq EV'
+rules = g['rules']
+assert len(rules)==2, len(rules)
+for r in rules:
+    assert r['noDataState']=='OK'
+    assert r['labels']['subsystem']=='12v'
+    q = [x for x in r['data'] if x['refId']=='v12'][0]['model']['query']
+    assert \"\\\"state\\\"='parked'\" in q, q
+print('12V YAML OK')
+"
+```
+Expected: `12V YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml
+git commit -m "$(cat <<'MSG'
+feat(grafana): add Ioniq parked-12V alert rules
+
+Warn <12.2V / critical <11.8V on aux_12v filtered to state='parked' so
+normal float-under-traction voltages do not false-fire. noDataState OK
+(no parked samples while driving is not an alert).
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Task 6: Grafana DTC alert rule (§4.4)
+
+**Files:**
+- Create: `config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml`
+
+**Interfaces:**
+- Consumes: the bot's `derived/dtc_count` signal (field `value`, group `derived/dtc_count`).
+- Produces: 1 alert rule in folder `Ioniq EV`, group `Ioniq DTC Alerts`.
+
+- [ ] **Step 1: Write the rule file**
+
+Create `config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml`:
+
+```yaml
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq DTC Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-dtc-present
+        title: "🚗 Ioniq Diagnostic Trouble Code"
+        condition: A
+        data:
+          - refId: dtc
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/dtc_count' AND time >= now() - 1h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [dtc] }
+                  reducer: { type: last }
+                  type: query
+              expression: dtc
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: critical, device: ioniq, subsystem: dtc }
+        annotations:
+          summary: "🚗 Diagnostic trouble code(s) present: {{ $values.dtc.Value }} active"
+          description: "The car reported one or more DTCs. The Telegram flag from the ioniq-dtc bot names the specific code(s); decode and act by code."
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+Run:
+```bash
+cd /home/groupsky/src/homy && python3 -c "
+import yaml
+d = yaml.safe_load(open('config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml'))
+r = d['groups'][0]['rules'][0]
+assert r['uid']=='ioniq-dtc-present'
+assert r['labels']['severity']=='critical'
+assert r['for']=='0s'
+assert r['noDataState']=='OK'
+q=[x for x in r['data'] if x['refId']=='dtc'][0]['model']['query']
+assert \"'derived/dtc_count'\" in q, q
+print('DTC YAML OK')
+"
+```
+Expected: `DTC YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml
+git commit -m "$(cat <<'MSG'
+feat(grafana): add Ioniq DTC alert rule
+
+Critical alert when derived/dtc_count > 0 (from the ioniq-dtc bot).
+Fires immediately; the bot's direct-flag names the specific codes.
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Task 7: Ioniq-scoped notification routing (§3)
+
+Add severity-based routes matched on `device = ioniq` so Ioniq alerts get their own cadence without touching house-alert behaviour.
+
+**Files:**
+- Modify: `config/grafana/provisioning/alerting/notification-policies.yaml`
+
+**Interfaces:**
+- Consumes: the existing `telegram-webhook` receiver and the `device: ioniq` / `severity` labels emitted by the rules in Tasks 4–6.
+- Produces: three child routes under the existing root policy; non-Ioniq alerts fall through unchanged.
+
+- [ ] **Step 1: Replace the file with the routed version**
+
+Overwrite `config/grafana/provisioning/alerting/notification-policies.yaml` with:
+
+```yaml
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: telegram-webhook
+    group_by:
+      - grafana_folder
+      - alertname
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    routes:
+      - receiver: telegram-webhook
+        matchers:
+          - device = ioniq
+          - severity = critical
+        group_wait: 10s
+        group_interval: 1m
+        repeat_interval: 1h
+      - receiver: telegram-webhook
+        matchers:
+          - device = ioniq
+          - severity = warning
+        group_wait: 1m
+        group_interval: 5m
+        repeat_interval: 12h
+      - receiver: telegram-webhook
+        matchers:
+          - device = ioniq
+          - severity = info
+        group_wait: 5m
+        group_interval: 30m
+        repeat_interval: 24h
+```
+
+- [ ] **Step 2: Validate the YAML and route isolation**
+
+Run:
+```bash
+cd /home/groupsky/src/homy && python3 -c "
+import yaml
+d = yaml.safe_load(open('config/grafana/provisioning/alerting/notification-policies.yaml'))
+root = d['policies'][0]
+assert root['receiver']=='telegram-webhook'
+assert root['repeat_interval']=='4h'   # house alerts unchanged
+routes = root['routes']
+assert len(routes)==3, len(routes)
+for r in routes:
+    assert 'device = ioniq' in r['matchers'], r['matchers']
+    assert r['receiver']=='telegram-webhook'
+    assert 'continue' not in r or r['continue'] is False
+sev = {m for r in routes for m in r['matchers'] if m.startswith('severity')}
+assert sev == {'severity = critical','severity = warning','severity = info'}, sev
+print('routing YAML OK')
+"
+```
+Expected: `routing YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/grafana/provisioning/alerting/notification-policies.yaml
+git commit -m "$(cat <<'MSG'
+feat(grafana): Ioniq-scoped severity notification routes
+
+Add device=ioniq + severity child routes (critical 1h / warning 12h /
+info 24h repeat) under the existing flat root policy. Non-Ioniq alerts
+match no child route and keep the unchanged 4h root behaviour — zero
+blast radius.
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Task 8: Documentation updates
+
+**Files:**
+- Modify: `docs/influxdb-schema.md`
+- Modify: `docs/ioniq-monitoring-alerting-spec.md`
+
+**Interfaces:**
+- Consumes: nothing (docs only).
+- Produces: schema entry for the new `derived/dtc_count` group and a phase-2 status note in the parent spec.
+
+- [ ] **Step 1: Document the derived group in the InfluxDB schema**
+
+In `docs/influxdb-schema.md`, in the `ioniq` measurement section (around the `group` tag description near lines 186–201), add a note that a new bot-produced group exists:
+
+```markdown
+- **`derived/dtc_count`** (tag `group`) — produced by the `ioniq-dtc` automations bot, not the
+  logger. Field `value` = count of active DTCs (union of `dtc/stored` + `dtc/pending`); field
+  `codes` = JSON-stringified array of the code strings. Grafana's `ioniq-dtc-present` rule alerts
+  on `value > 0`.
+```
+
+- [ ] **Step 2: Add a phase-2 implementation-status note to the parent spec**
+
+In `docs/ioniq-monitoring-alerting-spec.md`, under the `## 9. Rollout phases` section, append:
+
+```markdown
+> **Implementation status (2026-07-14):** Phase 2 is implemented on branch
+> `feat/ioniq-monitoring-phase2` — Grafana battery (§4.1 non-derived), parked-12 V (§4.2), and
+> DTC (§4.4) alert rules; the `ioniq-dtc` bot (derived `dtc_count` + direct-flag); the `Ioniq EV`
+> folder; and Ioniq-scoped notification routing (§3, scoped to `device = ioniq` rather than the
+> house-wide reroute). Connectivity/liveness (§4.5) is deferred to phase 3: a `count()`-based
+> Grafana rule cannot express it (empty window returns no row, not 0) and NoData would fire on
+> every normal park, so it needs a session-aware bot. See
+> `docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase2-design.md`.
+```
+
+- [ ] **Step 3: Verify both edits landed**
+
+Run:
+```bash
+cd /home/groupsky/src/homy && grep -q 'derived/dtc_count' docs/influxdb-schema.md && grep -q 'Implementation status (2026-07-14)' docs/ioniq-monitoring-alerting-spec.md && echo 'docs OK'
+```
+Expected: `docs OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/influxdb-schema.md docs/ioniq-monitoring-alerting-spec.md
+git commit -m "$(cat <<'MSG'
+docs(ioniq): document derived/dtc_count group and phase-2 status
+
+Add the bot-produced derived/dtc_count group to the InfluxDB schema and
+record phase-2 implementation status (with the connectivity deferral) in
+the monitoring spec.
+
+Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
+MSG
+)"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Run the full automations test suite: `cd docker/automations && npm test` — all pass.
+- [ ] Confirm all 4 new/modified Grafana YAML files parse (Tasks 4–7 validation steps).
+- [ ] `git log --oneline` shows one commit per task, all on `feat/ioniq-monitoring-phase2`.
+- [ ] Optional live smoke test (needs a running Grafana): provision the folder and confirm the multi-condition `ioniq-avail-dis-derate` rule loads without a "condition must not be empty" error, since multi-condition `classic_conditions` is new to this repo.
+
+## Notes for the executor
+
+- **Do not** add connectivity/liveness rules — deferred to phase 3 by design decision.
+- **Do not** introduce MSW or any new npm dependency for the bot's HTTP; the injected `httpPost` (default `fetch`) is intentional.
+- The `for: 0s` on the DTC rule is deliberate (immediate). All other `for:` values are ≥ the 1m group interval.
+- If `python3`/`PyYAML` is unavailable in the environment, substitute an equivalent Node YAML check (e.g. `npx js-yaml <file>`), but do not add a dependency to a service's `package.json` just for validation.

--- a/docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase2-design.md
@@ -1,0 +1,204 @@
+# Ioniq EV Monitoring — Phase 2 Implementation Design
+
+Status: approved for planning · Date: 2026-07-14 · Branch: `feat/ioniq-monitoring-phase2`
+Parent spec: [`docs/ioniq-monitoring-alerting-spec.md`](../../ioniq-monitoring-alerting-spec.md) (rollout phase 2)
+
+## 1. Scope
+
+This branch implements **rollout phase 2** of the Ioniq monitoring spec: the highest-value,
+lowest-effort slice — Grafana-native alerts, the thin DTC bot, the `Ioniq EV` Grafana folder,
+and Ioniq-scoped notification routing.
+
+**In scope**
+- Grafana alert rules for §4.1 (non-derived battery), §4.2 (parked 12 V), §4.5 (data-liveness).
+- `ioniq-dtc` automations bot (§5, thin) publishing `derived/dtc_count` and direct-flagging DTCs.
+- Grafana `derived/dtc_count > 0` rule (§4.4).
+- `Ioniq EV` Grafana folder + Ioniq-scoped severity notification routing (§3).
+
+**Out of scope (deferred to later branches / other owners)**
+- P0 prerequisites: raw→parsed promotion (`ioniq-logger` #7/#5), Mongo TTL fix and InfluxDB
+  retention (prod ops). These are external and do not block this branch's deliverables.
+- Computation bots: `ioniq-cell-health`, `ioniq-12v-ldc`, `ioniq-tpms`, `ioniq-charge-guard`
+  (spec §4.1 derived rows, §4.2 LDC/fast-delta, §4.3 tires, §4.6 usage) — phase 3.
+- Dashboards (§7) — phase 4.
+- Any alert whose signal is Mongo-only (see §2 findings) or not yet decoded.
+
+## 2. Prod verification findings (2026-07-14, read-only queries on routy)
+
+Confirmed against the live `ioniq` measurement in prod InfluxDB (db `homy`):
+
+- **Groups present in InfluxDB:** `ambient`, `bms/2101`, `bms/2105`, `cells/1|33|65`,
+  `dtc/pending`, `dtc/stored`, `gps`, `odometer`, `tpms`, `vmcu`.
+- **`state` tag values:** `active`, `charging`, `parked`.
+- **Field names confirmed (spec was correct):** `aux_12v` (NOT `12v`), `isolation_kohm`
+  (pinned 1000), `cell_min_v`, `cell_max_v`, `temp_max`, `avail_dis` (pinned 98), `soc` all in
+  `bms/2101`; `soh` (=100) and `soc_display` in `bms/2105`. `charging`, `ignition`, `main` are
+  numeric **fields**, not tags.
+- **DTC shape:** groups `dtc/stored` and `dtc/pending` each carry a `codes` field stored as a
+  **JSON string** (`"[]"` when healthy). Grafana cannot parse/count this string → the bot must
+  compute the count. This is exactly why `ioniq-dtc` exists.
+- **Key gap — no `status`/`bcm`/`obc` in InfluxDB.** These are Mongo-only (raw namespace).
+  Consequences for this branch:
+  - The §4.5 "status flapping (≥3 offline transitions/h)" alert is **NOT Grafana-expressible**
+    and is dropped from phase 2. (Revisit if `ioniq/status` is ever promoted to parsed.)
+  - Data-liveness must key off `count("hv_v") FROM "ioniq" WHERE "group"='bms/2101'`, not the LWT.
+
+## 3. Architecture (phase-2 slice)
+
+```
+logger ─MQTT─> mqtt-influx-ioniq ─> InfluxDB "ioniq" ─> Grafana rules ─┐
+                                                                        ├─> telegram-webhook ─> telegram-bridge ─> Telegram
+ioniq-dtc bot ─MQTT─> ioniq/parsed/derived/dtc_count ─> InfluxDB ───────┘   (Grafana path)
+        │
+        └─HTTP POST {message} ─────────────────────────> telegram-bridge ─> Telegram  (bot direct-flag path)
+```
+
+- **Grafana** owns all threshold/liveness queries and their notification delivery.
+- **`ioniq-dtc` bot** owns the array logic (`codes.length`), publishes a clean numeric derived
+  signal, AND direct-flags on a DTC edge so the message names the actual code(s).
+
+## 4. Component A — Grafana alert rules
+
+Location: `config/grafana/provisioning/alerting/`. All rules follow the canonical
+`sunseeker-*` shape: `classic_conditions` (never `threshold`), explicit
+`WHERE time >= now() - <window>` (never `$timeFilter`), datasource UID `P3C6603E967DC8568`,
+group header `folder: Ioniq EV`, `🚗` prefix in `title`/`summary`, labels
+`severity` / `device: ioniq` / `subsystem`. Each warn/crit pair is two separate rules.
+
+### 4.1 `ioniq-battery-alerts.yaml` (subsystem: battery) — §4.1 non-derived only
+
+| uid | Query (field, group) | Condition | Sev | for |
+|---|---|---|---|---|
+| ioniq-isolation-low | `last(isolation_kohm)` bms/2101 | `< 500` | warning | 10m |
+| ioniq-isolation-critical | `last(isolation_kohm)` bms/2101 | `< 100` | critical | 10m |
+| ioniq-cell-min-low | `last(cell_min_v)` bms/2101 | `< 3.0` | warning | 1m |
+| ioniq-cell-min-critical | `last(cell_min_v)` bms/2101 | `< 2.5` | critical | 1m |
+| ioniq-cell-max-critical | `last(cell_max_v)` bms/2101 | `> 4.15` | critical | 1m |
+| ioniq-pack-temp-high | `last(temp_max)` bms/2101 | `> 45` | warning | 5m |
+| ioniq-pack-temp-critical | `last(temp_max)` bms/2101 | `> 55` | critical | 5m |
+| ioniq-soh-step | `last(soh)` bms/2105 | `< 98` | warning | 1h |
+| ioniq-soh-critical | `last(soh)` bms/2105 | `< 85` | critical | 1h |
+| ioniq-avail-dis-derate | `last(avail_dis)` AND `last(soc)` bms/2101 | `avail_dis < 70` AND `soc > 30` | warning | 15m |
+
+SoH uses the v1 **static** baseline (spec §4.1 note); rolling baseline is deferred. The
+`avail-dis-derate` rule uses two data queries (`avail_dis`, `soc`, both in bms/2101) combined in
+one `classic_conditions` with two ANDed conditions.
+
+### 4.2 `ioniq-12v-alerts.yaml` (subsystem: 12v) — §4.2 parked only
+
+| uid | Query | Condition | Sev | for |
+|---|---|---|---|---|
+| ioniq-12v-low-parked | `last(aux_12v)` bms/2101, `WHERE "state"='parked'` | `< 12.2` | warning | 30s |
+| ioniq-12v-critical-parked | `last(aux_12v)` bms/2101, `WHERE "state"='parked'` | `< 11.8` | critical | 30s |
+
+State filter is an InfluxQL `AND "state"='parked'` in the WHERE clause. This suppresses the
+"12.9 V float under heavy traction is normal" false positive (only evaluates parked samples).
+LDC-not-charging and fast-delta (§4.2 bot rows) are deferred to phase 3.
+
+### 4.3 `ioniq-connectivity-alerts.yaml` (subsystem: connectivity) — §4.5
+
+TPMS "box powers off ~60 s after lock" means a naive silence alert fires on every park. The
+liveness rules use a **two-window** query so they only fire when telemetry *should* be flowing
+(recent activity present) but the fast tier has gone silent:
+
+| uid | Logic | Sev | for |
+|---|---|---|---|
+| ioniq-telemetry-gap | `count(hv_v)` in last 15m `< 1` AND `count(hv_v)` in prior 15–45m window `> 0` | warning | 15m |
+| ioniq-telemetry-silent | `count(hv_v)` in last 30m `< 1` AND prior 30–90m window `> 0` | warning | 30m |
+
+Both use `count()` over `bms/2101`; the "prior window" is a second data query with
+`WHERE time >= now() - Xm AND time <= now() - Ym`. `noDataState: NoData` (no data at all ≠ alert;
+the gate query going empty means the car was already parked, correctly no alert). The
+status-flapping rule is dropped (§2: `status` is Mongo-only). Thresholds/windows are tunable.
+
+### 4.4 `ioniq-dtc-alerts.yaml` (subsystem: dtc) — §4.4
+
+| uid | Query | Condition | Sev | for |
+|---|---|---|---|---|
+| ioniq-dtc-present | `last(value)` `WHERE "group"='derived/dtc_count'` | `> 0` | critical | 0s |
+
+Reads the bot's derived signal. Fires immediately (`for: 0`). Per the "both notify" decision,
+this Grafana notification fires **in addition to** the bot's direct-flag; the Grafana message
+carries the count, the bot's message names the codes.
+
+## 5. Component B — `ioniq-dtc` bot
+
+Files: `docker/automations/bots/ioniq-dtc.js` + `docker/automations/bots/ioniq-dtc.test.js`,
+registered in `config/automations/config.js`.
+
+**Signature:** `module.exports = (name, config) => ({ persistedCache, start })` (repo pattern).
+
+**Subscribes** (exact topics — bot routing is exact-match, wildcards don't work):
+`ioniq/parsed/dtc/stored` and `ioniq/parsed/dtc/pending`.
+
+**State:** holds last-known `codes` array for each of stored/pending (combined =
+`stored.codes ∪ pending.codes`). `persistedCache` (version 1) persists the last-emitted code set
+so a restart doesn't re-flag an already-known DTC.
+
+**On each message:**
+1. Update the relevant (stored|pending) code list; compute `count = |stored ∪ pending|`.
+2. **Publish** `ioniq/parsed/derived/dtc_count` as
+   `{_type:'ioniq', group:'derived/dtc_count', state, ts, value: count, codes: [...]}`
+   (`_type:'ioniq'` is required for the mqtt-influx bridge to accept it; `value` is the numeric
+   alert input; `codes` passes the list through for history/dashboards).
+3. **Direct-flag on 0→N edge** (new codes appear vs. persisted set): HTTP `POST` to
+   `config.telegramWebhookUrl` (default `http://telegram-bridge:3000/webhook`) with
+   `{message: "🚗 DTC present: <code>, <code> (stored/pending)"}`. Edge-triggered + persisted-set
+   dedupe so it flags on appearance, not on every sample. Message uses HTML (`<b>`) per bridge.
+
+**Config fields:** `storedTopic`, `pendingTopic`, `outputTopic`, `telegramWebhookUrl`,
+`flagOnEdge` (bool, default true), plus standard `enabled`/`verbose`.
+
+**Testing (TDD, Jest, mocked MQTT + mocked HTTP):**
+- Empty `codes` → publishes `value: 0`, no flag.
+- Codes appear → publishes correct count + codes, POSTs a message naming the codes.
+- Same codes persist across samples → publishes each sample but flags only once (dedupe).
+- Codes clear (N→0) → publishes `value: 0`, no flag; a later re-appearance flags again.
+- stored and pending combine (union, de-duplicated count).
+- Restart with persisted set → no re-flag of already-known codes.
+- HTTP POST failure is caught/logged and does not crash the bot (publish still happens).
+
+HTTP uses Node's built-in `http` (no new dependency), mocked in tests.
+
+## 6. Component C — notification routing (Ioniq-scoped)
+
+Edit `config/grafana/provisioning/alerting/notification-policies.yaml`: keep the existing flat
+root policy (all house alerts unchanged, 4h repeat) and add a `routes:` array whose entries match
+`device = ioniq` + `severity`, `continue: false`, giving Ioniq alerts their own cadence:
+
+- `device = ioniq, severity = critical` → group_wait 10s, group_interval 1m, repeat 1h.
+- `device = ioniq, severity = warning` → group_wait 1m, group_interval 5m, repeat 12h.
+- `device = ioniq, severity = info` → group_wait 5m, group_interval 30m, repeat 24h.
+
+All still terminate at the existing `telegram-webhook` receiver. **Zero blast radius** on
+non-Ioniq alerts (they never match `device = ioniq` and fall through to the root default).
+
+## 7. Component D — contact point
+
+Reuse the existing `telegram-webhook` contact point unchanged. A dedicated Ioniq Telegram chat
+is **not possible** without `telegram-bridge` code changes (single global chat id — verified), so
+v1 differentiates via the `🚗` prefix in every rule summary and the bot's message text.
+
+## 8. Testing & verification strategy
+
+- **Bot:** `cd docker/automations && npm test` — full TDD per §5, red-green-refactor.
+- **Grafana YAML:** validated for structure against the canonical `sunseeker-*` shape;
+  provisioning correctness is verified by rule-file structure review (no live Grafana in CI).
+- **Subagent reviews:** each component (bot, each alert file group, routing) gets an independent
+  subagent code review before merge, per the repo's requesting-code-review flow.
+- **InfluxDB queries** were pre-validated against prod data shapes (§2) so no rule silently
+  matches nothing.
+
+## 9. Deliverables checklist
+
+- [ ] `config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml`
+- [ ] `config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml`
+- [ ] `config/grafana/provisioning/alerting/ioniq-connectivity-alerts.yaml`
+- [ ] `config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml`
+- [ ] `config/grafana/provisioning/alerting/notification-policies.yaml` (Ioniq routes added)
+- [ ] `docker/automations/bots/ioniq-dtc.js` + `.test.js`
+- [ ] `config/automations/config.js` (register `ioniq-dtc`)
+- [ ] `example.env` / `secrets/` updates if any new config surfaces (none expected — webhook URL
+      has an in-code default)
+- [ ] Docs: update `docs/influxdb-schema.md` for the new `derived/dtc_count` group; note phase-2
+      status in the parent spec.

--- a/docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase2-design.md
@@ -10,7 +10,7 @@ lowest-effort slice — Grafana-native alerts, the thin DTC bot, the `Ioniq EV` 
 and Ioniq-scoped notification routing.
 
 **In scope**
-- Grafana alert rules for §4.1 (non-derived battery), §4.2 (parked 12 V), §4.5 (data-liveness).
+- Grafana alert rules for §4.1 (non-derived battery) and §4.2 (parked 12 V).
 - `ioniq-dtc` automations bot (§5, thin) publishing `derived/dtc_count` and direct-flagging DTCs.
 - Grafana `derived/dtc_count > 0` rule (§4.4).
 - `Ioniq EV` Grafana folder + Ioniq-scoped severity notification routing (§3).
@@ -18,10 +18,34 @@ and Ioniq-scoped notification routing.
 **Out of scope (deferred to later branches / other owners)**
 - P0 prerequisites: raw→parsed promotion (`ioniq-logger` #7/#5), Mongo TTL fix and InfluxDB
   retention (prod ops). These are external and do not block this branch's deliverables.
+- **Connectivity / data-liveness (§4.5) — deferred to phase 3 as a stateful bot.** Grafana
+  cannot distinguish "logger died" from "car parked and powered off by design" without
+  session-aware state: a `count()`-based rule returns *no row* (not `0`) over an empty window so
+  it can only fire via the NoData path, and a NoData alert would notify on every normal park.
+  Correct liveness needs a bot that tracks last-known `state` and emits a real
+  `derived/telemetry_stale` signal only when data stops *while the car was active/charging*.
+  See §4.3.
 - Computation bots: `ioniq-cell-health`, `ioniq-12v-ldc`, `ioniq-tpms`, `ioniq-charge-guard`
   (spec §4.1 derived rows, §4.2 LDC/fast-delta, §4.3 tires, §4.6 usage) — phase 3.
 - Dashboards (§7) — phase 4.
 - Any alert whose signal is Mongo-only (see §2 findings) or not yet decoded.
+
+## 2a. Grafana correctness rules baked into this design (from review gate)
+
+These were confirmed during the design review and MUST hold for every rule in this branch:
+- **`noDataState: OK` on every threshold rule.** For a car that sleeps, "no matching data in the
+  window" is normal, not an alert. Grafana routes `DatasourceNoData` as a notification (the
+  `telegram-bridge` even formats it), so `NoData` would fire on every park / every drive for the
+  state-filtered rules. Absence-of-data detection is the deferred connectivity bot's job, not a
+  side effect of battery/12 V rules.
+- **`execErrState: Alerting`** stays (a real query error is worth surfacing).
+- **Explicit query window on every `last()` rule** (`WHERE … AND time >= now() - <window>`), since
+  `relativeTimeRange` does not filter InfluxQL (repo gotcha).
+- **Group `interval` must be ≤ each rule's `for:`** or `for:` is meaningless. Ioniq groups use
+  `interval: 1m` (responsive enough for `for: 1m` cell/12 V rules; longer `for:` values like 10m/1h
+  still work under a 1m interval).
+- **`count()` over an empty window returns no row, not `0`** — do not write liveness/threshold
+  rules that depend on `count(...) < 1` evaluating with data. (This is why connectivity is a bot.)
 
 ## 2. Prod verification findings (2026-07-14, read-only queries on routy)
 
@@ -62,7 +86,8 @@ ioniq-dtc bot ─MQTT─> ioniq/parsed/derived/dtc_count ─> InfluxDB ───
 Location: `config/grafana/provisioning/alerting/`. All rules follow the canonical
 `sunseeker-*` shape: `classic_conditions` (never `threshold`), explicit
 `WHERE time >= now() - <window>` (never `$timeFilter`), datasource UID `P3C6603E967DC8568`,
-group header `folder: Ioniq EV`, `🚗` prefix in `title`/`summary`, labels
+group header `folder: Ioniq EV` + `interval: 1m`, `noDataState: OK` (see §2a),
+`execErrState: Alerting`, `🚗` prefix in `title`/`summary`, labels
 `severity` / `device: ioniq` / `subsystem`. Each warn/crit pair is two separate rules.
 
 ### 4.1 `ioniq-battery-alerts.yaml` (subsystem: battery) — §4.1 non-derived only
@@ -80,46 +105,89 @@ group header `folder: Ioniq EV`, `🚗` prefix in `title`/`summary`, labels
 | ioniq-soh-critical | `last(soh)` bms/2105 | `< 85` | critical | 1h |
 | ioniq-avail-dis-derate | `last(avail_dis)` AND `last(soc)` bms/2101 | `avail_dis < 70` AND `soc > 30` | warning | 15m |
 
-SoH uses the v1 **static** baseline (spec §4.1 note); rolling baseline is deferred. The
-`avail-dis-derate` rule uses two data queries (`avail_dis`, `soc`, both in bms/2101) combined in
-one `classic_conditions` with two ANDed conditions.
+SoH uses the v1 **static** baseline (spec §4.1 note); rolling baseline is deferred.
+
+The `avail-dis-derate` rule is the one **multi-condition** rule: two data queries
+(`disq` = `last(avail_dis)`, `socq` = `last(soc)`, both bms/2101, both always-present so no
+NoData trap) combined in a single `classic_conditions` block with two ANDed conditions. This
+construct has no existing precedent in the repo, so it must be implemented from a fully-worked,
+validated example. Canonical shape:
+
+```yaml
+- refId: disq   # SELECT last("avail_dis") FROM "ioniq" WHERE "group"='bms/2101' AND time >= now() - 15m
+- refId: socq   # SELECT last("soc")       FROM "ioniq" WHERE "group"='bms/2101' AND time >= now() - 15m
+- refId: A
+  datasourceUid: __expr__
+  model:
+    type: classic_conditions
+    conditions:
+      - evaluator: { type: lt, params: [70] }
+        operator: { type: and }
+        query:    { params: [disq] }
+        reducer:  { type: last }
+        type: query
+      - evaluator: { type: gt, params: [30] }
+        operator: { type: and }   # ANDs with the previous condition
+        query:    { params: [socq] }
+        reducer:  { type: last }
+        type: query
+    expression: disq
+# condition: A
+```
+
+Because `classic_conditions` drops `GROUP BY` tag labels, no rule here may reference
+`{{ $labels.* }}` in annotations — all Ioniq rules are single-series (one car), so this is
+satisfied; annotations use static text (and `{{ $values.<refId>.Value }}` where a number helps).
 
 ### 4.2 `ioniq-12v-alerts.yaml` (subsystem: 12v) — §4.2 parked only
 
-| uid | Query | Condition | Sev | for |
-|---|---|---|---|---|
-| ioniq-12v-low-parked | `last(aux_12v)` bms/2101, `WHERE "state"='parked'` | `< 12.2` | warning | 30s |
-| ioniq-12v-critical-parked | `last(aux_12v)` bms/2101, `WHERE "state"='parked'` | `< 11.8` | critical | 30s |
+Query template (both rules): `SELECT last("aux_12v") FROM "ioniq" WHERE "group"='bms/2101' AND
+"state"='parked' AND time >= now() - 15m`.
 
-State filter is an InfluxQL `AND "state"='parked'` in the WHERE clause. This suppresses the
-"12.9 V float under heavy traction is normal" false positive (only evaluates parked samples).
+| uid | Condition | Sev | for |
+|---|---|---|---|
+| ioniq-12v-low-parked | `< 12.2` | warning | 1m |
+| ioniq-12v-critical-parked | `< 11.8` | critical | 1m |
+
+State filter is an InfluxQL `AND "state"='parked'` in the WHERE clause (`state` is a tag; single
+quotes). This suppresses the "12.9 V float under heavy traction is normal" false positive (only
+parked samples are evaluated). While driving, the window has no parked rows → NoData → **no
+alert** (`noDataState: OK`). `for: 1m` matches the 1m group interval (parent spec's 30s isn't
+meaningfully expressible below the eval interval; a sustained 1m dip is the practical equivalent).
 LDC-not-charging and fast-delta (§4.2 bot rows) are deferred to phase 3.
 
-### 4.3 `ioniq-connectivity-alerts.yaml` (subsystem: connectivity) — §4.5
+### 4.3 Connectivity / data-liveness (§4.5) — DEFERRED to phase 3
 
-TPMS "box powers off ~60 s after lock" means a naive silence alert fires on every park. The
-liveness rules use a **two-window** query so they only fire when telemetry *should* be flowing
-(recent activity present) but the fast tier has gone silent:
+Not implemented in this branch. Rationale (confirmed at the design review gate):
 
-| uid | Logic | Sev | for |
-|---|---|---|---|
-| ioniq-telemetry-gap | `count(hv_v)` in last 15m `< 1` AND `count(hv_v)` in prior 15–45m window `> 0` | warning | 15m |
-| ioniq-telemetry-silent | `count(hv_v)` in last 30m `< 1` AND prior 30–90m window `> 0` | warning | 30m |
+- A `count(hv_v) < 1` Grafana rule **cannot work**: InfluxQL `count()` over an empty window
+  returns *no row*, not a `0`, so the condition never evaluates true-with-data — the rule could
+  only ever fire through the NoData path.
+- Relying on NoData would notify on **every normal park** (the box powers off ~60 s after lock by
+  design), which is exactly the false-alarm the parent spec set out to avoid.
+- Distinguishing "logger died" from "car parked and powered off" needs **session-aware state**
+  (was the car `active`/`charging` when telemetry stopped?) — stateful/edge logic that belongs in
+  a bot, not a Grafana threshold.
+- The parent spec's status-flapping rule is additionally impossible in Grafana because
+  `ioniq/status` is **Mongo-only** (§2).
 
-Both use `count()` over `bms/2101`; the "prior window" is a second data query with
-`WHERE time >= now() - Xm AND time <= now() - Ym`. `noDataState: NoData` (no data at all ≠ alert;
-the gate query going empty means the car was already parked, correctly no alert). The
-status-flapping rule is dropped (§2: `status` is Mongo-only). Thresholds/windows are tunable.
+Phase-3 plan: a liveness bot (candidate: `timeout-emit` gated on last-known `state`, or a small
+bespoke bot) emits `derived/telemetry_stale` (0/1) only when data stops while the car was
+active/charging; Grafana then alerts on that real numeric signal with a trivial threshold.
 
 ### 4.4 `ioniq-dtc-alerts.yaml` (subsystem: dtc) — §4.4
 
-| uid | Query | Condition | Sev | for |
-|---|---|---|---|---|
-| ioniq-dtc-present | `last(value)` `WHERE "group"='derived/dtc_count'` | `> 0` | critical | 0s |
+Query: `SELECT last("value") FROM "ioniq" WHERE "group"='derived/dtc_count' AND time >= now() - 1h`.
 
-Reads the bot's derived signal. Fires immediately (`for: 0`). Per the "both notify" decision,
-this Grafana notification fires **in addition to** the bot's direct-flag; the Grafana message
-carries the count, the bot's message names the codes.
+| uid | Condition | Sev | for |
+|---|---|---|---|
+| ioniq-dtc-present | `> 0` | critical | 0s |
+
+Reads the bot's derived signal. Fires immediately (`for: 0`). `noDataState: OK` — when the car is
+asleep the bot publishes nothing, so an empty window must not alert; real-time detection of a DTC
+edge is covered by the bot's direct-flag regardless. Per the "both notify" decision, this Grafana
+notification fires **in addition to** the bot's direct-flag; the Grafana message carries the
+count, the bot's message names the codes.
 
 ## 5. Component B — `ioniq-dtc` bot
 
@@ -129,7 +197,11 @@ registered in `config/automations/config.js`.
 **Signature:** `module.exports = (name, config) => ({ persistedCache, start })` (repo pattern).
 
 **Subscribes** (exact topics — bot routing is exact-match, wildcards don't work):
-`ioniq/parsed/dtc/stored` and `ioniq/parsed/dtc/pending`.
+`ioniq/parsed/dtc/stored` and `ioniq/parsed/dtc/pending`. These strings are inferred from the
+InfluxDB `group` tags (`dtc/stored`, `dtc/pending`) + the parent spec's `ioniq/parsed/dtc/#`
+pattern; **verify the exact live topic strings with `mosquitto_sub` at implementation time**
+(a wrong string silently no-ops under exact-match routing). Topics are configurable so a
+correction is config-only.
 
 **State:** holds last-known `codes` array for each of stored/pending (combined =
 `stored.codes ∪ pending.codes`). `persistedCache` (version 1) persists the last-emitted code set
@@ -140,11 +212,16 @@ so a restart doesn't re-flag an already-known DTC.
 2. **Publish** `ioniq/parsed/derived/dtc_count` as
    `{_type:'ioniq', group:'derived/dtc_count', state, ts, value: count, codes: [...]}`
    (`_type:'ioniq'` is required for the mqtt-influx bridge to accept it; `value` is the numeric
-   alert input; `codes` passes the list through for history/dashboards).
+   alert input; `codes` passes the list through for history/dashboards). Note the framework's
+   `mqtt.publish` also injects `_bot` and `_tz`, so the converter will additionally write
+   `_bot.name`/`_bot.type`/`_tz` fields on this series — harmless, and the Grafana rule only reads
+   `value`.
 3. **Direct-flag on 0→N edge** (new codes appear vs. persisted set): HTTP `POST` to
-   `config.telegramWebhookUrl` (default `http://telegram-bridge:3000/webhook`) with
-   `{message: "🚗 DTC present: <code>, <code> (stored/pending)"}`. Edge-triggered + persisted-set
-   dedupe so it flags on appearance, not on every sample. Message uses HTML (`<b>`) per bridge.
+   `config.telegramWebhookUrl` (default `http://telegram-bridge:3000/webhook`) with a `{message}`
+   body naming the concrete codes, e.g. `{message: "🚗 <b>DTC present</b>: P0AA6, P1B76 (stored)"}`.
+   The message is built by interpolating the actual code strings (never a literal `<code>` token,
+   which the bridge's HTML `parse_mode` would treat as markup). Edge-triggered + persisted-set
+   dedupe so it flags on appearance, not on every sample.
 
 **Config fields:** `storedTopic`, `pendingTopic`, `outputTopic`, `telegramWebhookUrl`,
 `flagOnEdge` (bool, default true), plus standard `enabled`/`verbose`.
@@ -183,7 +260,9 @@ v1 differentiates via the `🚗` prefix in every rule summary and the bot's mess
 
 - **Bot:** `cd docker/automations && npm test` — full TDD per §5, red-green-refactor.
 - **Grafana YAML:** validated for structure against the canonical `sunseeker-*` shape;
-  provisioning correctness is verified by rule-file structure review (no live Grafana in CI).
+  provisioning correctness is verified by rule-file structure review (no live Grafana in CI). The
+  multi-condition `avail-dis-derate` rule (novel construct) should additionally be smoke-tested
+  against a live Grafana before relying on it. Every rule carries `noDataState: OK` (§2a).
 - **Subagent reviews:** each component (bot, each alert file group, routing) gets an independent
   subagent code review before merge, per the repo's requesting-code-review flow.
 - **InfluxDB queries** were pre-validated against prod data shapes (§2) so no rule silently
@@ -193,7 +272,6 @@ v1 differentiates via the `🚗` prefix in every rule summary and the bot's mess
 
 - [ ] `config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml`
 - [ ] `config/grafana/provisioning/alerting/ioniq-12v-alerts.yaml`
-- [ ] `config/grafana/provisioning/alerting/ioniq-connectivity-alerts.yaml`
 - [ ] `config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml`
 - [ ] `config/grafana/provisioning/alerting/notification-policies.yaml` (Ioniq routes added)
 - [ ] `docker/automations/bots/ioniq-dtc.js` + `.test.js`


### PR DESCRIPTION
## Summary

Implements **phase 2** of the Ioniq EV monitoring spec (`docs/ioniq-monitoring-alerting-spec.md`): the highest-value, lowest-effort slice. Design + plan under `docs/superpowers/{specs,plans}/2026-07-14-ioniq-monitoring-phase2-*`.

**Delivered:**
- **`ioniq-dtc` automations bot** (`docker/automations/bots/ioniq-dtc.js`) — subscribes to `ioniq/parsed/dtc/{stored,pending}`, unions the code arrays, and publishes a numeric `ioniq/parsed/derived/dtc_count` for Grafana. On a DTC edge it also **direct-flags** a code-naming message to `telegram-bridge` (the one thing Grafana can't do — codes land in InfluxDB as an opaque JSON string). Deduped across restarts via `persistedCache`. Registered in `config/automations/config.js`.
- **Grafana alert rules** in a new `Ioniq EV` folder:
  - `ioniq-battery-alerts.yaml` — HV isolation, min/max cell voltage, pack temp, static SoH steps, available-discharge derate (multi-condition `avail_dis<70 AND soc>30`).
  - `ioniq-12v-alerts.yaml` — parked-only aux 12 V (`state='parked'` filter).
  - `ioniq-dtc-alerts.yaml` — critical on `derived/dtc_count > 0`.
- **Ioniq-scoped notification routing** — `device = ioniq` + severity child routes added to `notification-policies.yaml`; existing house alerts fall through to the unchanged root policy (**zero blast radius**).
- **Docs** — `derived/dtc_count` group added to the InfluxDB schema; phase-2 status recorded in the monitoring spec.

## Key decisions
- **Connectivity/data-liveness (§4.5) deferred to phase 3.** A `count()`-based Grafana rule can't express it (empty window returns no row, not `0`) and NoData would fire on every normal park; correct liveness needs a session-aware bot.
- **`noDataState: OK`** on every rule — a car that sleeps must not alert on absence of data.
- **"Both notify" for DTCs** — bot direct-flags (names the code) *and* Grafana alerts (carries the count).

## Verification
- Field/tag/topic names and the DTC payload shape were **verified read-only against prod InfluxDB/Mongo** before writing any query (`aux_12v`, `isolation_kohm`, `soh`, group `derived/dtc_count`, topics `ioniq/parsed/dtc/{stored,pending}`).
- Bot: 11 Jest tests, full automations suite green.
- Grafana YAML: structural validators per rule file; every `__expr__` node matches the proven repo shape (`datasource`/`intervalMs`/`maxDataPoints`/`hide`).
- Built with spec → plan → subagent-driven TDD execution, each task independently reviewed, plus a final whole-branch review (READY TO MERGE, no Critical/Important findings).

## Deploy-time TODO
- Live-Grafana smoke test of the multi-condition `ioniq-avail-dis-derate` rule (multi-condition `classic_conditions` is new to this repo — the one thing offline validation can't cover).

https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN