### PR TITLE
feat(ioniq): cell-health bot — derived cell/module spread signals + Grafana rules

### DIFF
--- a/config/automations/config.js
+++ b/config/automations/config.js
@@ -489,6 +489,18 @@ module.exports = {
       tpmsTopic: 'ioniq/parsed/tpms',
       ambientTopic: 'ioniq/parsed/ambient',
     },
+    ioniqCellHealth: {
+      type: 'ioniq-cell-health',
+      cellTopics: [
+        'ioniq/parsed/cells/1',
+        'ioniq/parsed/cells/33',
+        'ioniq/parsed/cells/65',
+      ],
+      moduleTemp1Topic: 'ioniq/parsed/bms/2101',
+      moduleTemp2Topic: 'ioniq/parsed/bms/2105',
+      cellSpreadOutputTopic: 'ioniq/parsed/derived/cell_spread_mv',
+      moduleTempSpreadOutputTopic: 'ioniq/parsed/derived/module_temp_spread_c',
+    },
   },
   gates: {
     mqtt: {

--- a/config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml
@@ -1,0 +1,155 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq Cell Health Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-cell-spread-warning
+        title: "🚗 Ioniq Cell Spread High (warning)"
+        condition: A
+        data:
+          - refId: spread
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/cell_spread_mv' AND time >= now() - 30m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [50] }
+                  operator: { type: and }
+                  query: { params: [spread] }
+                  reducer: { type: last }
+                  type: query
+              expression: spread
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Cell voltage spread {{ $values.spread.Value }} mV at rest (> 50 mV)"
+          description: "Rest cell-voltage spread is elevated (baseline ~20 mV). A widening spread points to a weakening cell; check the outlier cell index on the derived/cell_spread_mv series."
+
+      - uid: ioniq-cell-spread-critical
+        title: "🚗 Ioniq Cell Spread Critical"
+        condition: A
+        data:
+          - refId: spread
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/cell_spread_mv' AND time >= now() - 30m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [100] }
+                  operator: { type: and }
+                  query: { params: [spread] }
+                  reducer: { type: last }
+                  type: query
+              expression: spread
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Cell voltage spread {{ $values.spread.Value }} mV at rest (> 100 mV)"
+          description: "Rest cell-voltage spread is critically high. A cell is likely failing — inspect the outlier cell and have the pack serviced."
+
+      - uid: ioniq-module-temp-spread-warning
+        title: "🚗 Ioniq Module Temp Spread High (warning)"
+        condition: A
+        data:
+          - refId: spread
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/module_temp_spread_c' AND time >= now() - 30m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [8] }
+                  operator: { type: and }
+                  query: { params: [spread] }
+                  reducer: { type: last }
+                  type: query
+              expression: spread
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: warning, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Battery module temperature spread {{ $values.spread.Value }} °C (> 8 °C)"
+          description: "Module temperatures are diverging (baseline ~2 °C). Uneven cooling or a hot module — watch for a rising trend."
+
+      - uid: ioniq-module-temp-spread-critical
+        title: "🚗 Ioniq Module Temp Spread Critical"
+        condition: A
+        data:
+          - refId: spread
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/module_temp_spread_c' AND time >= now() - 30m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [15] }
+                  operator: { type: and }
+                  query: { params: [spread] }
+                  reducer: { type: last }
+                  type: query
+              expression: spread
+        noDataState: OK
+        execErrState: Alerting
+        for: 10m
+        labels: { severity: critical, device: ioniq, subsystem: battery }
+        annotations:
+          summary: "🚗 Battery module temperature spread {{ $values.spread.Value }} °C (> 15 °C)"
+          description: "Module temperature spread is critically high. Risk of a thermal fault in one module — stop charging/driving and have the battery inspected."

--- a/docker/automations/bots/ioniq-cell-health.js
+++ b/docker/automations/bots/ioniq-cell-health.js
@@ -1,0 +1,134 @@
+// ioniq-cell-health: reduces raw per-segment cell-voltage and module-temperature
+// frames into pack-level derived signals (derived/cell_spread_mv,
+// derived/module_temp_spread_c) that Grafana can alert on with a plain
+// classic_conditions threshold, instead of expressing 96-cell array math and
+// cross-frame merges in InfluxQL.
+
+// The framework JSON-parses the MQTT envelope, but the cells/module_temps
+// fields inside carry their own JSON-string-encoded float arrays. Tolerate an
+// already-parsed array too (defensive, mirrors ioniq-dtc's parseCodes) so a
+// delivery quirk can't silently corrupt a segment.
+function parseFloatArray (raw, expectedLen) {
+  let arr = raw
+  if (typeof arr === 'string') {
+    try {
+      arr = JSON.parse(arr)
+    } catch (err) {
+      return null
+    }
+  } else if (!Array.isArray(arr)) {
+    return null
+  }
+  if (!Array.isArray(arr) || arr.length !== expectedLen || !arr.every(Number.isFinite)) {
+    return null
+  }
+  return arr
+}
+
+// Round to 0.1 to strip binary floating-point noise (e.g. (3.70-3.64)*1000 =
+// 60.00000000000006) from the value written to InfluxDB and rendered in the
+// Grafana annotation. 0.1 keeps well below the ~10 mV / ~0.1 °C sensor
+// granularity, so no meaningful precision is lost.
+function round1 (n) {
+  return Math.round(n * 10) / 10
+}
+
+module.exports = function createIoniqCellHealth (name, config) {
+  const cellTopics = config.cellTopics || [
+    'ioniq/parsed/cells/1',
+    'ioniq/parsed/cells/33',
+    'ioniq/parsed/cells/65'
+  ]
+  const moduleTemp1Topic = config.moduleTemp1Topic || 'ioniq/parsed/bms/2101'
+  const moduleTemp2Topic = config.moduleTemp2Topic || 'ioniq/parsed/bms/2105'
+  const cellSpreadOutputTopic = config.cellSpreadOutputTopic || 'ioniq/parsed/derived/cell_spread_mv'
+  const moduleTempSpreadOutputTopic = config.moduleTempSpreadOutputTopic || 'ioniq/parsed/derived/module_temp_spread_c'
+  const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
+
+  // The three cells/* topics map 1:1 to persistedCache.seg0/seg1/seg2 in
+  // array order (topic index 0 -> cells 1-32, 1 -> 33-64, 2 -> 65-96).
+  const segKeys = ['seg0', 'seg1', 'seg2']
+
+  return {
+    persistedCache: {
+      version: 1,
+      // Holds the last-known-good parsed array per segment. null means "not
+      // yet received" (or "never a good value") — a bad frame never
+      // overwrites a good one.
+      default: { seg0: null, seg1: null, seg2: null, moduleTemps: null, moduleTemps6_12: null }
+    },
+
+    start: async ({ mqtt, persistedCache }) => {
+      const handleCells = (segKey) => (payload) => {
+        const parsed = parseFloatArray(payload && payload.cells, 32)
+        if (parsed === null) {
+          log(`rejected malformed cells frame for ${segKey}, keeping prior segment`)
+          return
+        }
+        persistedCache[segKey] = parsed
+
+        // Rest-spread only: a moving pack under load skews cell voltages, so
+        // only parked/charging samples are meaningful here.
+        if (payload.state === 'active') return
+
+        const { seg0, seg1, seg2 } = persistedCache
+        if (seg0 === null || seg1 === null || seg2 === null) return
+
+        const cells = seg0.concat(seg1, seg2)
+        const max = Math.max(...cells)
+        const min = Math.min(...cells)
+        const mean = cells.reduce((sum, cell) => sum + cell, 0) / cells.length
+
+        // 1-based index of the cell furthest from the pack mean; ties resolve
+        // to the lowest index. outlierIndex defaults to 1 — arbitrary but
+        // harmless — when the pack is perfectly balanced (value 0, every
+        // cell tied at zero deviation).
+        let outlierIndex = 1
+        let maxDeviation = -Infinity
+        cells.forEach((cell, i) => {
+          const deviation = Math.abs(cell - mean)
+          if (deviation > maxDeviation) {
+            maxDeviation = deviation
+            outlierIndex = i + 1
+          }
+        })
+
+        mqtt.publish(cellSpreadOutputTopic, {
+          _type: 'ioniq',
+          group: 'derived/cell_spread_mv',
+          state: payload.state,
+          ts: payload.ts,
+          value: round1((max - min) * 1000),
+          outlierIndex
+        })
+      }
+
+      const handleModuleTemps = (segKey, expectedLen, field) => (payload) => {
+        const parsed = parseFloatArray(payload && payload[field], expectedLen)
+        if (parsed === null) {
+          log(`rejected malformed ${field} frame, keeping prior segment`)
+          return
+        }
+        persistedCache[segKey] = parsed
+
+        const { moduleTemps, moduleTemps6_12 } = persistedCache
+        if (moduleTemps === null || moduleTemps6_12 === null) return
+
+        const temps = moduleTemps.concat(moduleTemps6_12)
+        mqtt.publish(moduleTempSpreadOutputTopic, {
+          _type: 'ioniq',
+          group: 'derived/module_temp_spread_c',
+          state: payload.state,
+          ts: payload.ts,
+          value: round1(Math.max(...temps) - Math.min(...temps))
+        })
+      }
+
+      await Promise.all([
+        ...cellTopics.map((topic, index) => mqtt.subscribe(topic, handleCells(segKeys[index]))),
+        mqtt.subscribe(moduleTemp1Topic, handleModuleTemps('moduleTemps', 5, 'module_temps')),
+        mqtt.subscribe(moduleTemp2Topic, handleModuleTemps('moduleTemps6_12', 7, 'module_temps_6_12'))
+      ])
+    }
+  }
+}

--- a/docker/automations/bots/ioniq-cell-health.test.js
+++ b/docker/automations/bots/ioniq-cell-health.test.js
@@ -1,0 +1,223 @@
+const { beforeEach, describe, expect, it, jest } = require('@jest/globals')
+const createIoniqCellHealth = require('./ioniq-cell-health')
+
+const CELLS1 = 'ioniq/parsed/cells/1'
+const CELLS33 = 'ioniq/parsed/cells/33'
+const CELLS65 = 'ioniq/parsed/cells/65'
+const BMS2101 = 'ioniq/parsed/bms/2101'
+const BMS2105 = 'ioniq/parsed/bms/2105'
+const CELL_SPREAD_OUT = 'ioniq/parsed/derived/cell_spread_mv'
+const MODULE_TEMP_SPREAD_OUT = 'ioniq/parsed/derived/module_temp_spread_c'
+
+function makeMqtt () {
+  const mqtt = {
+    _callbacks: {},
+    subscribe: jest.fn().mockImplementation((topic, cb) => {
+      mqtt._callbacks[topic] = cb
+      return Promise.resolve()
+    }),
+    publish: jest.fn().mockResolvedValue(),
+    _trigger: (topic, message) =>
+      mqtt._callbacks[topic] ? mqtt._callbacks[topic](message) : undefined
+  }
+  return mqtt
+}
+
+function makeCache () {
+  return { seg0: null, seg1: null, seg2: null, moduleTemps: null, moduleTemps6_12: null }
+}
+
+const config = {
+  cellTopics: [CELLS1, CELLS33, CELLS65],
+  moduleTemp1Topic: BMS2101,
+  moduleTemp2Topic: BMS2105,
+  cellSpreadOutputTopic: CELL_SPREAD_OUT,
+  moduleTempSpreadOutputTopic: MODULE_TEMP_SPREAD_OUT
+}
+
+// 32 identical cell voltages, used as the "balanced segment" baseline in
+// most tests so spread math is easy to reason about.
+function flatSegment (value = 3.64) {
+  return new Array(32).fill(value)
+}
+
+describe('ioniq-cell-health bot — subscriptions', () => {
+  it('subscribes to all five exact topics', async () => {
+    const mqtt = makeMqtt()
+    const bot = createIoniqCellHealth('ioniq-cell-health', config)
+    await bot.start({ mqtt, persistedCache: makeCache() })
+    expect(mqtt.subscribe).toHaveBeenCalledWith(CELLS1, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(CELLS33, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(CELLS65, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(BMS2101, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(BMS2105, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledTimes(5)
+  })
+})
+
+describe('ioniq-cell-health bot — cell_spread_mv', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(async () => {
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    bot = createIoniqCellHealth('ioniq-cell-health', config)
+    await bot.start({ mqtt, persistedCache })
+  })
+
+  it('reassembles the full 96-cell pack and computes spread/outlier across a segment boundary', async () => {
+    const seg0 = flatSegment()
+    const seg1 = flatSegment()
+    const seg2 = flatSegment()
+    // Cell 70 = seg2[5] (65 + 5 = 70), the outlier.
+    seg2[5] = 3.70
+
+    await mqtt._trigger(CELLS1, { cells: JSON.stringify(seg0), state: 'parked', ts: 1000 })
+    await mqtt._trigger(CELLS33, { cells: JSON.stringify(seg1), state: 'parked', ts: 1000 })
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg2), state: 'parked', ts: 1000 })
+
+    // (3.70 - 3.64) * 1000 = 60.00000000000006 raw; the bot rounds to 0.1 mV.
+    expect(mqtt.publish).toHaveBeenLastCalledWith(CELL_SPREAD_OUT, {
+      _type: 'ioniq',
+      group: 'derived/cell_spread_mv',
+      state: 'parked',
+      ts: 1000,
+      value: 60,
+      outlierIndex: 70
+    })
+  })
+
+  it('skips emission while active, then emits on a subsequent parked sample', async () => {
+    const seg = flatSegment()
+    await mqtt._trigger(CELLS1, { cells: JSON.stringify(seg), state: 'active', ts: 1 })
+    await mqtt._trigger(CELLS33, { cells: JSON.stringify(seg), state: 'active', ts: 1 })
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg), state: 'active', ts: 1 })
+    expect(mqtt.publish).not.toHaveBeenCalledWith(CELL_SPREAD_OUT, expect.anything())
+
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg), state: 'parked', ts: 2 })
+    expect(mqtt.publish).toHaveBeenCalledWith(CELL_SPREAD_OUT, expect.objectContaining({ state: 'parked', ts: 2 }))
+  })
+
+  it('emits for charging state too (only active is skipped)', async () => {
+    const seg = flatSegment()
+    await mqtt._trigger(CELLS1, { cells: JSON.stringify(seg), state: 'charging', ts: 1 })
+    await mqtt._trigger(CELLS33, { cells: JSON.stringify(seg), state: 'charging', ts: 1 })
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg), state: 'charging', ts: 1 })
+    expect(mqtt.publish).toHaveBeenCalledWith(CELL_SPREAD_OUT, expect.objectContaining({ state: 'charging', value: 0 }))
+  })
+
+  it('does not emit until all three segments have arrived', async () => {
+    const seg = flatSegment()
+    await mqtt._trigger(CELLS1, { cells: JSON.stringify(seg), state: 'parked', ts: 1 })
+    expect(mqtt.publish).not.toHaveBeenCalled()
+
+    await mqtt._trigger(CELLS33, { cells: JSON.stringify(seg), state: 'parked', ts: 2 })
+    expect(mqtt.publish).not.toHaveBeenCalled()
+
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg), state: 'parked', ts: 3 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['non-JSON string', 'not-json{{{'],
+    ['wrong length (31)', JSON.stringify(flatSegment().slice(0, 31))],
+    ['non-array', JSON.stringify({ not: 'an array' })],
+    ['NaN element', JSON.stringify([...flatSegment().slice(0, 31), null])]
+  ])('rejects a malformed cells frame (%s) and keeps the prior good segment, with no emission from the bad frame', async (_label, badCells) => {
+    const seg = flatSegment()
+    await mqtt._trigger(CELLS1, { cells: JSON.stringify(seg), state: 'parked', ts: 1 })
+    await mqtt._trigger(CELLS33, { cells: JSON.stringify(seg), state: 'parked', ts: 1 })
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg), state: 'parked', ts: 1 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+    mqtt.publish.mockClear()
+
+    // Corrupt segment 1 (CELLS33) — must not emit at all for this bad frame.
+    await mqtt._trigger(CELLS33, { cells: badCells, state: 'parked', ts: 2 })
+    expect(mqtt.publish).not.toHaveBeenCalled()
+
+    // A subsequent good frame on any topic re-triggers emission using the
+    // retained (prior good) segment 1 — never NaN.
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg), state: 'parked', ts: 3 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+    const published = mqtt.publish.mock.calls[0][1]
+    expect(Number.isNaN(published.value)).toBe(false)
+    expect(published.value).toBe(0)
+  })
+
+  it('breaks an outlier tie by choosing the lowest index', async () => {
+    const seg0 = flatSegment()
+    seg0[4] = 3.70 // cell 5 (1-based)
+    seg0[9] = 3.70 // cell 10 (1-based), tied deviation from mean
+    const seg1 = flatSegment()
+    const seg2 = flatSegment()
+
+    await mqtt._trigger(CELLS1, { cells: JSON.stringify(seg0), state: 'parked', ts: 1 })
+    await mqtt._trigger(CELLS33, { cells: JSON.stringify(seg1), state: 'parked', ts: 1 })
+    await mqtt._trigger(CELLS65, { cells: JSON.stringify(seg2), state: 'parked', ts: 1 })
+
+    expect(mqtt.publish).toHaveBeenCalledWith(CELL_SPREAD_OUT, expect.objectContaining({ outlierIndex: 5 }))
+  })
+})
+
+describe('ioniq-cell-health bot — module_temp_spread_c', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(async () => {
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    bot = createIoniqCellHealth('ioniq-cell-health', config)
+    await bot.start({ mqtt, persistedCache })
+  })
+
+  it('merges the 5+7 module temps and computes max-min, passing through state/ts and _type/group', async () => {
+    const moduleTemps = [30, 31, 29, 30, 30]
+    const moduleTemps6_12 = [30, 30, 33, 30, 30, 30, 28]
+
+    await mqtt._trigger(BMS2101, { module_temps: JSON.stringify(moduleTemps), state: 'parked', ts: 500 })
+    await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'parked', ts: 501 })
+
+    expect(mqtt.publish).toHaveBeenLastCalledWith(MODULE_TEMP_SPREAD_OUT, {
+      _type: 'ioniq',
+      group: 'derived/module_temp_spread_c',
+      state: 'parked',
+      ts: 501,
+      value: 33 - 28
+    })
+  })
+
+  it('emits even when state is active (no active-skip for module temps)', async () => {
+    const moduleTemps = [30, 30, 30, 30, 30]
+    const moduleTemps6_12 = [30, 30, 30, 30, 30, 30, 30]
+    await mqtt._trigger(BMS2101, { module_temps: JSON.stringify(moduleTemps), state: 'active', ts: 1 })
+    await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'active', ts: 1 })
+
+    expect(mqtt.publish).toHaveBeenCalledWith(MODULE_TEMP_SPREAD_OUT,
+      expect.objectContaining({ state: 'active', value: 0 }))
+  })
+
+  it('does not emit until both module-temp frames have arrived', async () => {
+    const moduleTemps = [30, 30, 30, 30, 30]
+    await mqtt._trigger(BMS2101, { module_temps: JSON.stringify(moduleTemps), state: 'parked', ts: 1 })
+    expect(mqtt.publish).not.toHaveBeenCalled()
+
+    const moduleTemps6_12 = [30, 30, 30, 30, 30, 30, 30]
+    await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'parked', ts: 2 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a malformed module_temps frame, keeps the prior good segment, and does not emit for the bad frame', async () => {
+    const moduleTemps = [30, 31, 29, 30, 30]
+    const moduleTemps6_12 = [30, 30, 33, 30, 30, 30, 28]
+    await mqtt._trigger(BMS2101, { module_temps: JSON.stringify(moduleTemps), state: 'parked', ts: 1 })
+    await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'parked', ts: 1 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+    mqtt.publish.mockClear()
+
+    // wrong length (4 instead of 5) — rejected, no emission from this frame
+    await mqtt._trigger(BMS2101, { module_temps: JSON.stringify([30, 31, 29, 30]), state: 'parked', ts: 2 })
+    expect(mqtt.publish).not.toHaveBeenCalled()
+
+    // retrigger with the other good topic — should use retained good moduleTemps
+    await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'parked', ts: 3 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+    expect(mqtt.publish).toHaveBeenCalledWith(MODULE_TEMP_SPREAD_OUT, expect.objectContaining({ value: 33 - 28 }))
+  })
+})

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -204,6 +204,17 @@ query this measurement's `v` field. See
   - `derived/tire_<w>_temp_excess` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — `ioniq-tpms`: `value` = wheel
     temperature minus the mean temperature of the other three wheels (°C). Grafana
     `ioniq-tpms-<w>-temp-excess` alerts on `value > 8`.
+  - `derived/cell_spread_mv` — a bot-produced `group` value (not from the logger): the
+    `ioniq-cell-health` automations bot reassembles the 96-cell pack (from `cells/1`, `cells/33`,
+    `cells/65`) and publishes field `value` = `(max − min) · 1000` in mV (rest spread; emitted only
+    when `state` is `parked`/`charging`, skipped while `active`), plus field `outlierIndex` = the
+    1-based cell index (1–96) furthest from the pack mean. Grafana's `ioniq-cell-spread-*` rules alert
+    on `value > 50` (warning) / `> 100` (critical).
+  - `derived/module_temp_spread_c` — a bot-produced `group` value (not from the logger): the
+    `ioniq-cell-health` automations bot merges the 12 battery module temperatures (`module_temps`[5]
+    from `bms/2101` + `module_temps_6_12`[7] from `bms/2105`) and publishes field `value` =
+    `max − min` in °C. Grafana's `ioniq-module-temp-spread-*` rules alert on `value > 8` (warning) /
+    `> 15` (critical).
 - `state`: vehicle state (`active` / `parked` / `charging` / …), from `payload.state` — low-cardinality, what dashboards filter/group by
 **Timestamp**: `payload.ts` (epoch ms), written at `ms` precision
 **Fields**: every payload key except `_type`, `group`, `state`, `ts`:

--- a/docs/superpowers/plans/2026-07-14-ioniq-cell-health.md
+++ b/docs/superpowers/plans/2026-07-14-ioniq-cell-health.md
@@ -1,0 +1,58 @@
+# Implementation Plan — `ioniq-cell-health` bot
+
+Spec: [`../specs/2026-07-14-ioniq-cell-health-design.md`](../specs/2026-07-14-ioniq-cell-health-design.md)
+· Contract: [`../specs/2026-07-14-ioniq-monitoring-phase3-design.md`](../specs/2026-07-14-ioniq-monitoring-phase3-design.md)
+Branch: `feat/ioniq-cell-health` (isolated worktree)
+
+## Preconditions (done)
+
+- [x] Prod-verified all five topic strings live (`mosquitto_sub`) + field shapes (InfluxDB).
+- [x] Spec + plan written; independent spec/plan review before coding.
+
+## Task 1 — Bot (TDD, red → green → refactor)
+
+1. Write `docker/automations/bots/ioniq-cell-health.test.js` first (fails: no module). Cover the 9
+   scenarios in spec §7 using the mocked-MQTT pattern from `ioniq-dtc.test.js` (`makeMqtt` with
+   `_callbacks`/`_trigger`, plain-object `persistedCache`).
+2. Implement `docker/automations/bots/ioniq-cell-health.js`:
+   - `module.exports = (name, config) => ({ persistedCache: { version:1, default:{…} }, start })`.
+   - Config defaults per spec §4; `persistedCache.default` holds `cellSegments` (3 nullable arrays keyed
+     by segment index 0/33/65 or a `{seg1,seg33,seg65}` object) + `moduleTemps`/`moduleTemps6_12`.
+   - Helper `parseFloatArray(raw, expectedLen)` → array or `null` (JSON.parse guard, Array.isArray,
+     length check, `Number.isFinite` on every element). Mirror `ioniq-dtc`'s `parseCodes` tolerance.
+   - Cell handler: update segment, emit `cell_spread_mv` when all 3 present and `state !== 'active'`.
+   - Temp handler: update segment, emit `module_temp_spread_c` when both present.
+   - Outlier index: 1-based argmax of `|cell − mean|`, lowest index on tie.
+3. Run `cd docker/automations && npm ci && npx jest bots/ioniq-cell-health.test.js` → green.
+4. Independent per-task review (fresh subagent). Address findings.
+
+## Task 2 — Register bot in `config/automations/config.js`
+
+- Append `ioniqCellHealth` block immediately after the `ioniqDtc` block (~line 486). Selective edit,
+  no reformatting.
+
+## Task 3 — Grafana rules `config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml`
+
+- Clone `ioniq-12v-alerts.yaml`; four rules per spec §5. Validate YAML parses.
+
+## Task 4 — `docs/influxdb-schema.md`
+
+- Under the `ioniq` measurement `group` list, add `derived/cell_spread_mv` and
+  `derived/module_temp_spread_c` bullets following the `derived/dtc_count` pattern (field `value` = the
+  numeric signal; `cell_spread_mv` extra field `outlierIndex`).
+
+## Task 5 — Whole-branch review + PR
+
+- Fresh whole-branch review (opus). Address findings.
+- Full test run `cd docker/automations && npm test` green; confirm no `MODULE_NOT_FOUND` for the new bot
+  in the config load path (config registration resolves the type).
+- Commit selectively (spec/plan; bot+test; config; grafana; schema) with `Claude-Session` trailer.
+- Push, `gh pr create` (base master), title per orchestrator brief. Fresh PR review → verdict.
+
+## Risks / notes
+
+- `cells/*` frames are high-rate; emitting on every frame is acceptable (matches `dtc_count` cadence,
+  Grafana reads `last`). Active-skip prevents driving-noise from polluting the rest-spread signal.
+- Do not overwrite a good segment with a malformed one — retention is essential so a single bad frame
+  can't zero the signal.
+</content>

--- a/docs/superpowers/specs/2026-07-14-ioniq-cell-health-design.md
+++ b/docs/superpowers/specs/2026-07-14-ioniq-cell-health-design.md
@@ -1,0 +1,118 @@
+# Ioniq `ioniq-cell-health` bot — Design Spec
+
+Status: draft for review · Date: 2026-07-14 · Parent contract:
+[`2026-07-14-ioniq-monitoring-phase3-design.md`](2026-07-14-ioniq-monitoring-phase3-design.md) §4.1
+· Reference bot: [`docker/automations/bots/ioniq-dtc.js`](../../../docker/automations/bots/ioniq-dtc.js)
+
+## 1. Purpose
+
+Reduce two battery-health conditions that Grafana/InfluxQL express poorly (96-cell array math,
+cross-frame merge) into trivial numeric derived signals the `mqtt-influx-ioniq` bridge writes to
+InfluxDB, where Grafana alerts on them with a plain `classic_conditions` threshold:
+
+- `derived/cell_spread_mv` — pack cell-voltage spread in millivolts at rest, plus the outlier cell index.
+- `derived/module_temp_spread_c` — battery module temperature spread across all 12 modules, in °C.
+
+## 2. Prod-verified data shapes (2026-07-14, read-only routy queries + live `mosquitto_sub`)
+
+All five source topics confirmed live on prod and their field shapes verified against InfluxDB:
+
+| Topic | Field | Shape | Cells/modules |
+| --- | --- | --- | --- |
+| `ioniq/parsed/cells/1` | `cells` | JSON string, 32 floats e.g. `"[3.64,3.64,…]"` | cells 1–32 |
+| `ioniq/parsed/cells/33` | `cells` | JSON string, 32 floats | cells 33–64 |
+| `ioniq/parsed/cells/65` | `cells` | JSON string, 32 floats | cells 65–96 |
+| `ioniq/parsed/bms/2101` | `module_temps` | JSON string, 5 floats e.g. `"[30,30,30,30,30]"` | modules 1–5 |
+| `ioniq/parsed/bms/2105` | `module_temps_6_12` | JSON string, 7 floats | modules 6–12 |
+
+`state` tag values seen: `active`, `parked`, `charging`. Each payload also carries `state` and `ts`
+fields (pass-through per §3 convention). The framework JSON-parses the MQTT payload, so the bot
+receives a JS object whose `cells`/`module_temps`/`module_temps_6_12` values are **strings** that must
+be `JSON.parse`d and guarded. (The `cells/1` prod sample confirmed the payload carries its own `state`
+and `ts`.)
+
+## 3. Behaviour
+
+The bot follows the repo pattern `module.exports = (name, config) => ({ persistedCache, start })`,
+exact-match topic subscriptions (config-overridable), and mocked-MQTT Jest tests.
+
+### 3.1 `derived/cell_spread_mv`
+
+- Reassemble the 96-cell array from the three `cells` segments (1→1-32, 33→33-64, 65→65-96). Each
+  segment's last-known parsed array is held in `persistedCache` so a signal can be emitted whenever
+  **any** of the three arrives while all three segments are present.
+- On each incoming `cells/*` sample, update that segment, then if all three segments are present:
+  compute `spread = (max − min) · 1000` mV over the 96 values; `outlierIndex` = the 1-based cell index
+  whose value is furthest from the pack mean (`argmax |cell − mean|`, ties → lowest index).
+- **Skip emission when `state === 'active'`** — this is a rest-spread signal; only emit for
+  `parked`/`charging`. State/ts are taken from the triggering `cells/*` sample.
+- Publish object: `{ _type:'ioniq', group:'derived/cell_spread_mv', state, ts, value:spread,
+  outlierIndex }`.
+- **Guards:** a segment that fails `JSON.parse`, is not an array, has the wrong length (≠ 32), or holds
+  a non-finite value is rejected — the prior good segment is retained (not overwritten with garbage).
+  If fewer than three good segments exist, no emission.
+
+`bms/2101` is **not** a cell-spread source (only a module-temp source); cell frames carry their own
+state/ts (verified in prod sample), so cell-spread is driven entirely by the `cells/*` frames.
+
+### 3.2 `derived/module_temp_spread_c`
+
+- Hold last-known parsed `module_temps` (5) and `module_temps_6_12` (7) in `persistedCache`.
+- On each `bms/2101` or `bms/2105` sample, update that segment, then if both present: merge into 12
+  module temps, compute `value = max − min` °C; publish `{ _type:'ioniq',
+  group:'derived/module_temp_spread_c', state, ts, value }` using the triggering sample's state/ts. No
+  active-skip (temperature spread matters at all states).
+- **Guards:** same JSON/array/length (5 and 7)/finite guards; retain prior good segment on garbage; no
+  emission until both present.
+
+## 4. Config surface
+
+```js
+ioniqCellHealth: {
+  type: 'ioniq-cell-health',
+  cellTopics: ['ioniq/parsed/cells/1', 'ioniq/parsed/cells/33', 'ioniq/parsed/cells/65'],
+  moduleTemp1Topic: 'ioniq/parsed/bms/2101',
+  moduleTemp2Topic: 'ioniq/parsed/bms/2105',
+  cellSpreadOutputTopic: 'ioniq/parsed/derived/cell_spread_mv',
+  moduleTempSpreadOutputTopic: 'ioniq/parsed/derived/module_temp_spread_c',
+}
+```
+
+All topics have in-code defaults matching the above; no new env vars or secrets.
+
+## 5. Grafana rules — `config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml`
+
+Four rules (each warn/crit a separate rule), cloning the `ioniq-12v-alerts.yaml` shape:
+
+| uid | signal | evaluator | severity | for |
+| --- | --- | --- | --- | --- |
+| `ioniq-cell-spread-warning` | `cell_spread_mv` | `gt 50` | warning | 10m |
+| `ioniq-cell-spread-critical` | `cell_spread_mv` | `gt 100` | critical | 10m |
+| `ioniq-module-temp-spread-warning` | `module_temp_spread_c` | `gt 8` | warning | 10m |
+| `ioniq-module-temp-spread-critical` | `module_temp_spread_c` | `gt 15` | critical | 10m |
+
+Each: `SELECT last("value") FROM "ioniq" WHERE "group"='derived/<name>' AND time >= now() - <window>`
+(window 30m ≥ `for` 10m), datasource `P3C6603E967DC8568`, folder `Ioniq EV`, group `interval: 1m`,
+`noDataState: OK`, `execErrState: Alerting`, full `__expr__` node model, `🚗` in title/summary, labels
+`severity`/`device: ioniq`/`subsystem: battery`, static annotation text (`{{ $values.A.Value }}` for
+the number only).
+
+## 6. Deliverables
+
+- `docker/automations/bots/ioniq-cell-health.js` + `.test.js`
+- `config/automations/config.js` — `ioniqCellHealth` registered next to `ioniqDtc`
+- `config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml`
+- `docs/influxdb-schema.md` — document `derived/cell_spread_mv` + `derived/module_temp_spread_c`
+
+## 7. Test scenarios (TDD)
+
+1. Subscribes to all five exact topics.
+2. Full 96-cell reassembly from three segments → correct `value` (mV) and `outlierIndex`.
+3. `state === 'active'` → cell-spread emission skipped; `parked`/`charging` → emitted.
+4. Partial data: only 1 or 2 segments present → no cell-spread emission; third arrival triggers it.
+5. Malformed/short/non-array/`NaN` segment → rejected, prior good segment retained, no bad emission.
+6. Module temp merge (5 + 7 = 12) → `max − min`; no active-skip.
+7. Module temp partial-data holding; malformed guard.
+8. Payload shape: `_type:'ioniq'`, correct `group`, `state`/`ts` pass-through, numeric `value`.
+9. Outlier index tie-break (lowest index) and 1-based indexing across segment boundaries.
+</content>


### PR DESCRIPTION
## What

Adds the **`ioniq-cell-health`** automations bot (Phase 3 §4.1 of the umbrella contract), which reduces two EV battery-health conditions that Grafana/InfluxQL express poorly into trivial numeric derived signals:

- **`derived/cell_spread_mv`** — reassembles the 96-cell pack from the three `cells/*` segments (`cells/1`→1-32, `cells/33`→33-64, `cells/65`→65-96) and emits `(max−min)·1000` mV plus the 1-based **outlier cell index** (cell furthest from the pack mean). Skipped while `state === 'active'` (rest-spread signal); emitted for `parked`/`charging`. Holds last-known-good per segment in `persistedCache`; a malformed/stale frame never overwrites a good segment nor emits `NaN`.
- **`derived/module_temp_spread_c`** — merges the 12 battery module temps (`module_temps`[5] from `bms/2101` + `module_temps_6_12`[7] from `bms/2105`) and emits `max−min` °C.

Both values are rounded to 0.1 to strip binary float noise from the InfluxDB write and the Grafana annotation (well below sensor granularity).

Bundled per the umbrella deliverables checklist:
- `docker/automations/bots/ioniq-cell-health.js` + `.test.js` (TDD, 14 tests)
- `config/automations/config.js` — bot registered next to `ioniqDtc`
- `config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml` — four `classic_conditions` rules
- `docs/influxdb-schema.md` — the two new `derived/*` groups documented
- Per-bot design spec + implementation plan under `docs/superpowers/`

## Why

Array logic (96-cell spread, cross-frame 12-module merge) is impractical in InfluxQL. The bot pre-reduces each condition to a clean scalar on `ioniq/parsed/derived/*` so the existing `mqtt-influx-ioniq` bridge writes it and Grafana alerts on it with a plain threshold. The outlier cell index turns a "spread is high" alert into an actionable "cell N is the problem."

## Grafana rules

Cloning the phase-2 `ioniq-12v` shape — each warn/crit is a separate rule, `classic_conditions`, explicit `time >= now() - 30m` bound, `noDataState: OK`, `execErrState: Alerting`, datasource `P3C6603E967DC8568`, folder `Ioniq EV`, group `interval: 1m`, `🚗` in title/summary, labels `severity`/`device: ioniq`/`subsystem: battery`:

| signal | warn | crit | for |
| --- | --- | --- | --- |
| `cell_spread_mv` | > 50 | > 100 | 10m |
| `module_temp_spread_c` | > 8 | > 15 | 10m |

## Prod-verification evidence (read-only, routy, 2026-07-14)

All five source topics confirmed live via `mosquitto_sub` and their field shapes verified against prod InfluxDB (db `homy`, measurement `ioniq`):
- `ioniq/parsed/cells/{1,33,65}` — field `cells` = JSON string of **32 floats** (e.g. `"[3.64,3.64,…]"`).
- `ioniq/parsed/bms/2101` — field `module_temps` = JSON string of **5 floats** (`[30,30,30,30,30]`).
- `ioniq/parsed/bms/2105` — field `module_temps_6_12` = JSON string of **7 floats**.
- `state` tag values observed: `active`, `parked`, `charging`. Cell frames carry their own `state`/`ts`.

## Test evidence

`cd docker/automations && npx jest` → **409/409 passing** (14 suites), including the new `bots/ioniq-cell-health.test.js` (14 tests): 96-cell reassembly + spread + outlier index across a segment boundary; active-skip vs parked/charging emit; partial-data gating; malformed-frame guards (non-JSON, wrong length, non-array, NaN) with prior-good-segment retention proving no NaN emission; module 5+7 merge; outlier tie-break (lowest index); full payload-shape assertion.

## Independent review verdict

Fresh-subagent gates (author never self-reviewed): spec/plan review → REQUEST-CHANGES (traceability: branch was rebased onto the umbrella base so the referenced contract file is present) then clean; whole-branch review → **APPROVE, no blocking findings**, tests confirmed green by the reviewer. The one substantive minor note (float noise in `value`) was addressed by the 0.1 rounding in this branch.

## Base note

This branch is based on the shared Phase-3 umbrella base commit `1fa9c24` (`docs(ioniq): Phase 3 computation-bots umbrella design`), which is not yet on `origin/master` (direct push to protected `master` is declined). That commit therefore currently rides along in this PR's diff and will drop out once the umbrella base lands on `master`. This PR's own change is the single `feat(ioniq): cell-health bot …` commit.

https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN
