### PR TITLE
fix(ci): always rebuild directly-changed services instead of retagging stale images

### DIFF
--- a/.github/scripts/detect-changes/src/index.ts
+++ b/.github/scripts/detect-changes/src/index.ts
@@ -18,6 +18,7 @@ import { buildReverseDependencyMap, detectAffectedServices } from './lib/depende
 import { detectChangedBaseImages, detectChangedServices, isTestOnlyChange } from './lib/change-detection.js';
 import { hasHealthcheck, extractFinalStageBase } from './lib/dockerfile-parser.js';
 import { checkAllServices, validateForkPrBaseImages } from './lib/ghcr-client.js';
+import { partitionBuildStrategy } from './lib/build-strategy.js';
 import { validatePackageJson, validateNvmrc } from './lib/validation.js';
 import type { DetectionResult, GitHubActionsOutputs, Service, BuildGroup } from './lib/types.js';
 
@@ -236,9 +237,32 @@ async function detectChanges(options: CliOptions): Promise<DetectionResult> {
 
   // Step 10: GHCR existence checks
   console.error('Step 10: Checking GHCR for existing images...');
-  const servicesForCheck = services.filter((s) => servicesToBuild.includes(s.service_name));
+
+  // Precompute test-only status for each changed service (reused in Step 10.5).
+  const testOnlyByService = new Map<string, boolean>();
+  for (const serviceName of changedServices) {
+    const service = services.find((s) => s.service_name === serviceName);
+    testOnlyByService.set(
+      serviceName,
+      service ? isTestOnlyChange(options.baseRef, service) : false
+    );
+  }
+
+  // A directly-changed service whose changes are NOT test-only must ALWAYS
+  // rebuild — its own source changed, so any existing base-SHA image is stale
+  // and reusing it would ship an image missing the new/changed source. Only
+  // affected services (own source unchanged) and changed test-only services are
+  // retag-eligible and handed to the GHCR existence check.
+  const { mustBuild, retagEligible } = partitionBuildStrategy({
+    changedServices,
+    affectedServices,
+    isTestOnly: (name) => testOnlyByService.get(name) ?? false,
+  });
+
+  const servicesForCheck = services.filter((s) => retagEligible.includes(s.service_name));
   const checkResult = await checkAllServices(servicesForCheck, options.baseSha);
-  const toBuild = checkResult.toBuild;
+  // Force-build directly-changed non-test services regardless of GHCR existence.
+  const toBuild = Array.from(new Set([...mustBuild, ...checkResult.toBuild]));
   const toRetag = checkResult.toRetag;
   console.error(`To build: ${toBuild.length}, To retag: ${toRetag.length}`);
 
@@ -252,14 +276,8 @@ async function detectChanges(options: CliOptions): Promise<DetectionResult> {
       continue;
     }
 
-    // Find service object
-    const service = services.find((s) => s.service_name === serviceName);
-    if (!service) {
-      continue;
-    }
-
-    // Check if this is a test-only change
-    if (isTestOnlyChange(options.baseRef, service)) {
+    // Check if this is a test-only change (reuse precomputed status)
+    if (testOnlyByService.get(serviceName)) {
       // Verify that image exists in toRetag (already checked by Step 10)
       // If image exists at base SHA, we can pull it for testing
       if (toRetag.includes(serviceName)) {

--- a/.github/scripts/detect-changes/src/lib/build-strategy.ts
+++ b/.github/scripts/detect-changes/src/lib/build-strategy.ts
@@ -1,0 +1,59 @@
+/**
+ * Build-vs-retag eligibility strategy.
+ *
+ * The CI pipeline tags a service's image by the base SHA and, when that image
+ * already exists in GHCR, would rather retag it than rebuild. That reuse is only
+ * safe when the service's OWN buildable source did not change. If a directly
+ * changed service is retagged, CI ships a stale image missing the new/changed
+ * source (this bit us when a new automations bot module referenced from the
+ * mounted config was absent from the retagged image, crash-looping the container
+ * with MODULE_NOT_FOUND).
+ *
+ * This module partitions the services considered for building into:
+ *   - mustBuild: directly changed services whose changes are NOT test-only. These
+ *     must ALWAYS build and must never be retag-eligible, regardless of whether a
+ *     base-SHA image already exists.
+ *   - retagEligible: everything else that was in scope, i.e. affected services
+ *     (pulled in by a base-image change, own source unchanged) and changed
+ *     services whose changes are test-only (preserving the test-only
+ *     optimization). Only these are handed to the GHCR existence check.
+ */
+
+export interface BuildStrategyInput {
+  /** Services whose own source changed (from detectChangedServices). */
+  changedServices: string[];
+  /** Services pulled in by a base-image change, own source unchanged. */
+  affectedServices: string[];
+  /** Returns true if the changed service's changes are test-only. */
+  isTestOnly: (serviceName: string) => boolean;
+}
+
+export interface BuildStrategy {
+  /** Services that must be rebuilt unconditionally (never retag-eligible). */
+  mustBuild: string[];
+  /** Services eligible for the GHCR existence check (retag if image exists). */
+  retagEligible: string[];
+}
+
+/**
+ * Partition in-scope services into unconditional builds vs retag-eligible.
+ *
+ * mustBuild = changed services that are not test-only.
+ * retagEligible = (changed ∪ affected) minus mustBuild
+ *               = affected services plus changed test-only services.
+ *
+ * Order within each list follows first-seen order of the inputs (changed before
+ * affected) so downstream output is stable.
+ */
+export function partitionBuildStrategy(input: BuildStrategyInput): BuildStrategy {
+  const { changedServices, affectedServices, isTestOnly } = input;
+
+  const mustBuild = changedServices.filter((name) => !isTestOnly(name));
+  const mustBuildSet = new Set(mustBuild);
+
+  const retagEligible = Array.from(new Set([...changedServices, ...affectedServices])).filter(
+    (name) => !mustBuildSet.has(name)
+  );
+
+  return { mustBuild, retagEligible };
+}

--- a/.github/scripts/detect-changes/tests/lib/build-strategy.test.ts
+++ b/.github/scripts/detect-changes/tests/lib/build-strategy.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Test suite for build-strategy module.
+ *
+ * Encodes the retag-vs-build eligibility rule that guards against shipping a
+ * STALE image for a service whose own source changed:
+ *
+ *   - A directly-changed service whose changes are NOT test-only must ALWAYS
+ *     build. It must never be retag-eligible, regardless of whether a base-SHA
+ *     image already exists in GHCR.
+ *   - Retag-eligible services are: affected services (pulled in by a base-image
+ *     change, own source unchanged) and changed services whose changes are
+ *     test-only (preserving the test-only optimization).
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { partitionBuildStrategy } from '../../src/lib/build-strategy.js';
+
+describe('partitionBuildStrategy', () => {
+  test('directly-changed non-test service is force-built and NOT retag-eligible', () => {
+    const result = partitionBuildStrategy({
+      changedServices: ['automations'],
+      affectedServices: [],
+      isTestOnly: () => false,
+    });
+
+    // The core bug fix: a changed non-test service must build, never retag.
+    expect(result.mustBuild).toEqual(['automations']);
+    expect(result.retagEligible).toEqual([]);
+  });
+
+  test('changed test-only service stays retag-eligible (test-only optimization preserved)', () => {
+    const result = partitionBuildStrategy({
+      changedServices: ['automations'],
+      affectedServices: [],
+      isTestOnly: (name) => name === 'automations',
+    });
+
+    expect(result.mustBuild).toEqual([]);
+    expect(result.retagEligible).toEqual(['automations']);
+  });
+
+  test('affected service (own source unchanged) stays retag-eligible', () => {
+    const result = partitionBuildStrategy({
+      changedServices: [],
+      affectedServices: ['features'],
+      isTestOnly: () => false,
+    });
+
+    expect(result.mustBuild).toEqual([]);
+    expect(result.retagEligible).toEqual(['features']);
+  });
+
+  test('service that is both changed non-test-only AND affected must build (not retag)', () => {
+    const result = partitionBuildStrategy({
+      changedServices: ['automations'],
+      affectedServices: ['automations'],
+      isTestOnly: () => false,
+    });
+
+    expect(result.mustBuild).toEqual(['automations']);
+    expect(result.retagEligible).toEqual([]);
+  });
+
+  test('mixed set partitions correctly', () => {
+    // automations: changed, production code -> must build
+    // features: changed, test-only -> retag eligible
+    // ha_discovery: affected only -> retag eligible
+    const result = partitionBuildStrategy({
+      changedServices: ['automations', 'features'],
+      affectedServices: ['ha_discovery'],
+      isTestOnly: (name) => name === 'features',
+    });
+
+    expect(result.mustBuild).toEqual(['automations']);
+    expect(result.retagEligible.sort()).toEqual(['features', 'ha_discovery']);
+  });
+
+  test('retagEligible never overlaps mustBuild', () => {
+    const result = partitionBuildStrategy({
+      changedServices: ['a', 'b', 'c'],
+      affectedServices: ['b', 'd'],
+      isTestOnly: (name) => name === 'b',
+    });
+
+    const overlap = result.retagEligible.filter((s) => result.mustBuild.includes(s));
+    expect(overlap).toEqual([]);
+    // a, c changed non-test -> build; b test-only -> retag; d affected -> retag
+    expect(result.mustBuild.sort()).toEqual(['a', 'c']);
+    expect(result.retagEligible.sort()).toEqual(['b', 'd']);
+  });
+
+  test('empty input yields empty partitions', () => {
+    const result = partitionBuildStrategy({
+      changedServices: [],
+      affectedServices: [],
+      isTestOnly: () => false,
+    });
+
+    expect(result.mustBuild).toEqual([]);
+    expect(result.retagEligible).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug

The unified CI change-detection tool (`.github/scripts/detect-changes`, run via `tsx src/index.ts`) tags each service image by the base SHA and, when that image already exists in GHCR, retags it instead of rebuilding. `index.ts` **Step 10** handed **every** in-scope service (`changedServices ∪ affectedServices`) to `checkAllServices()`, which classifies retag-vs-build **purely** on whether `ghcr.io/groupsky/homy/<image>:<baseSha>` already exists. Since the base SHA is the PR merge-base (or `HEAD^1` on master push), that image almost always exists — so a service whose **own source changed** was classified **To retag** and shipped a **stale** image.

This bit us: adding a new automations bot module (`docker/automations/bots/ioniq-dtc.js`) referenced from the **mounted** `config/automations/config.js` produced a retagged `automations` image missing the file, crash-looping the container with `Error: Cannot find module '../bots/ioniq-dtc'` (MODULE_NOT_FOUND) and failing the Lights Integration Test. Had CI pulled it to prod, it would have taken down all automations.

## The fix

Partition in-scope services **before** the GHCR existence check:

- **`mustBuild`** = directly-changed services whose changes are **not** test-only. These **always** build and are **never** retag-eligible, regardless of whether a base-SHA image exists.
- **`retagEligible`** = affected services (base-image change, own source unchanged) **plus** changed **test-only** services. Only these are handed to `checkAllServices()`, preserving the affected-service and test-only (pull-for-testing) optimizations in Step 10.5.

The partition rule is extracted into a pure, unit-tested helper `src/lib/build-strategy.ts` (`partitionBuildStrategy`) and wired into `index.ts` Steps 10/10.5. Added `tests/lib/build-strategy.test.ts`; full suite: 378 tests pass, `tsc --noEmit` clean.

## CI mock-validation

The base-SHA `automations` image exists in GHCR at master `9653648`, so under the **old** logic a directly-changed `automations` would have been classified **To retag**. Validation evidence (mock no-op comment edit to `docker/automations/index.js`, then reverted) is recorded in the PR thread — with the fix, `automations` appears under **To build** and the Build App Images job runs for it.

Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN

https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN