### PR TITLE
feat(ioniq): tpms bot — derived cold-pressure/spread/temp signals + Grafana rules

### DIFF
--- a/config/automations/config.js
+++ b/config/automations/config.js
@@ -484,6 +484,11 @@ module.exports = {
       outputTopic: 'ioniq/parsed/derived/dtc_count',
       telegramWebhookUrl: 'http://telegram-bridge:3000/webhook',
     },
+    ioniqTpms: {
+      type: 'ioniq-tpms',
+      tpmsTopic: 'ioniq/parsed/tpms',
+      ambientTopic: 'ioniq/parsed/ambient',
+    },
   },
   gates: {
     mqtt: {

--- a/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
@@ -1,0 +1,636 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq TPMS Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-tpms-fl-psi-low
+        title: "🚗 Ioniq Tire Low — FL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fl_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [30] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FL (front-left) tire cold-pressure below 30 psi"
+          description: "Cold-normalized front-left tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+
+      - uid: ioniq-tpms-fl-psi-crit
+        title: "🚗 Ioniq Tire Critical — FL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fl_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [26] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: critical, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FL (front-left) tire cold-pressure below 26 psi"
+          description: "Cold-normalized front-left tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+
+      - uid: ioniq-tpms-fl-overinflated
+        title: "🚗 Ioniq Tire Over-inflated — FL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fl_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [42] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: info, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FL (front-left) tire cold-pressure above 42 psi"
+          description: "Cold-normalized front-left tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+
+      - uid: ioniq-tpms-fl-temp-excess
+        title: "🚗 Ioniq Tire Hot — FL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fl_temp_excess' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [8] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FL (front-left) tire running hot vs the other wheels"
+          description: "front-left tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+
+      - uid: ioniq-tpms-fr-psi-low
+        title: "🚗 Ioniq Tire Low — FR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fr_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [30] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FR (front-right) tire cold-pressure below 30 psi"
+          description: "Cold-normalized front-right tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+
+      - uid: ioniq-tpms-fr-psi-crit
+        title: "🚗 Ioniq Tire Critical — FR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fr_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [26] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: critical, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FR (front-right) tire cold-pressure below 26 psi"
+          description: "Cold-normalized front-right tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+
+      - uid: ioniq-tpms-fr-overinflated
+        title: "🚗 Ioniq Tire Over-inflated — FR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fr_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [42] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: info, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FR (front-right) tire cold-pressure above 42 psi"
+          description: "Cold-normalized front-right tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+
+      - uid: ioniq-tpms-fr-temp-excess
+        title: "🚗 Ioniq Tire Hot — FR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_fr_temp_excess' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [8] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 FR (front-right) tire running hot vs the other wheels"
+          description: "front-right tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+
+      - uid: ioniq-tpms-rl-psi-low
+        title: "🚗 Ioniq Tire Low — RL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rl_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [30] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RL (rear-left) tire cold-pressure below 30 psi"
+          description: "Cold-normalized rear-left tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+
+      - uid: ioniq-tpms-rl-psi-crit
+        title: "🚗 Ioniq Tire Critical — RL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rl_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [26] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: critical, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RL (rear-left) tire cold-pressure below 26 psi"
+          description: "Cold-normalized rear-left tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+
+      - uid: ioniq-tpms-rl-overinflated
+        title: "🚗 Ioniq Tire Over-inflated — RL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rl_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [42] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: info, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RL (rear-left) tire cold-pressure above 42 psi"
+          description: "Cold-normalized rear-left tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+
+      - uid: ioniq-tpms-rl-temp-excess
+        title: "🚗 Ioniq Tire Hot — RL"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rl_temp_excess' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [8] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RL (rear-left) tire running hot vs the other wheels"
+          description: "rear-left tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+
+      - uid: ioniq-tpms-rr-psi-low
+        title: "🚗 Ioniq Tire Low — RR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rr_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [30] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RR (rear-right) tire cold-pressure below 30 psi"
+          description: "Cold-normalized rear-right tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+
+      - uid: ioniq-tpms-rr-psi-crit
+        title: "🚗 Ioniq Tire Critical — RR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rr_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [26] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: critical, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RR (rear-right) tire cold-pressure below 26 psi"
+          description: "Cold-normalized rear-right tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+
+      - uid: ioniq-tpms-rr-overinflated
+        title: "🚗 Ioniq Tire Over-inflated — RR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rr_psi_cold' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [42] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: info, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RR (rear-right) tire cold-pressure above 42 psi"
+          description: "Cold-normalized rear-right tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+
+      - uid: ioniq-tpms-rr-temp-excess
+        title: "🚗 Ioniq Tire Hot — RR"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_rr_temp_excess' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [8] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 RR (rear-right) tire running hot vs the other wheels"
+          description: "rear-right tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+
+      - uid: ioniq-tpms-spread-high
+        title: "🚗 Ioniq Tire Pressure Spread High"
+        condition: A
+        data:
+          - refId: q
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/tire_spread_psi' AND time >= now() - 6h
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [3] }
+                  operator: { type: and }
+                  query: { params: [q] }
+                  reducer: { type: last }
+                  type: query
+              expression: q
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: tpms }
+        annotations:
+          summary: "🚗 Tire cold-pressure spread above 3 psi across wheels"
+          description: "The cold-normalized pressures of the four tires differ by more than 3 psi. Even out inflation and check the lowest wheel for a leak."

--- a/docker/automations/bots/ioniq-tpms.js
+++ b/docker/automations/bots/ioniq-tpms.js
@@ -1,0 +1,123 @@
+// ioniq-tpms: temperature-compensates the Ioniq's per-wheel tire pressures to a
+// 15 °C cold reference and derives cross-wheel signals (spread, per-wheel
+// temperature excess) onto ioniq/parsed/derived/* so Grafana can alert with a
+// trivial threshold. Raw psi is not comparable to the 36 psi cold placard because
+// pressure rises ~0.18 psi/°C, so a hot tire reads high; cold-normalization makes
+// the number directly comparable.
+//
+// TPMS refreshes only on wheel rotation: parked/charging samples are stale and the
+// sensor repeats its last reading verbatim. So we evaluate only fresh `active`
+// samples and de-duplicate identical consecutive raw readings.
+
+const stringify = require('fast-json-stable-stringify')
+
+const WHEELS = ['fl', 'fr', 'rl', 'rr']
+const TEMP_COEFF = 0.18 // psi per °C
+const REF_TEMP_C = 15 // cold reference temperature
+
+const isFiniteNum = (x) => typeof x === 'number' && Number.isFinite(x)
+const round2 = (x) => Math.round(x * 100) / 100
+
+module.exports = function createIoniqTpms (name, config = {}) {
+  const tpmsTopic = config.tpmsTopic || 'ioniq/parsed/tpms'
+  const ambientTopic = config.ambientTopic || 'ioniq/parsed/ambient'
+  const prefix = config.outputTopicPrefix || 'ioniq/parsed/derived/'
+  const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
+
+  return {
+    persistedCache: {
+      version: 1,
+      // `lastRaw` holds the last processed raw wheel tuple so a frozen (repeated)
+      // reading is skipped. Non-critical: a reset at worst re-emits the current
+      // reading once, which is harmless.
+      default: { lastRaw: null }
+    },
+
+    start: async ({ mqtt, persistedCache }) => {
+      // Latest ambient temperature, used as a per-wheel fallback when a wheel's
+      // own temperature is missing. Not persisted — it refills on the next sample.
+      let ambientC = null
+
+      const publish = (signal, base, value, extra) => {
+        mqtt.publish(prefix + signal, {
+          _type: 'ioniq',
+          group: 'derived/' + signal,
+          state: base.state,
+          ts: base.ts,
+          value: round2(value),
+          ...extra
+        })
+      }
+
+      const onTpms = (payload) => {
+        if (!payload || payload.state !== 'active') return
+
+        // Extract the raw wheel tuple in a fixed key order for stable dedupe.
+        const raw = {}
+        for (const w of WHEELS) {
+          raw[`${w}.psi`] = payload[`${w}.psi`]
+          raw[`${w}.c`] = payload[`${w}.c`]
+        }
+        const rawKey = stringify(raw)
+        if (persistedCache.lastRaw && stringify(persistedCache.lastRaw) === rawKey) {
+          return // frozen/duplicate reading — nothing changed
+        }
+        persistedCache.lastRaw = raw
+
+        // Per wheel resolve two temperatures:
+        //  - ownTemp: the wheel's actual measured temperature (no fallback). Used
+        //    for the wheel-vs-wheel temp_excess comparison — substituting ambient
+        //    here would make a dead-sensor wheel report a meaningless excess.
+        //  - compTemp: ownTemp, else the cached ambient temp. Used only to
+        //    temperature-compensate pressure (psi_cold), where any reasonable
+        //    reference temperature is better than none.
+        const ownTemp = {}
+        const compTemp = {}
+        const cold = {}
+        for (const w of WHEELS) {
+          const wt = payload[`${w}.c`]
+          if (isFiniteNum(wt)) ownTemp[w] = wt
+          const t = isFiniteNum(wt) ? wt : (isFiniteNum(ambientC) ? ambientC : null)
+          if (t !== null) compTemp[w] = t
+
+          const psi = payload[`${w}.psi`]
+          if (isFiniteNum(psi) && t !== null) {
+            cold[w] = psi - TEMP_COEFF * (t - REF_TEMP_C)
+          }
+        }
+
+        // Per-wheel cold pressures.
+        for (const w of WHEELS) {
+          if (cold[w] === undefined) continue
+          publish(`tire_${w}_psi_cold`, payload, cold[w], {
+            psi: payload[`${w}.psi`], temp: compTemp[w]
+          })
+        }
+
+        // Spread across all wheels that produced a cold pressure (needs >= 2).
+        const coldVals = WHEELS.filter((w) => cold[w] !== undefined).map((w) => cold[w])
+        if (coldVals.length >= 2) {
+          publish('tire_spread_psi', payload, Math.max(...coldVals) - Math.min(...coldVals))
+        }
+
+        // Per-wheel temperature excess vs the mean of the OTHER wheels that have a
+        // real measured temperature (needs >= 1 other). A hot wheel relative to its
+        // peers flags a dragging brake / bearing even if its own pressure cell is
+        // dead. Only measured temps participate — no ambient fallback here.
+        const tempWheels = WHEELS.filter((w) => ownTemp[w] !== undefined)
+        for (const w of tempWheels) {
+          const others = tempWheels.filter((o) => o !== w).map((o) => ownTemp[o])
+          if (others.length === 0) continue
+          const mean = others.reduce((a, b) => a + b, 0) / others.length
+          publish(`tire_${w}_temp_excess`, payload, ownTemp[w] - mean)
+        }
+      }
+
+      await mqtt.subscribe(ambientTopic, (payload) => {
+        ambientC = payload && isFiniteNum(payload.c) ? payload.c : ambientC
+        log('ambient', ambientC)
+      })
+      await mqtt.subscribe(tpmsTopic, onTpms)
+    }
+  }
+}

--- a/docker/automations/bots/ioniq-tpms.test.js
+++ b/docker/automations/bots/ioniq-tpms.test.js
@@ -1,0 +1,210 @@
+const { describe, expect, it, jest, beforeEach } = require('@jest/globals')
+const createIoniqTpms = require('./ioniq-tpms')
+
+const TPMS = 'ioniq/parsed/tpms'
+const AMBIENT = 'ioniq/parsed/ambient'
+const P = (name) => `ioniq/parsed/derived/${name}`
+
+function makeMqtt () {
+  const mqtt = {
+    _callbacks: {},
+    subscribe: jest.fn().mockImplementation((topic, cb) => {
+      mqtt._callbacks[topic] = cb
+      return Promise.resolve()
+    }),
+    publish: jest.fn().mockResolvedValue(),
+    _trigger: (topic, message) =>
+      mqtt._callbacks[topic] ? mqtt._callbacks[topic](message) : undefined
+  }
+  return mqtt
+}
+
+function makeCache () {
+  return { lastRaw: null }
+}
+
+const config = { tpmsTopic: TPMS, ambientTopic: AMBIENT }
+
+// Realistic prod-derived sample (2026-07-14 routy). Cold-normalize to 15 °C @ 0.18 psi/°C.
+// fl: 36.6 - 0.18*(35-15) = 33.0 ; fr: 35.2 - 0.18*(36-15) = 31.42
+// rl: 35.6 - 0.18*(37-15) = 31.64 ; rr: 36.2 - 0.18*(37-15) = 32.24
+function sample (overrides = {}) {
+  return {
+    _type: 'ioniq',
+    group: 'tpms',
+    state: 'active',
+    ts: 1000,
+    'fl.psi': 36.6, 'fl.c': 35,
+    'fr.psi': 35.2, 'fr.c': 36,
+    'rl.psi': 35.6, 'rl.c': 37,
+    'rr.psi': 36.2, 'rr.c': 37,
+    ...overrides
+  }
+}
+
+// Fetch the payload published to a given derived topic (last call), or undefined.
+function published (mqtt, name) {
+  const calls = mqtt.publish.mock.calls.filter((c) => c[0] === P(name))
+  return calls.length ? calls[calls.length - 1][1] : undefined
+}
+function publishedTopics (mqtt) {
+  return mqtt.publish.mock.calls.map((c) => c[0])
+}
+
+describe('ioniq-tpms bot', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(async () => {
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    bot = createIoniqTpms('ioniq-tpms', config)
+    await bot.start({ mqtt, persistedCache })
+  })
+
+  it('subscribes to the tpms and ambient topics', () => {
+    expect(mqtt.subscribe).toHaveBeenCalledWith(TPMS, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(AMBIENT, expect.any(Function))
+  })
+
+  it('emits four per-wheel cold pressures with correct payload shape', async () => {
+    await mqtt._trigger(TPMS, sample())
+    expect(published(mqtt, 'tire_fl_psi_cold')).toEqual(expect.objectContaining({
+      _type: 'ioniq', group: 'derived/tire_fl_psi_cold', state: 'active', ts: 1000, value: 33.0
+    }))
+    expect(published(mqtt, 'tire_fr_psi_cold').value).toBe(31.42)
+    expect(published(mqtt, 'tire_rl_psi_cold').value).toBe(31.64)
+    expect(published(mqtt, 'tire_rr_psi_cold').value).toBe(32.24)
+  })
+
+  it('includes raw psi and used temp as extra fields', async () => {
+    await mqtt._trigger(TPMS, sample())
+    expect(published(mqtt, 'tire_fl_psi_cold')).toEqual(expect.objectContaining({ psi: 36.6, temp: 35 }))
+  })
+
+  it('emits tire_spread_psi = max - min of cold pressures', async () => {
+    await mqtt._trigger(TPMS, sample())
+    // max 33.0 (fl) - min 31.42 (fr) = 1.58
+    expect(published(mqtt, 'tire_spread_psi')).toEqual(expect.objectContaining({
+      _type: 'ioniq', group: 'derived/tire_spread_psi', value: 1.58
+    }))
+  })
+
+  it('emits per-wheel temp_excess = wheel - mean(other three)', async () => {
+    await mqtt._trigger(TPMS, sample())
+    // fl: 35 - mean(36,37,37)= 35 - 36.6667 = -1.67
+    expect(published(mqtt, 'tire_fl_temp_excess').value).toBe(-1.67)
+    // fr: 36 - mean(35,37,37)= 36 - 36.3333 = -0.33
+    expect(published(mqtt, 'tire_fr_temp_excess').value).toBe(-0.33)
+    // rl: 37 - mean(35,36,37)= 37 - 36 = 1
+    expect(published(mqtt, 'tire_rl_temp_excess').value).toBe(1)
+    // rr: 37 - mean(35,36,37)= 37 - 36 = 1
+    expect(published(mqtt, 'tire_rr_temp_excess').value).toBe(1)
+  })
+
+  it('falls back to ambient temp when a wheel temp is missing', async () => {
+    await mqtt._trigger(AMBIENT, { c: 25 })
+    await mqtt._trigger(TPMS, sample({ 'fl.c': undefined }))
+    // fl uses ambient 25: 36.6 - 0.18*(25-15) = 36.6 - 1.8 = 34.8
+    expect(published(mqtt, 'tire_fl_psi_cold').value).toBe(34.8)
+    expect(published(mqtt, 'tire_fl_psi_cold').temp).toBe(25)
+  })
+
+  describe('active-only gating', () => {
+    it.each(['parked', 'charging'])('emits nothing for state=%s', async (state) => {
+      await mqtt._trigger(TPMS, sample({ state }))
+      expect(mqtt.publish).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('frozen-duplicate dedupe', () => {
+    it('skips an identical consecutive active sample', async () => {
+      await mqtt._trigger(TPMS, sample({ ts: 1 }))
+      const after = mqtt.publish.mock.calls.length
+      expect(after).toBeGreaterThan(0)
+      await mqtt._trigger(TPMS, sample({ ts: 2 })) // same readings, new ts
+      expect(mqtt.publish.mock.calls.length).toBe(after)
+    })
+
+    it('re-emits when any reading changes', async () => {
+      await mqtt._trigger(TPMS, sample({ ts: 1 }))
+      const after = mqtt.publish.mock.calls.length
+      await mqtt._trigger(TPMS, sample({ ts: 2, 'fl.psi': 30.0 }))
+      expect(mqtt.publish.mock.calls.length).toBeGreaterThan(after)
+    })
+
+    it('holds dedupe across restart via pre-seeded lastRaw', async () => {
+      mqtt = makeMqtt()
+      const raw = {
+        'fl.psi': 36.6, 'fl.c': 35, 'fr.psi': 35.2, 'fr.c': 36,
+        'rl.psi': 35.6, 'rl.c': 37, 'rr.psi': 36.2, 'rr.c': 37
+      }
+      persistedCache = { lastRaw: raw }
+      bot = createIoniqTpms('ioniq-tpms', config)
+      await bot.start({ mqtt, persistedCache })
+      await mqtt._trigger(TPMS, sample()) // identical to seeded lastRaw
+      expect(mqtt.publish).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('partial payloads', () => {
+    it('omits a wheel with missing psi but still emits the others', async () => {
+      await mqtt._trigger(TPMS, sample({ 'fl.psi': undefined }))
+      expect(published(mqtt, 'tire_fl_psi_cold')).toBeUndefined()
+      expect(published(mqtt, 'tire_fr_psi_cold')).toBeDefined()
+    })
+
+    it('excludes a psi-less wheel from spread', async () => {
+      await mqtt._trigger(TPMS, sample({ 'fl.psi': undefined }))
+      // remaining cold: fr 31.42, rl 31.64, rr 32.24 → spread 32.24-31.42 = 0.82
+      expect(published(mqtt, 'tire_spread_psi').value).toBe(0.82)
+    })
+
+    it('still counts a psi-less-but-temp-present wheel in others temp_excess', async () => {
+      // fl has temp 35 but no psi. fr temp_excess still uses fl's temp in the mean.
+      await mqtt._trigger(TPMS, sample({ 'fl.psi': undefined }))
+      expect(published(mqtt, 'tire_fr_temp_excess').value).toBe(-0.33)
+    })
+
+    it('emits no psi_cold for a wheel missing both its temp and any ambient', async () => {
+      await mqtt._trigger(TPMS, sample({ 'fl.c': undefined }))
+      expect(published(mqtt, 'tire_fl_psi_cold')).toBeUndefined()
+    })
+
+    it('does not emit spread when fewer than two wheels are valid', async () => {
+      await mqtt._trigger(TPMS, sample({
+        'fr.psi': undefined, 'rl.psi': undefined, 'rr.psi': undefined
+      }))
+      expect(published(mqtt, 'tire_fl_psi_cold')).toBeDefined()
+      expect(published(mqtt, 'tire_spread_psi')).toBeUndefined()
+    })
+
+    it('does not emit temp_excess for a lone-temp wheel', async () => {
+      await mqtt._trigger(TPMS, sample({
+        'fr.c': undefined, 'rl.c': undefined, 'rr.c': undefined,
+        'fr.psi': undefined, 'rl.psi': undefined, 'rr.psi': undefined
+      }))
+      expect(publishedTopics(mqtt)).not.toContain(P('tire_fl_temp_excess'))
+    })
+
+    it('does not emit temp_excess for a wheel using only ambient fallback temp', async () => {
+      await mqtt._trigger(AMBIENT, { c: 25 })
+      await mqtt._trigger(TPMS, sample({ 'fl.c': undefined }))
+      // fl still gets a cold pressure (via ambient) but no temp_excess (no own temp)
+      expect(published(mqtt, 'tire_fl_psi_cold')).toBeDefined()
+      expect(published(mqtt, 'tire_fl_temp_excess')).toBeUndefined()
+    })
+
+    it('excludes an ambient-fallback wheel from the others temp_excess mean', async () => {
+      await mqtt._trigger(AMBIENT, { c: 25 })
+      await mqtt._trigger(TPMS, sample({ 'fl.c': undefined }))
+      // fr excess uses only fr,rl,rr real temps: 36 - mean(37,37) = 36 - 37 = -1
+      expect(published(mqtt, 'tire_fr_temp_excess').value).toBe(-1)
+    })
+
+    it('ignores a non-finite ambient temp', async () => {
+      await mqtt._trigger(AMBIENT, { c: 'n/a' })
+      await mqtt._trigger(TPMS, sample({ 'fl.c': undefined }))
+      // no valid temp for fl → no psi_cold
+      expect(published(mqtt, 'tire_fl_psi_cold')).toBeUndefined()
+    })
+  })
+})

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -193,6 +193,17 @@ query this measurement's `v` field. See
     automations bot publishes it with field `value` = count of active DTCs (union of `dtc/stored`
     + `dtc/pending`) and field `codes` = JSON-stringified array of the code strings. Grafana's
     `ioniq-dtc-present` rule alerts on `value > 0`.
+  - `derived/tire_<w>_psi_cold` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — bot-produced by the `ioniq-tpms`
+    automations bot: per-wheel tire pressure temperature-compensated to a 15 °C cold reference
+    (`value = psi − 0.18·(temp − 15)` psi, using the wheel's own `.c` temp, falling back to
+    `ambient.c`). Extra fields `psi` (raw psi) and `temp` (temperature used). Only emitted for fresh
+    `state='active'` samples, de-duplicated against frozen readings. Grafana `ioniq-tpms-*-psi-low`
+    (`< 30` warn) / `-psi-crit` (`< 26` crit) / `-overinflated` (`> 42` info) rules alert on it.
+  - `derived/tire_spread_psi` — `ioniq-tpms`: `value` = max − min of the four cold-normalized
+    pressures (psi). Grafana `ioniq-tpms-spread-high` alerts on `value > 3`.
+  - `derived/tire_<w>_temp_excess` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — `ioniq-tpms`: `value` = wheel
+    temperature minus the mean temperature of the other three wheels (°C). Grafana
+    `ioniq-tpms-<w>-temp-excess` alerts on `value > 8`.
 - `state`: vehicle state (`active` / `parked` / `charging` / …), from `payload.state` — low-cardinality, what dashboards filter/group by
 **Timestamp**: `payload.ts` (epoch ms), written at `ms` precision
 **Fields**: every payload key except `_type`, `group`, `state`, `ts`:

--- a/docs/superpowers/plans/2026-07-14-ioniq-tpms.md
+++ b/docs/superpowers/plans/2026-07-14-ioniq-tpms.md
@@ -1,0 +1,53 @@
+# Ioniq TPMS bot — implementation plan
+
+Spec: [`../specs/2026-07-14-ioniq-tpms-design.md`](../specs/2026-07-14-ioniq-tpms-design.md)
+Branch: `feat/ioniq-tpms` (worktree). TDD, red→green→refactor.
+
+## Task 1 — TDD the bot (`ioniq-tpms.js` + `.test.js`)
+1. Write `ioniq-tpms.test.js` first, mirroring `ioniq-dtc.test.js` mocked-MQTT pattern
+   (`makeMqtt` with `_callbacks`/`_trigger`, `makeCache` returning `{ lastRaw: null }`). Cover every
+   scenario in spec §8. Use realistic prod-derived vectors (fl.psi=36.6, fl.c=35 → psi_cold 33.0).
+2. Run `npm ci` (fresh worktree) then `npx jest bots/ioniq-tpms.test.js` → RED (module missing).
+3. Implement `ioniq-tpms.js`:
+   - `module.exports = (name, config) => ({ persistedCache, start })`.
+   - Config: `tpmsTopic`, `ambientTopic`, output topic prefix `ioniq/parsed/derived/`, all overridable.
+   - `persistedCache`: `{ version:1, default:{ lastRaw:null } }`.
+   - `start({ mqtt, persistedCache })`: subscribe ambient (cache `ambient.c`), subscribe tpms (evaluate).
+   - Helpers: `finite(x)` guard, `round2(x)`, `coldPsi(psi,temp)`, per-wheel extraction of dotted keys.
+   - Gate on `state==='active'`; dedupe via stable-stringify of raw tuple vs `lastRaw`.
+   - Emit the 4 psi_cold, spread, 4 temp_excess signals per spec §4.3.
+4. Run tests → GREEN. Refactor for clarity; keep comments explaining *why* (dedupe, gating).
+5. **Review gate (fresh subagent):** per-task review of bot + tests.
+
+## Task 2 — Register bot in `config/automations/config.js`
+Append an `ioniqTpms` block near `ioniqDtc` (~line 486). Selective edit, no reformatting.
+```js
+ioniqTpms: {
+  type: 'ioniq-tpms',
+  tpmsTopic: 'ioniq/parsed/tpms',
+  ambientTopic: 'ioniq/parsed/ambient',
+},
+```
+
+## Task 3 — Grafana rules `config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml`
+17 rules per spec §6, cloning `ioniq-12v-alerts.yaml` structure. Mechanical transcription (haiku-suitable)
+but generated carefully and validated with a YAML parse.
+
+## Task 4 — Doc `docs/influxdb-schema.md`
+Add the new `derived/tire_*` groups under the `ioniq` measurement `group` bullet, following the
+`derived/dtc_count` precedent (name each group, its `value` meaning, and the Grafana rule that consumes it).
+
+## Task 5 — Verification & review
+1. `npx jest bots/ioniq-tpms.test.js` green; full `npm test` sanity (no regressions).
+2. Node syntax check of config.js; YAML parse of the alerts file.
+3. **Whole-branch review (fresh subagent)** before PR.
+4. Commit (selective staging, `Claude-Session` trailer), push, `gh pr create`.
+5. **Fresh PR review** after opening.
+
+## Review gates (never self-review)
+- Spec review (done before impl).
+- Plan review (done before impl).
+- Task-1 per-task review.
+- Whole-branch review.
+- Fresh PR review.
+Escalate to human only for a genuine product/judgment call.

--- a/docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase3-design.md
+++ b/docs/superpowers/specs/2026-07-14-ioniq-monitoring-phase3-design.md
@@ -1,0 +1,197 @@
+# Ioniq EV Monitoring — Phase 3 Implementation Design (computation bots)
+
+Status: approved for planning · Date: 2026-07-14 · Parent spec:
+[`docs/ioniq-monitoring-alerting-spec.md`](../../ioniq-monitoring-alerting-spec.md) (rollout phase 3)
+Phase-2 template: [`2026-07-14-ioniq-monitoring-phase2-design.md`](2026-07-14-ioniq-monitoring-phase2-design.md)
+
+This is the **umbrella contract** for Phase 3. Each bot below is implemented in its own git worktree
+by an independent orchestrator that produces a per-bot spec → plan → TDD → review → PR. This document
+fixes the shared scope, data shapes, conventions, and gotchas so the three streams stay consistent.
+
+## 1. Scope
+
+Phase 3 builds the **computation bots** (spec §5) whose conditions Grafana/InfluxQL express poorly
+(array logic, cross-field math, rolling/stateful edges). Each bot reduces its condition to a clean
+numeric signal on `ioniq/parsed/derived/<name>` so the existing `mqtt-influx-ioniq` bridge writes it to
+InfluxDB and Grafana alerts on it with a trivial threshold.
+
+**In scope — three bespoke bots, one worktree + PR each:**
+- `ioniq-cell-health` → `derived/cell_spread_mv`, `derived/module_temp_spread_c`
+- `ioniq-12v-ldc` → `derived/ldc_ok`, `derived/aux12v_drop`
+- `ioniq-tpms` → `derived/tire_<w>_psi_cold` (×4), `derived/tire_spread_psi`, `derived/tire_<w>_temp_excess`
+
+Each PR bundles: `docker/automations/bots/<bot>.js` + `<bot>.test.js`, registration in
+`config/automations/config.js`, the bot's Grafana derived-threshold rule file under
+`config/grafana/provisioning/alerting/`, and the `docs/influxdb-schema.md` update for the new
+`derived/*` groups.
+
+**Deferred (out of scope for phase 3):**
+- **`ioniq-charge-guard`** (`soc_at_park`, `charge_stalled`, `charge_reduced_rate`) → **Phase 3.5**,
+  its own brainstorm/spec. Data is now available (see §2) but it is the most complex bot (correlating
+  three MQTT groups by time) and is split out to keep phase 3 tight and de-risked.
+- **Connectivity / data-liveness (`telemetry_stale`)** → **DROPPED.** A session-aware staleness
+  watchdog was judged too unreliable to be worth shipping (false-positive risk on the car's normal
+  power-cycling outweighs the value). Not implemented in phase 3; revisit only if a robust design emerges.
+- **Dashboards (§7)** → Phase 4, after these derived signals are landing in InfluxDB.
+
+## 2. Prod verification findings (2026-07-14, read-only queries on routy)
+
+Confirmed live against prod InfluxDB (db `homy`, measurement `ioniq`) and MongoDB. **These exact
+field/tag/topic strings are the contract — do not trust the parent spec's names blindly, they were
+re-verified here.**
+
+- **`group` tag values now in InfluxDB:** `ambient, bcm_b00e, bms/2101, bms/2105, cells/1, cells/33,
+  cells/65, derived/dtc_count, dtc/pending, dtc/stored, gps, hvac, mcu, net, obc, odometer, tpms, vmcu`.
+  **Change since phase 2: `bcm_b00e` and `obc` are now promoted to InfluxDB** (P0-1 done by the logger
+  team) — this unblocks charge-guard but that's phase 3.5.
+- **`state` tag values:** `active`, `charging`, `parked`.
+- **`cells/1` · `cells/33` · `cells/65`:** each row carries a single field **`cells`** stored as a
+  **JSON string** of 32 floats, e.g. `"[3.68,3.68,…]"`. `cells/1`→cells 1–32, `cells/33`→33–64,
+  `cells/65`→65–96 (96 total). Must `JSON.parse` and guard malformed input.
+- **`bms/2101`:** `aux_12v` (V), `ignition` (0/1 field), `hv_kw`, `charging` (0/1 field), `soc`,
+  `cell_max_v`, `cell_min_v`, `temp_max`, `temp_min`, `inlet`, `module_temps` (**JSON string**, 5 floats
+  = modules 1–5), `ac_port`/`dc_port` (0/1). Fast tier (~0.5 s).
+- **`bms/2105`:** `soh`, `module_temps_6_12` (**JSON string**, 7 floats = modules 6–12), `heater_1`,
+  `heater_2`, `cell_v_dev` (deadbanded to 0 — **do not use**). Slow tier (~75 s).
+- **`tpms`:** dotted fields **`fl.psi`, `fl.c`, `fr.psi`, `fr.c`, `rl.psi`, `rl.c`, `rr.psi`, `rr.c`**
+  (`.c` = temperature °C). Quote dotted fields in InfluxQL (`"fl.psi"`). Refreshes only on wheel
+  rotation — frozen/duplicated while parked.
+- **`ambient`:** temperature field is **`c`** (e.g. `30.5`). (A `outdoor_c` key exists in schema but was
+  not populated in sampled rows — use `c`.)
+
+## 3. Derived-signals convention (P0-4 — all bots MUST follow)
+
+Every emitted object on `ioniq/parsed/derived/<name>` MUST include the fields the `mqtt-influx-ioniq`
+bridge needs, exactly as `ioniq-dtc` does:
+
+```js
+mqtt.publish('ioniq/parsed/derived/<name>', {
+  _type: 'ioniq',            // REQUIRED — bridge rejects the message without it
+  group: 'derived/<name>',   // becomes the InfluxDB `group` tag
+  state,                     // pass through the source sample's state
+  ts,                        // pass through the source sample's ts
+  value: <number>,           // the numeric alert input Grafana thresholds on
+  // …optional extra fields (e.g. codes, cellIndex) for history/dashboards
+})
+```
+
+The framework's `mqtt.publish` also injects `_bot` and `_tz`; the converter writes those as extra
+series fields — harmless, Grafana only reads `value`. `mqtt.publish` takes a **JS object**, never a
+JSON string.
+
+## 4. Bot designs
+
+All bots follow the repo pattern `module.exports = (name, config) => ({ persistedCache, start })`,
+receive **parsed JS objects** from `mqtt.subscribe` (framework JSON-parses), use **exact-match topic
+subscriptions** (no wildcards — a wrong string silently no-ops), and ship with Jest tests using the
+repo's mocked-MQTT pattern. `ioniq-dtc.js` is the reference for shape, persisted-cache versioning, and
+HTML-escaping.
+
+### 4.1 `ioniq-cell-health`
+
+**Subscribes:** `ioniq/parsed/cells/1`, `ioniq/parsed/cells/33`, `ioniq/parsed/cells/65`,
+`ioniq/parsed/bms/2101`, `ioniq/parsed/bms/2105` (exact topics; inferred from the `group` tags — verify
+live with `mosquitto_sub` at implementation, config-overridable).
+
+**Emits:**
+- `derived/cell_spread_mv` — reassemble the 96-cell array from the three `cells` JSON strings, compute
+  `(max − min) · 1000` in mV, and include the **outlier cell index** (1–96, the cell furthest from the
+  pack mean) in the payload as an extra field. **Skip emission when `state === 'active'`** — this is a
+  rest-spread signal (§4.1); only emit for `parked`/`charging`. Emit only when all three arrays are
+  present/fresh (hold last-known per-segment in `persistedCache`; guard against a stale segment).
+- `derived/module_temp_spread_c` — merge 12 module temps (`module_temps`[5] from 2101 +
+  `module_temps_6_12`[7] from 2105, both JSON strings) → `max − min` °C.
+
+**Thresholds (Grafana):** `cell_spread_mv > 50` warn / `> 100` crit, `for: 10m`.
+`module_temp_spread_c > 8` warn / `> 15` crit, `for: 10m`. (baseline: 20 mV, 2 °C)
+
+Note: coarse pack spread (`cell_max_v − cell_min_v` from `bms/2101`) is directly Grafana-expressible but
+is **not** built here — the bot's full-reassembly signal supersedes it and adds the outlier index.
+
+### 4.2 `ioniq-12v-ldc`
+
+**Subscribes:** `ioniq/parsed/bms/2101`.
+
+**State:** rolling window of recent `{aux_12v, ignition, hv_kw, state, ts}` samples (bounded, in
+`persistedCache`).
+
+**Emits:**
+- `derived/ldc_ok` (0/1) — `0` (not charging) when `max(aux_12v) < 13.2 V` while `ignition === 1` and a
+  recent low-`hv_kw` sample, sustained ≥ 60 s; else `1`. This encodes the suppression rule: 12.9 V float
+  under heavy traction is normal LDC load-priority, not a fault, so the low-voltage judgement is gated
+  on low HV load.
+- `derived/aux12v_drop` (0/1) — `1` on a sag edge: `aux_12v` drop ≥ 0.8 V within 5 s, **or** ≥ 0.3 V/min
+  while `state === 'parked'`; else `0`.
+
+**Thresholds (Grafana):** `ldc_ok < 1` warn, `for: 60s`. `aux12v_drop > 0` warn, `for: 0s`.
+
+### 4.3 `ioniq-tpms`
+
+**Subscribes:** `ioniq/parsed/tpms`, `ioniq/parsed/ambient`.
+
+**Logic:** cold-normalize each wheel to 15 °C: `psi_cold = psi − 0.18·(temp − 15)` using the wheel's own
+`.c` temp (fall back to `ambient.c` if a wheel temp is missing). TPMS only refreshes on rotation →
+**evaluate on fresh `state === 'active'` samples only** and dedupe unchanged/frozen values (hold last
+raw reading in `persistedCache`; skip if identical to the prior sample).
+
+**Emits (per fresh active sample):**
+- `derived/tire_fl_psi_cold`, `…_fr_…`, `…_rl_…`, `…_rr_…` — four separate signals, one per wheel.
+- `derived/tire_spread_psi` — `max − min` of the four cold-normalized pressures.
+- `derived/tire_fl_temp_excess` … `_rr_…` — per wheel: `wheel_temp − mean(other three) ` °C (or a 0/1
+  flag when `> 8 °C`; per-bot spec picks representation, keep Grafana threshold trivial).
+
+**Thresholds (Grafana):** per-wheel `psi_cold < 30` warn / `< 26` crit (placard 36, no spare).
+`tire_spread_psi > 3` warn. per-wheel `temp_excess > 8` warn. over-inflation `psi_cold > 42` info.
+
+## 5. Grafana derived-threshold rules (shared shape)
+
+One rule file per bot under `config/grafana/provisioning/alerting/`
+(`ioniq-cell-health-alerts.yaml`, `ioniq-12v-ldc-alerts.yaml`, `ioniq-tpms-alerts.yaml`), cloning the
+phase-2 / `sunseeker-*` canonical shape. **Every rule MUST:**
+- Use `classic_conditions` (never `threshold`).
+- Query `SELECT last("value") FROM "ioniq" WHERE "group"='derived/<name>' AND time >= now() - <window>`
+  — explicit time bound, never `$timeFilter`.
+- Set `noDataState: OK` (the car sleeps; absence of data ≠ alert) and `execErrState: Alerting`.
+- Use datasource UID `P3C6603E967DC8568`, folder `Ioniq EV`, group `interval: 1m`
+  (≤ every rule's `for:`).
+- Give every `__expr__` node a full model: `datasource: {type: __expr__, uid: __expr__}`,
+  `intervalMs: 1000`, `maxDataPoints: 43200`, `refId: A`, `hide: false`.
+- Carry `🚗` in `title`/`summary` and labels `severity` (warning|critical|info), `device: ioniq`,
+  `subsystem` (battery|12v|tpms). Each warn/crit pair is two separate rules.
+- Use static annotation text (`classic_conditions` drops GROUP BY labels; all Ioniq rules are
+  single-series so no `{{ $labels.* }}`). `{{ $values.A.Value }}` is fine for a number.
+
+Notification routing (§3 of parent spec) already exists from phase 2 (`device = ioniq` severity routes)
+— no routing changes needed.
+
+## 6. Orchestration model
+
+Three **opus orchestrators**, each in its own **git worktree**, dispatched in **parallel** (background).
+Each orchestrator:
+1. Writes a per-bot design spec + implementation plan (using this doc as the parent contract).
+2. Runs subagent-driven **TDD** (Jest, mocked MQTT/HTTP; sonnet for implementation, haiku for mechanical
+   transcription) — red → green → refactor.
+3. Runs **independent fresh-subagent review gates** — spec review, plan review, per-task review,
+   whole-branch review, and a fresh PR review before the merge recommendation. The author never reviews
+   itself. Model matched to difficulty (opus for the hard review gates).
+4. Verifies field/tag/topic strings against **prod** (read-only) before writing queries; verifies the
+   built automations image contains the new module (`grep` for `MODULE_NOT_FOUND`) as part of the
+   deploy-readiness check.
+5. Opens a PR that is implemented, TDD-tested, and independently reviewed, carrying a clear
+   **GOOD TO MERGE** verdict (with evidence) or **FAILURE: <reason>**. The human decides merges.
+
+**Commits:** selective staging only (never `git add .`); end every commit body with the
+`Claude-Session` trailer.
+
+**Merge coordination:** the three PRs each append to `config/automations/config.js` and
+`docs/influxdb-schema.md`. Conflicts are trivial (append-only, disjoint blocks) and resolved as PRs are
+merged one at a time.
+
+## 7. Deliverables checklist (per bot)
+
+- [ ] `docker/automations/bots/<bot>.js` + `<bot>.test.js` (TDD, full scenario coverage)
+- [ ] `config/automations/config.js` — bot registered
+- [ ] `config/grafana/provisioning/alerting/<bot>-alerts.yaml` — derived-threshold rules
+- [ ] `docs/influxdb-schema.md` — new `derived/*` groups documented
+- [ ] `example.env` / `secrets/` — only if new config surfaces (none expected; webhook has in-code default)
+- [ ] Independent review verdict: GOOD TO MERGE (evidence) or FAILURE

--- a/docs/superpowers/specs/2026-07-14-ioniq-tpms-design.md
+++ b/docs/superpowers/specs/2026-07-14-ioniq-tpms-design.md
@@ -1,0 +1,129 @@
+# Ioniq TPMS bot — per-bot design spec
+
+Status: draft · Date: 2026-07-14 · Parent contract:
+[`2026-07-14-ioniq-monitoring-phase3-design.md`](2026-07-14-ioniq-monitoring-phase3-design.md) (§4.3)
+Parent spec: [`docs/ioniq-monitoring-alerting-spec.md`](../../ioniq-monitoring-alerting-spec.md)
+
+## 1. Goal
+
+Reduce the Ioniq's per-wheel tire-pressure telemetry to clean numeric alert inputs on
+`ioniq/parsed/derived/*` that Grafana thresholds trivially. Tire pressure varies with temperature
+(~0.18 psi/°C), so a raw psi reading is not comparable to the 36 psi cold placard. This bot
+temperature-compensates each wheel to a 15 °C reference and derives cross-wheel signals (spread,
+per-wheel temperature excess) that a single InfluxQL threshold cannot express.
+
+## 2. Prod verification (2026-07-14, read-only on routy)
+
+Confirmed against prod InfluxDB (`homy`.`ioniq`):
+- `tpms` carries dotted fields `fl.psi`,`fl.c`,`fr.psi`,`fr.c`,`rl.psi`,`rl.c`,`rr.psi`,`rr.c`
+  (`.c` = °C). Realistic sample: `fl.psi=36.6, fl.c=35`. Cold-normal → `36.6 − 0.18·(35−15) = 33.0`.
+- `state` values seen for `tpms`: `active` (104 samples/30d), `charging` (6), `parked` (5).
+  TPMS refreshes on wheel rotation → the overwhelming majority of fresh data is `active`.
+- Parked/charging rows are **frozen duplicates** (e.g. `fl.psi=36.2` repeated across timestamps) —
+  the sensor holds its last reading, so identical consecutive samples must be de-duplicated.
+- `ambient` carries temp field `c` (e.g. `25`, `26.5`).
+
+## 3. Subscriptions
+
+Exact-match topics (no wildcards), config-overridable:
+- `tpmsTopic` = `ioniq/parsed/tpms`
+- `ambientTopic` = `ioniq/parsed/ambient`
+
+The framework JSON-parses payloads → the bot receives JS objects. The `ambient` handler only caches
+the latest ambient temp; it never emits. The `tpms` handler does all evaluation.
+
+## 4. Logic
+
+### 4.1 Gating (evaluate only fresh, moving samples)
+- Skip any `tpms` sample whose `state !== 'active'`. (Parked/charging TPMS is stale by definition.)
+- Dedupe: hold the last raw `{fl.psi,fl.c,...,rr.psi,rr.c}` tuple in `persistedCache.lastRaw`. If the
+  incoming raw tuple is identical (stable-stringify) to the previous one, skip processing entirely
+  (frozen reading). On a raw tuple that differs from `lastRaw`, set `lastRaw` to it **and then**
+  compute/emit — so `lastRaw` tracks the sensor's raw state even for a changed-but-unusable sample
+  (e.g. all psi missing, which then simply emits nothing). This guarantees each distinct raw reading
+  is processed at most once.
+
+### 4.2 Cold normalization
+Per wheel `w ∈ {fl,fr,rl,rr}`:
+```
+comp_temp_w = (w.c is a finite number) ? w.c : ambient.c    # ambient fallback for compensation
+psi_cold_w  = w.psi − 0.18 · (comp_temp_w − 15)
+```
+Ambient fallback applies **only** to `psi_cold` (any reasonable reference beats none). The
+`temp_excess` signal below uses the wheel's **own measured** temperature only (no ambient
+fallback) — substituting ambient for a dead-sensor wheel would fabricate a meaningless excess.
+If a wheel's `psi` is missing/non-finite, that wheel produces no `psi_cold` signal and is excluded
+from the `tire_spread_psi` calculation. (This does **not** exclude the wheel from `temp_excess`: a
+wheel with a valid temp but a dead pressure cell must still count toward the temperature comparison —
+see §4.3.) If a wheel temp is missing AND no ambient temp is cached, that wheel cannot be
+cold-compensated → it emits no `psi_cold`.
+
+### 4.3 Emitted signals (per fresh, changed, active sample)
+All via `mqtt.publish(topic, { _type:'ioniq', group:'derived/<name>', state, ts, value:<number>, ... })`.
+`state` and `ts` pass through from the `tpms` payload.
+
+- `derived/tire_fl_psi_cold`, `…_fr_…`, `…_rl_…`, `…_rr_…` — one per wheel that has a valid
+  `psi_cold`. `value` = rounded `psi_cold` (2 dp). Extra field: `psi` (raw), `temp` (used temp).
+- `derived/tire_spread_psi` — `max − min` over all wheels that produced a `psi_cold`. Requires ≥ 2
+  valid wheels; otherwise not emitted. `value` = rounded spread (2 dp).
+- `derived/tire_fl_temp_excess` … `_rr_…` — per wheel with a finite **own measured** temp:
+  `value` = `own_temp_w − mean(own temps of the OTHER wheels that have a finite own temp)`, °C,
+  rounded 2 dp. Requires ≥ 1 other wheel with a finite own temp; otherwise not emitted. A wheel
+  whose own temp is missing does not participate even if ambient is cached.
+  (This is the raw °C excess, not a 0/1 flag — keeps the Grafana threshold trivial: `> 8`.)
+
+Numeric rounding uses `Math.round(x*100)/100` to avoid float noise polluting InfluxDB.
+
+## 5. persistedCache
+```
+version: 1
+default: { lastRaw: null }
+```
+`lastRaw` = the last emitted raw tuple as a plain object (`{ 'fl.psi':.., 'fl.c':.., ... }`), used only
+for frozen-duplicate detection across restarts. Cache is non-critical: a reset at worst re-emits one
+already-current sample, which is harmless.
+
+## 6. Grafana rules — `config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml`
+
+Clone the phase-2 shape. `classic_conditions` only; query
+`SELECT last("value") FROM "ioniq" WHERE "group"='derived/<name>' AND time >= now() - 6h`
+(6 h window — TPMS is sparse but a fresh drive lands data; `noDataState: OK` so a parked car is silent).
+Rationale for 6 h (not longer): the derived signals are only trustworthy for the most recent drive;
+after the car sleeps for hours the reading is stale and would false-alarm on a cooled tire, so we
+deliberately let it age out (the driver's own dash TPMS light is the primary safety indicator; this
+alert is a backstop that fires while data is fresh). Every rule MUST set both `noDataState: OK` and
+`execErrState: Alerting`. Every `__expr__` node: `datasource:{type:__expr__,uid:__expr__}`,
+`intervalMs:1000`, `maxDataPoints:43200`, `refId:A`, `hide:false`. Datasource UID `P3C6603E967DC8568`,
+folder `Ioniq EV`, group `interval: 1m`. `🚗` prefix; labels `severity`/`device: ioniq`/`subsystem: tpms`.
+Static annotations. Rules (17 total):
+- per-wheel `psi_cold < 30` **warning** (4) and `< 26` **critical** (4).
+- `tire_spread_psi > 3` **warning** (1).
+- per-wheel `temp_excess > 8` **warning** (4).
+- per-wheel over-inflation `psi_cold > 42` **info** (4).
+
+`for:` — `0s` (TPMS is already sparse and gated to fresh drives; no need to sustain). Note: umbrella §5
+asks group `interval` (1m) ≤ each rule's `for`; `for: 0s` means fire-immediately in Grafana and is
+explicitly sanctioned by the umbrella (§4.2 `aux12v_drop` uses `for: 0s`), so this is intentional.
+
+## 7. Files delivered
+- `docker/automations/bots/ioniq-tpms.js` + `.test.js`
+- `config/automations/config.js` — `ioniqTpms` registration appended near `ioniqDtc`
+- `config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml`
+- `docs/influxdb-schema.md` — document the new `derived/tire_*` groups
+
+## 8. Test scenarios (TDD)
+- subscribes to both configured topics
+- cold-normalization math per wheel using own `.c`
+- ambient fallback when a wheel temp missing
+- active-only gating: `parked`/`charging` samples emit nothing
+- frozen-duplicate dedupe: identical consecutive active sample emits nothing; a changed one emits
+- four per-wheel `psi_cold` signals, correct topics + payload shape (`_type`, group, state, ts, value)
+- spread = max−min of cold pressures; needs ≥2 wheels
+- temp_excess per wheel = wheel − mean(other three); each wheel independently
+- missing-wheel / partial payload: absent psi → no signal for that wheel, others still emit
+- wheel temp missing AND no ambient cached → that wheel emits no `psi_cold`; temp_excess also absent
+- single valid wheel only → neither `tire_spread_psi` nor any `temp_excess` emitted
+- a wheel with valid temp but missing psi still counts toward other wheels' `temp_excess`
+- non-finite `ambient.c` payload is ignored (not used as a fallback)
+- payload shape assertions (`_type:'ioniq'`, `group`, numeric `value`)
+- persistedCache survives across restart (lastRaw pre-seeded → dedupe holds)


### PR DESCRIPTION
## What

Adds the **`ioniq-tpms`** automations bot (phase-3 umbrella §4.3) that reduces the Ioniq's per-wheel TPMS telemetry to clean numeric alert inputs on `ioniq/parsed/derived/*`, plus its Grafana rules, config registration, and InfluxDB schema docs.

Emits per fresh, changed, `active` TPMS sample:
- `derived/tire_<w>_psi_cold` (×4) — pressure temperature-compensated to 15 °C: `psi − 0.18·(temp−15)`, using the wheel's own temp, ambient fallback for the compensation only.
- `derived/tire_spread_psi` — max−min of the four cold pressures.
- `derived/tire_<w>_temp_excess` (×4) — wheel's own temp − mean(other wheels' own temps), °C. Uses **measured** temps only (no ambient fallback) so a dead-sensor wheel can't fabricate an excess.

## Why

Raw psi isn't comparable to the 36 psi cold placard (pressure rises ~0.18 psi/°C), and cross-wheel spread / temperature-excess logic can't be expressed in a single InfluxQL threshold. The bot pushes the math into JS so Grafana alerts stay trivial.

TPMS only refreshes on wheel rotation, so evaluation is gated to `state==='active'` and frozen/duplicate raw readings are de-duplicated via `persistedCache.lastRaw` (holds across restart).

## Prod evidence (read-only, routy InfluxDB, 2026-07-14)
- Confirmed dotted fields `fl.psi`/`fl.c`/…/`rr.c` on `group='tpms'` (e.g. `fl.psi=36.6, fl.c=35` → cold `33.0`), and `c` on `group='ambient'`.
- `state` distribution over 30 d: active=104, charging=6, parked=5 → active-only gating is correct.
- Parked/charging rows are **frozen duplicates** (repeated readings) → dedupe is required.

## Grafana rules — `config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml`
17 `classic_conditions` rules (subsystem `tpms`), cloning the phase-2 shape: explicit `time >= now() - 6h`, `noDataState: OK`, `execErrState: Alerting`, datasource `P3C6603E967DC8568`, folder `Ioniq EV`, group `interval: 1m`, full `__expr__` node models, 🚗 prefix, static annotations.
- per-wheel `psi_cold < 30` warn (4) / `< 26` crit (4)
- `tire_spread_psi > 3` warn (1)
- per-wheel `temp_excess > 8` warn (4)
- per-wheel over-inflation `psi_cold > 42` info (4)

## Test evidence
- 20 TDD unit tests for the bot (cold-normalization math, ambient fallback, active-only gating, frozen dedupe incl. restart, spread, per-wheel temp_excess with measured-temp-only semantics, partial/missing-wheel payloads, payload shape).
- Full automations suite green: **14 suites / 415 tests**.
- `config.js` loads; alert YAML parses (17 rules, unique UIDs, correct severity split).

## Review verdict
Independent fresh-subagent gates: spec/plan review (CHANGES-REQUESTED → addressed), whole-branch review (**APPROVED**, math/dedupe/YAML independently re-verified; one semantic nit on temp_excess ambient fallback was fixed in this branch).

## Note for reviewers
This branch is based on the phase-3 umbrella design commit (`docs(ioniq): Phase 3 computation-bots umbrella design`), which is shared groundwork for all three phase-3 bot PRs and is **not yet on `master`**. It appears in this diff and will drop out once it (or a sibling PR) lands. The tpms-specific changes are the 7 files in the top commit.

https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN