### PR TITLE
feat(ioniq): 12v-ldc bot — derived ldc_ok/aux12v_drop signals + Grafana rules

### DIFF
--- a/config/automations/config.js
+++ b/config/automations/config.js
@@ -501,6 +501,12 @@ module.exports = {
       cellSpreadOutputTopic: 'ioniq/parsed/derived/cell_spread_mv',
       moduleTempSpreadOutputTopic: 'ioniq/parsed/derived/module_temp_spread_c',
     },
+    ioniq12vLdc: {
+      type: 'ioniq-12v-ldc',
+      inputTopic: 'ioniq/parsed/bms/2101',
+      ldcOkTopic: 'ioniq/parsed/derived/ldc_ok',
+      auxDropTopic: 'ioniq/parsed/derived/aux12v_drop',
+    },
   },
   gates: {
     mqtt: {

--- a/config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml
@@ -1,0 +1,81 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Ioniq 12V LDC Alerts
+    folder: Ioniq EV
+    interval: 1m
+    rules:
+      - uid: ioniq-ldc-not-charging
+        title: "🚗 Ioniq LDC Not Charging"
+        condition: A
+        data:
+          - refId: ldc
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/ldc_ok' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+                  operator: { type: and }
+                  query: { params: [ldc] }
+                  reducer: { type: last }
+                  type: query
+              expression: ldc
+        noDataState: OK
+        execErrState: Alerting
+        for: 60s
+        labels: { severity: warning, device: ioniq, subsystem: 12v }
+        annotations:
+          summary: "🚗 12V LDC not charging"
+          description: "The DC-DC converter (LDC) held the 12V rail below 13.2V for over a minute while driving at low HV load. Suspect an LDC fault — the 12V battery is not being replenished. Investigate before it strands the car."
+
+      - uid: ioniq-12v-sag
+        title: "🚗 Ioniq 12V Sag"
+        condition: A
+        data:
+          - refId: sag
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: |
+                SELECT last("value") FROM "ioniq"
+                WHERE "group"='derived/aux12v_drop' AND time >= now() - 10m
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource: { type: __expr__, uid: __expr__ }
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              hide: false
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+                  operator: { type: and }
+                  query: { params: [sag] }
+                  reducer: { type: last }
+                  type: query
+              expression: sag
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        labels: { severity: warning, device: ioniq, subsystem: 12v }
+        annotations:
+          summary: "🚗 12V rail sag detected"
+          description: "The 12V rail dropped abnormally fast (>=0.8V within 5s) or is drifting down while parked (>=0.3V/min). Check the 12V battery and LDC health."

--- a/docker/automations/bots/ioniq-12v-ldc.js
+++ b/docker/automations/bots/ioniq-12v-ldc.js
@@ -1,0 +1,169 @@
+// ioniq-12v-ldc: reduces the Ioniq 12 V / LDC (DC-DC converter) telemetry on
+// bms/2101 to two numeric derived signals for Grafana:
+//   derived/ldc_ok     (0/1) — is the LDC actually charging the 12 V battery?
+//   derived/aux12v_drop (0/1) — did the 12 V rail just sag abnormally?
+//
+// The whole point of ldc_ok is to NOT false-alarm on normal behaviour: under
+// heavy traction the LDC de-prioritises 12 V charging (load priority), so
+// aux_12v legitimately floats down to ~12.8-13.0 V — that is not a fault. The
+// low-voltage judgement is therefore gated on a SUSTAINED low HV load, the only
+// regime where a healthy LDC unambiguously holds the rail well above 13.2 V
+// (prod: aux_12v mean 13.69 at <0.5 kW vs 13.28 under heavy traction).
+//
+// All time math uses receipt time (Date.now()), not the payload ts: "sustained
+// >=60 s" is a real-elapsed-time judgement and must not depend on the logger's
+// clock. The emitted payload passes the source ts/state through per the
+// derived-signals convention (phase-3 umbrella §3).
+
+function isFiniteNum (v) {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+// A sample is usable only if the three fields the logic needs are finite
+// numbers; a malformed/partial payload must never corrupt the window or emit a
+// spurious signal.
+function isValidSample (p) {
+  return !!p && isFiniteNum(p.aux_12v) && isFiniteNum(p.ignition) && isFiniteNum(p.hv_kw)
+}
+
+module.exports = function createIoniq12vLdc (name, config = {}) {
+  const inputTopic = config.inputTopic || 'ioniq/parsed/bms/2101'
+  const ldcOkTopic = config.ldcOkTopic || 'ioniq/parsed/derived/ldc_ok'
+  const auxDropTopic = config.auxDropTopic || 'ioniq/parsed/derived/aux12v_drop'
+
+  const lowVoltThreshold = config.lowVoltThreshold ?? 13.2 // V
+  const lowHvKwThreshold = config.lowHvKwThreshold ?? 0.5 // kW
+  const lowLoadWindowMs = config.lowLoadWindowMs ?? 15000 // low load must hold this long
+  const sustainMs = config.sustainMs ?? 60000 // low-voltage sustain for a fault
+  const coverageToleranceMs = config.coverageToleranceMs ?? 5000 // allowed gap at window start
+  const fastDropVolts = config.fastDropVolts ?? 0.8 // V
+  const fastDropWindowMs = config.fastDropWindowMs ?? 5000
+  const slowDropRatePerMin = config.slowDropRatePerMin ?? 0.3 // V/min (parked)
+  const slowDropMinSpanMs = config.slowDropMinSpanMs ?? 30000
+  const auxDropHoldMs = config.auxDropHoldMs ?? 60000 // latch a sag high this long
+  const windowMaxAgeMs = config.windowMaxAgeMs ?? 65000
+  const windowMaxSamples = config.windowMaxSamples ?? 300
+
+  const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
+
+  return {
+    persistedCache: {
+      version: 1,
+      // window: chronological recent samples. auxDropLatchUntil: receipt time
+      // until which aux12v_drop is held high after a sag (so a 1 m last() poll
+      // reliably catches an otherwise sub-5-s pulse). Persisted so a restart
+      // does not blind the detectors for the sustain window.
+      default: { window: [], auxDropLatchUntil: 0 },
+      migrate: ({ state }) => {
+        if (!Array.isArray(state.window)) state.window = []
+        if (!isFiniteNum(state.auxDropLatchUntil)) state.auxDropLatchUntil = 0
+        return state
+      }
+    },
+
+    start: async ({ mqtt, persistedCache }) => {
+      // ldc_ok: 0 (LDC not charging) only when low voltage held continuously for
+      // >=60 s while ignition on AND HV load stayed low for the trailing 15 s.
+      const evalLdcOk = (window, now) => {
+        const recent = window.filter((s) => s.rxTs >= now - sustainMs)
+        // Coverage requires BOTH: (a) at least 60 s of history exists (the full
+        // window reaches back past the sustain edge — preserves the exact 60 s
+        // floor), AND (b) the trailing 60 s is densely populated from near its
+        // start (the oldest IN-window sample is within `coverageToleranceMs` of
+        // the edge). (b) rejects a lone fresh sample that survived the max-age
+        // prune after a telemetry gap (which would otherwise false-fault on one
+        // sample); (a) rejects faulting before a genuine 60 s has elapsed.
+        const oldest = window[0]
+        const covered = !!oldest && oldest.rxTs <= now - sustainMs &&
+          recent.length > 0 && recent[0].rxTs <= now - sustainMs + coverageToleranceMs
+        if (!covered) return 1
+
+        const ignitionOn = recent.every((s) => s.ignition === 1)
+        const lowVolt = recent.every((s) => s.aux_12v < lowVoltThreshold)
+
+        // Sustained low load: the trailing 15 s must be entirely below the
+        // threshold. A single coast/regen blip inside heavy traction must not
+        // trigger a fault (that low voltage is load-explained).
+        const loadTail = window.filter((s) => s.rxTs >= now - lowLoadWindowMs)
+        const lowLoad = loadTail.length > 0 && loadTail.every((s) => s.hv_kw < lowHvKwThreshold)
+
+        const fault = ignitionOn && lowVolt && lowLoad
+        return fault ? 0 : 1
+      }
+
+      // aux12v_drop: instantaneous sag detection (fast edge or slow parked
+      // drift), then latched high for the hold window.
+      const detectSag = (window, sample, now) => {
+        const curr = sample.aux_12v
+
+        // Fast sag: current is >= fastDropVolts below some sample in the last
+        // fastDropWindowMs (excluding the current sample at rxTs === now).
+        const fastPrev = window.filter((s) => s.rxTs >= now - fastDropWindowMs && s.rxTs < now)
+        if (fastPrev.length > 0) {
+          const prevMax = Math.max(...fastPrev.map((s) => s.aux_12v))
+          if (prevMax - curr >= fastDropVolts) return true
+        }
+
+        // Slow parked drift: only while parked, and referenced against the
+        // oldest PARKED sample in the sustain window (scoped to parked so an
+        // active->parked transition does not mix a driving voltage into the rate).
+        if (sample.state === 'parked') {
+          const parked = window.filter((s) => s.state === 'parked' && s.rxTs >= now - sustainMs)
+          const ref = parked[0]
+          if (ref) {
+            const spanMs = now - ref.rxTs
+            if (spanMs >= slowDropMinSpanMs) {
+              const ratePerMin = (ref.aux_12v - curr) / (spanMs / 60000)
+              if (ratePerMin >= slowDropRatePerMin) return true
+            }
+          }
+        }
+        return false
+      }
+
+      await mqtt.subscribe(inputTopic, (payload) => {
+        if (!isValidSample(payload)) {
+          log('ignoring invalid sample', payload)
+          return
+        }
+        const now = Date.now()
+
+        // Append then prune by age and length (bounded, chronological).
+        const window = persistedCache.window
+        window.push({
+          aux_12v: payload.aux_12v,
+          ignition: payload.ignition,
+          hv_kw: payload.hv_kw,
+          state: payload.state,
+          ts: payload.ts,
+          rxTs: now
+        })
+        let pruned = window.filter((s) => s.rxTs >= now - windowMaxAgeMs)
+        if (pruned.length > windowMaxSamples) {
+          pruned = pruned.slice(pruned.length - windowMaxSamples)
+        }
+        persistedCache.window = pruned
+
+        const ldcOkValue = evalLdcOk(pruned, now)
+        mqtt.publish(ldcOkTopic, {
+          _type: 'ioniq',
+          group: 'derived/ldc_ok',
+          state: payload.state,
+          ts: payload.ts,
+          value: ldcOkValue
+        })
+
+        const sag = detectSag(pruned, payload, now)
+        if (sag) persistedCache.auxDropLatchUntil = now + auxDropHoldMs
+        const dropValue = (sag || now < persistedCache.auxDropLatchUntil) ? 1 : 0
+        mqtt.publish(auxDropTopic, {
+          _type: 'ioniq',
+          group: 'derived/aux12v_drop',
+          state: payload.state,
+          ts: payload.ts,
+          value: dropValue
+        })
+      })
+    }
+  }
+}

--- a/docker/automations/bots/ioniq-12v-ldc.test.js
+++ b/docker/automations/bots/ioniq-12v-ldc.test.js
@@ -1,0 +1,237 @@
+const { afterEach, beforeEach, describe, expect, it, jest } = require('@jest/globals')
+const createIoniq12vLdc = require('./ioniq-12v-ldc')
+
+const INPUT = 'ioniq/parsed/bms/2101'
+const LDC_OK = 'ioniq/parsed/derived/ldc_ok'
+const AUX_DROP = 'ioniq/parsed/derived/aux12v_drop'
+const BASE = 1700000000000
+
+function makeMqtt () {
+  const mqtt = {
+    _callbacks: {},
+    subscribe: jest.fn().mockImplementation((topic, cb) => {
+      mqtt._callbacks[topic] = cb
+      return Promise.resolve()
+    }),
+    publish: jest.fn().mockResolvedValue(),
+    _trigger: (topic, message) =>
+      mqtt._callbacks[topic] ? mqtt._callbacks[topic](message) : undefined
+  }
+  return mqtt
+}
+
+function makeCache () {
+  return { window: [], auxDropLatchUntil: 0 }
+}
+
+// Feed a sample at BASE+offsetMs of receipt (fake) time.
+function feed (mqtt, offsetMs, sample) {
+  jest.setSystemTime(BASE + offsetMs)
+  return mqtt._trigger(INPUT, { ts: BASE + offsetMs, ...sample })
+}
+
+// Last published payload on a given topic.
+function lastFor (mqtt, topic) {
+  const calls = mqtt.publish.mock.calls.filter((c) => c[0] === topic)
+  return calls.length ? calls[calls.length - 1][1] : undefined
+}
+
+describe('ioniq-12v-ldc bot', () => {
+  let mqtt, persistedCache, bot
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(BASE)
+    mqtt = makeMqtt()
+    persistedCache = makeCache()
+    bot = createIoniq12vLdc('ioniq-12v-ldc', {
+      inputTopic: INPUT,
+      ldcOkTopic: LDC_OK,
+      auxDropTopic: AUX_DROP
+    })
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('subscribes only to the exact input topic (no wildcard)', async () => {
+    await bot.start({ mqtt, persistedCache })
+    expect(mqtt.subscribe).toHaveBeenCalledTimes(1)
+    expect(mqtt.subscribe).toHaveBeenCalledWith(INPUT, expect.any(Function))
+  })
+
+  describe('derived/ldc_ok', () => {
+    it('stays 1 under heavy traction low voltage (no false fault)', async () => {
+      await bot.start({ mqtt, persistedCache })
+      // 60 s of low voltage but HV load always high -> load-explained, not a fault.
+      for (const t of [0, 20000, 40000, 48000, 54000, 60000]) {
+        await feed(mqtt, t, { aux_12v: 12.9, ignition: 1, hv_kw: 8, state: 'active' })
+      }
+      expect(lastFor(mqtt, LDC_OK).value).toBe(1)
+    })
+
+    it('emits 0 after low voltage sustained >=60 s at low HV load', async () => {
+      await bot.start({ mqtt, persistedCache })
+      for (const t of [0, 20000, 40000, 48000, 54000, 60000]) {
+        await feed(mqtt, t, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      }
+      expect(lastFor(mqtt, LDC_OK).value).toBe(0)
+    })
+
+    it('stays 1 before 60 s of history is covered even with fault-shaped samples', async () => {
+      await bot.start({ mqtt, persistedCache })
+      for (const t of [0, 20000, 40000]) {
+        await feed(mqtt, t, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      }
+      expect(lastFor(mqtt, LDC_OK).value).toBe(1)
+    })
+
+    it('stays 1 when a recovery sample >= 13.2 V appears within the 60 s', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      await feed(mqtt, 30000, { aux_12v: 13.5, ignition: 1, hv_kw: 0.2, state: 'active' })
+      for (const t of [48000, 54000, 60000]) {
+        await feed(mqtt, t, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      }
+      expect(lastFor(mqtt, LDC_OK).value).toBe(1)
+    })
+
+    it('stays 1 when ignition drops to 0 within the 60 s', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      await feed(mqtt, 30000, { aux_12v: 12.9, ignition: 0, hv_kw: 0.2, state: 'active' })
+      for (const t of [48000, 54000, 60000]) {
+        await feed(mqtt, t, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      }
+      expect(lastFor(mqtt, LDC_OK).value).toBe(1)
+    })
+
+    it('does not fault on a single low-load blip inside heavy traction', async () => {
+      await bot.start({ mqtt, persistedCache })
+      // 60 s low voltage, load heavy everywhere except one brief coast blip mid-window.
+      await feed(mqtt, 0, { aux_12v: 12.9, ignition: 1, hv_kw: 8, state: 'active' })
+      await feed(mqtt, 20000, { aux_12v: 12.9, ignition: 1, hv_kw: 8, state: 'active' })
+      await feed(mqtt, 30000, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' }) // blip
+      for (const t of [40000, 48000, 54000, 60000]) {
+        await feed(mqtt, t, { aux_12v: 12.9, ignition: 1, hv_kw: 8, state: 'active' })
+      }
+      expect(lastFor(mqtt, LDC_OK).value).toBe(1)
+    })
+
+    it('stays 1 when the trailing 15 s contains a high-load sample', async () => {
+      await bot.start({ mqtt, persistedCache })
+      // 60 s of low voltage, mostly low-load (coverage IS met), but the newest
+      // sample (in the last 15 s) is high-load -> load-explained, no fault.
+      for (const t of [0, 20000, 40000, 50000]) {
+        await feed(mqtt, t, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      }
+      await feed(mqtt, 60000, { aux_12v: 12.9, ignition: 1, hv_kw: 8, state: 'active' })
+      expect(lastFor(mqtt, LDC_OK).value).toBe(1)
+    })
+
+    it('does not false-fault on a lone fresh bad sample after a telemetry gap', async () => {
+      await bot.start({ mqtt, persistedCache })
+      // A healthy sample, then ~62 s of silence, then one cold-start bad sample.
+      // The stale sample survives the 65 s max-age prune, so a naive "oldest is
+      // >=60 s old" coverage check would false-fault on this single fresh sample.
+      await feed(mqtt, 0, { aux_12v: 13.6, ignition: 1, hv_kw: 5, state: 'active' })
+      await feed(mqtt, 62000, { aux_12v: 12.9, ignition: 1, hv_kw: 0.2, state: 'active' })
+      expect(lastFor(mqtt, LDC_OK).value).toBe(1)
+    })
+  })
+
+  describe('derived/aux12v_drop', () => {
+    it('flags a fast sag of >= 0.8 V within 5 s', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 13.0, ignition: 1, hv_kw: 2, state: 'active' })
+      await feed(mqtt, 3000, { aux_12v: 12.1, ignition: 1, hv_kw: 2, state: 'active' })
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(1)
+    })
+
+    it('does not flag a fast drop below 0.8 V', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 13.0, ignition: 1, hv_kw: 2, state: 'active' })
+      await feed(mqtt, 3000, { aux_12v: 12.6, ignition: 1, hv_kw: 2, state: 'active' })
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(0)
+    })
+
+    it('flags a slow parked drift of >= 0.3 V/min', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 12.8, ignition: 0, hv_kw: 0, state: 'parked' })
+      await feed(mqtt, 30000, { aux_12v: 12.6, ignition: 0, hv_kw: 0, state: 'parked' })
+      await feed(mqtt, 60000, { aux_12v: 12.4, ignition: 0, hv_kw: 0, state: 'parked' })
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(1)
+    })
+
+    it('does not flag the same slow drift while active (parked-only)', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 12.8, ignition: 1, hv_kw: 2, state: 'active' })
+      await feed(mqtt, 30000, { aux_12v: 12.6, ignition: 1, hv_kw: 2, state: 'active' })
+      await feed(mqtt, 60000, { aux_12v: 12.4, ignition: 1, hv_kw: 2, state: 'active' })
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(0)
+    })
+
+    it('does not corrupt the slow-drift rate with a pre-park active sample', async () => {
+      await bot.start({ mqtt, persistedCache })
+      // active at higher voltage, then park; a naive oldest-sample ref would falsely fault.
+      await feed(mqtt, 0, { aux_12v: 12.9, ignition: 1, hv_kw: 2, state: 'active' })
+      await feed(mqtt, 8000, { aux_12v: 12.8, ignition: 0, hv_kw: 0, state: 'parked' })
+      await feed(mqtt, 40000, { aux_12v: 12.7, ignition: 0, hv_kw: 0, state: 'parked' })
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(0)
+    })
+
+    it('latches high across subsequent non-sag samples then clears after the hold', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 13.0, ignition: 1, hv_kw: 2, state: 'active' })
+      await feed(mqtt, 3000, { aux_12v: 12.1, ignition: 1, hv_kw: 2, state: 'active' }) // fast sag
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(1)
+      // 30 s later, rail steady low, no new sag -> still latched high.
+      await feed(mqtt, 33000, { aux_12v: 12.1, ignition: 1, hv_kw: 2, state: 'active' })
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(1)
+      // beyond the 60 s hold from the sag (sag at 3000, hold until 63000) -> clears.
+      await feed(mqtt, 64000, { aux_12v: 12.1, ignition: 1, hv_kw: 2, state: 'active' })
+      expect(lastFor(mqtt, AUX_DROP).value).toBe(0)
+    })
+  })
+
+  describe('payload shape and robustness', () => {
+    it('emits the convention payload for both signals', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { ts: 999, aux_12v: 13.5, ignition: 1, hv_kw: 2, state: 'active' })
+      const ldc = lastFor(mqtt, LDC_OK)
+      expect(ldc).toEqual({ _type: 'ioniq', group: 'derived/ldc_ok', state: 'active', ts: 999, value: 1 })
+      const drop = lastFor(mqtt, AUX_DROP)
+      expect(drop).toEqual({ _type: 'ioniq', group: 'derived/aux12v_drop', state: 'active', ts: 999, value: 0 })
+    })
+
+    it('ignores null / partial payloads without publishing or growing the window', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, null)
+      await feed(mqtt, 1000, { ignition: 1, hv_kw: 2, state: 'active' }) // no aux_12v
+      await feed(mqtt, 2000, { aux_12v: 13.5, hv_kw: 2, state: 'active' }) // no ignition
+      await feed(mqtt, 3000, { aux_12v: 13.5, ignition: 1, state: 'active' }) // no hv_kw
+      await feed(mqtt, 4000, { aux_12v: 'x', ignition: 1, hv_kw: 2, state: 'active' }) // non-numeric
+      expect(mqtt.publish).not.toHaveBeenCalled()
+      expect(persistedCache.window).toHaveLength(0)
+    })
+
+    it('bounds the window by sample count', async () => {
+      bot = createIoniq12vLdc('ioniq-12v-ldc', {
+        inputTopic: INPUT, ldcOkTopic: LDC_OK, auxDropTopic: AUX_DROP, windowMaxSamples: 5
+      })
+      await bot.start({ mqtt, persistedCache })
+      for (let i = 0; i < 20; i++) {
+        await feed(mqtt, i * 100, { aux_12v: 13.5, ignition: 1, hv_kw: 2, state: 'active' })
+      }
+      expect(persistedCache.window.length).toBeLessThanOrEqual(5)
+    })
+
+    it('bounds the window by age', async () => {
+      await bot.start({ mqtt, persistedCache })
+      await feed(mqtt, 0, { aux_12v: 13.5, ignition: 1, hv_kw: 2, state: 'active' })
+      await feed(mqtt, 100000, { aux_12v: 13.5, ignition: 1, hv_kw: 2, state: 'active' })
+      // first sample is 100 s old, beyond the 65 s max age -> pruned.
+      expect(persistedCache.window.every((s) => s.rxTs >= BASE + 100000 - 65000)).toBe(true)
+      expect(persistedCache.window).toHaveLength(1)
+    })
+  })
+})

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -215,6 +215,16 @@ query this measurement's `v` field. See
     from `bms/2101` + `module_temps_6_12`[7] from `bms/2105`) and publishes field `value` =
     `max − min` in °C. Grafana's `ioniq-module-temp-spread-*` rules alert on `value > 8` (warning) /
     `> 15` (critical).
+  - `derived/ldc_ok` — a bot-produced `group` value (not from the logger): the `ioniq-12v-ldc`
+    automations bot publishes it from `bms/2101` with field `value` ∈ {0,1}. `0` means the LDC
+    (DC-DC converter) is not charging the 12 V battery — `aux_12v` held below 13.2 V for ≥60 s while
+    ignition on AND HV load stayed low (the low-voltage judgement is suppressed under heavy traction,
+    where a sagging rail is normal load-priority). `1` = OK. Grafana's `ioniq-ldc-not-charging` rule
+    alerts on `value < 1`.
+  - `derived/aux12v_drop` — a bot-produced `group` value (not from the logger): the `ioniq-12v-ldc`
+    bot publishes it from `bms/2101` with field `value` ∈ {0,1}. `1` marks a 12 V sag edge —
+    `aux_12v` fell ≥0.8 V within 5 s, or drifted ≥0.3 V/min while parked — latched high for 60 s so a
+    1 m Grafana poll catches the pulse. Grafana's `ioniq-12v-sag` rule alerts on `value > 0`.
 - `state`: vehicle state (`active` / `parked` / `charging` / …), from `payload.state` — low-cardinality, what dashboards filter/group by
 **Timestamp**: `payload.ts` (epoch ms), written at `ms` precision
 **Fields**: every payload key except `_type`, `group`, `state`, `ts`:

--- a/docs/superpowers/plans/2026-07-14-ioniq-12v-ldc.md
+++ b/docs/superpowers/plans/2026-07-14-ioniq-12v-ldc.md
@@ -1,0 +1,69 @@
+# Implementation Plan — `ioniq-12v-ldc` bot
+
+Spec: [`../specs/2026-07-14-ioniq-12v-ldc-design.md`](../specs/2026-07-14-ioniq-12v-ldc-design.md)
+Branch: `feat/ioniq-12v-ldc` · Worktree-isolated · TDD (red → green → refactor).
+
+## Task 1 — Bot + tests (TDD)
+
+Files: `docker/automations/bots/ioniq-12v-ldc.js`, `docker/automations/bots/ioniq-12v-ldc.test.js`.
+
+1. Write `ioniq-12v-ldc.test.js` first (red) covering spec §6 scenarios 1–11. Use the `ioniq-dtc.test.js`
+   mocked-MQTT pattern (`makeMqtt` with `_callbacks`/`_trigger`, `jest.fn` publish). Use Jest fake timers
+   + `jest.setSystemTime(...)` to control `Date.now()` (the bot's `rxTs` clock); advance system time
+   between `_trigger` calls to simulate real elapsed seconds. `persistedCache` seeded as `{ window: [] }`.
+2. Implement `ioniq-12v-ldc.js` (green) following the `module.exports = (name, config) => ({ persistedCache,
+   start })` shape. Pure event-driven: all evaluation on each incoming sample; **no `setTimeout`**
+   (sustain judged from `rxTs` timestamps in the window). Prune → validate → append → publish both signals.
+3. Refactor: factor `isValid`, `pruneWindow`, `evalLdcOk`, `evalAuxDrop` helpers; comment the suppression
+   rationale (why low-load gating). Keep the file self-contained (no new deps).
+4. Verify: `cd docker/automations && npx jest bots/ioniq-12v-ldc.test.js` → all green.
+
+Review gate: fresh subagent reviews bot+tests against spec (gating correctness, edge cases, no false fault
+under heavy traction). Address findings.
+
+## Task 2 — Config registration
+
+File: `config/automations/config.js`. Append an `ioniq12vLdc` block immediately after the `ioniqDtc`
+block (~line 486), selective — no reformatting of surrounding code. Only set non-default topics if needed;
+defaults live in the bot. Minimal:
+
+```js
+ioniq12vLdc: {
+  type: 'ioniq-12v-ldc',
+  inputTopic: 'ioniq/parsed/bms/2101',
+  ldcOkTopic: 'ioniq/parsed/derived/ldc_ok',
+  auxDropTopic: 'ioniq/parsed/derived/aux12v_drop',
+},
+```
+
+## Task 3 — Grafana rules
+
+File: `config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml`. Clone `ioniq-12v-alerts.yaml`
+structure exactly (two rules per spec §4). Validate YAML parses. `for: 60s` (ldc_ok), `for: 0s`
+(aux12v_drop). Group name e.g. `Ioniq 12V LDC Alerts`, `interval: 1m`.
+
+## Task 4 — Schema docs
+
+File: `docs/influxdb-schema.md`. Locate the `derived/dtc_count` entry; add `derived/ldc_ok` and
+`derived/aux12v_drop` alongside, same table/format, documenting `value` semantics (0/1), producing bot,
+and source topic.
+
+## Task 5 — Deploy-readiness
+
+Confirm the module loads (no `MODULE_NOT_FOUND`) via a require smoke check and the full automations test
+suite still green: `cd docker/automations && npx jest bots/ioniq-12v-ldc.test.js` and a broader
+`npx jest` sanity pass on the bots dir.
+
+## Review gates
+
+- Spec + plan review (before coding) — fresh subagent.
+- Task 1 per-task review — fresh subagent.
+- Whole-branch review before PR — fresh subagent.
+- Fresh PR review after opening — fresh subagent.
+Author never self-reviews. Escalate to human only for a genuine product/threshold judgement the data
+can't settle.
+
+## Commits (selective staging)
+
+1. bot + tests, 2. config registration, 3. grafana rules, 4. schema docs (or logically grouped). Every
+commit body ends with `Claude-Session: https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN`.

--- a/docs/superpowers/specs/2026-07-14-ioniq-12v-ldc-design.md
+++ b/docs/superpowers/specs/2026-07-14-ioniq-12v-ldc-design.md
@@ -1,0 +1,189 @@
+# Ioniq `ioniq-12v-ldc` Bot — Design Spec
+
+Status: draft for review · Date: 2026-07-14
+Parent contract: [`2026-07-14-ioniq-monitoring-phase3-design.md`](2026-07-14-ioniq-monitoring-phase3-design.md) §4.2
+Parent spec: [`../../ioniq-monitoring-alerting-spec.md`](../../ioniq-monitoring-alerting-spec.md) §4.2 / §5
+
+## 1. Purpose
+
+Turn the raw 12 V / LDC (DC-DC converter) telemetry on `ioniq/parsed/bms/2101` into two clean numeric
+signals Grafana can threshold trivially:
+
+- `derived/ldc_ok` (0/1) — is the LDC actually charging the 12 V battery when it should be?
+- `derived/aux12v_drop` (0/1) — did the 12 V rail just sag abnormally?
+
+The hard part is **not false-alarming on normal behaviour**: under heavy traction the LDC de-prioritises
+12 V charging (load priority), so `aux_12v` legitimately floats down to ~12.8–13.0 V. That is NOT a
+fault. The bot suppresses the low-voltage judgement whenever HV load is high, and only calls it a fault
+when the 12 V rail stays low *while HV load is low* (LDC has spare capacity and still isn't charging).
+
+## 2. Prod-grounded data (read-only queries on routy, 2026-07-14)
+
+`bms/2101` fields confirmed present with realistic values: `aux_12v` (V), `ignition` (0/1),
+`hv_kw` (kW, +traction / −regen), `charging` (0/1), `soc`, `state` tag ∈ {active, charging, parked}.
+
+Load-vs-voltage relationship (last 30 d, `group='bms/2101'`, `ignition=1`):
+
+| load band (hv_kw) | aux_12v min | mean | max | n |
+|---|---|---|---|---|
+| `< 0.5` (clearly idle/coasting) | 12.1 | **13.69** | 14.7 | 505 |
+| `0.5 – 1.0` | 12.9 | 13.40 | 14.7 | 150 |
+| `1.0 – 2.0` | 12.8 | 13.39 | 14.7 | 200 |
+| `2.0 – 3.0` | 12.8 | 13.42 | 14.7 | 91 |
+| `> 3` (heavy traction) | 12.8 | **13.28** | 14.5 | 1045 |
+
+`hv_kw` while `ignition=1`: min −53, max +57, mean 4.28 kW.
+`ignition=1 AND hv_kw<1.0 AND aux_12v<13.2`: 106 samples / 30 d (scattered transients, not sustained runs).
+
+**Interpretation:** `aux_12v` is only *clearly* high (mean 13.69) below **0.5 kW**; across the whole
+0.5–3 kW band it already sits ~13.4 with excursions to 12.8, and under heavy traction it averages 13.28.
+So the only load regime where a healthy LDC unambiguously holds the rail well above 13.2 V is `< 0.5 kW`.
+The gating threshold is therefore set at **0.5 kW** (not 1.0), giving clean separation and a conservative,
+false-positive-averse design. The 106 low-load-low-voltage samples over 30 d are scattered transients,
+which the 60 s continuous-sustain requirement filters out (a healthy rail dips briefly but does not stay
+< 13.2 for a full minute at idle).
+
+## 3. Signal definitions
+
+### Constants (all config-overridable)
+
+| name | default | grounding |
+|---|---|---|
+| `inputTopic` | `ioniq/parsed/bms/2101` | umbrella §4.2 |
+| `ldcOkTopic` | `ioniq/parsed/derived/ldc_ok` | §3 convention |
+| `auxDropTopic` | `ioniq/parsed/derived/aux12v_drop` | §3 convention |
+| `lowVoltThreshold` | `13.2` V | umbrella §4.2 |
+| `lowHvKwThreshold` | `0.5` kW | only regime where healthy aux_12v is clearly > 13.2 (mean 13.69); see §2 |
+| `lowLoadWindowMs` | `15000` | require load low for a sustained tail, not a single blip (§ review item 4) |
+| `sustainMs` | `60000` | umbrella §4.2 (≥60 s) |
+| `fastDropVolts` | `0.8` V | umbrella §4.2 |
+| `fastDropWindowMs` | `5000` | umbrella §4.2 (within 5 s) |
+| `slowDropRatePerMin` | `0.3` V/min | umbrella §4.2 |
+| `slowDropMinSpanMs` | `30000` | need ≥30 s of history to estimate a per-minute rate |
+| `auxDropHoldMs` | `60000` | latch a sag high so a 1 m `last()` Grafana poll reliably catches the pulse |
+| `windowMaxAgeMs` | `65000` | covers both 60 s sustain + slow-drop lookback with margin |
+| `windowMaxSamples` | `300` | bound persisted window growth |
+
+### Clock
+
+The window and all time math use **receipt time** (`Date.now()` at message arrival, stored as `rxTs`),
+not the payload's `ts`. "Sustained ≥ 60 s" is a real-elapsed-time judgement and must not depend on the
+logger's clock. The emitted payload still passes through the source `ts` (and `state`) per convention §3.
+Tests drive this with Jest fake timers + `jest.setSystemTime`.
+
+### Rolling window (persistedCache)
+
+`persistedCache = { version: 1, default: { window: [], auxDropLatchUntil: 0 } }`. Each valid sample
+appends `{ aux_12v, ignition, hv_kw, state, ts, rxTs }`. Pruned every sample by age
+(`rxTs < now − windowMaxAgeMs`) and length (keep newest `windowMaxSamples`). Persisted so a restart
+doesn't blind the detector for 60 s.
+
+### `derived/ldc_ok` (published every valid sample)
+
+Let `recent` = window samples with `rxTs ≥ now − sustainMs` (trailing 60 s) and `loadTail` = window
+samples with `rxTs ≥ now − lowLoadWindowMs` (trailing 15 s).
+
+`fault` is true iff ALL of:
+1. **Coverage (two-part):** (a) the *full window's* oldest sample has `rxTs ≤ now − sustainMs` (we hold
+   ≥ 60 s of history — preserves the exact 60 s floor), AND (b) the oldest sample *within* `recent` has
+   `rxTs ≤ now − sustainMs + coverageToleranceMs` (the trailing 60 s is densely populated from near its
+   start). (b) rejects a lone fresh sample that survived the 65 s max-age prune after a telemetry gap
+   (e.g. cold-start after parking) — without it, a single bad sample would false-fault; (a) alone (the
+   `window[0]` check) is insufficient for that reason, and checking `recent[0]` with no tolerance would
+   only ever be true at an exact boundary. `coverageToleranceMs` default 5 s.
+2. **Continuous ignition on:** every sample in `recent` has `ignition === 1`.
+3. **Continuous low voltage:** `max(recent.aux_12v) < lowVoltThreshold` (⟺ every sample < 13.2 for the
+   full 60 s).
+4. **Sustained low HV load:** `loadTail` is non-empty and `max(loadTail.hv_kw) < lowHvKwThreshold`
+   (⟺ HV load stayed below 0.5 kW for the whole trailing 15 s). This is a deliberate hardening of the
+   umbrella's "a recent low-hv_kw sample": a single coast/regen blip inside otherwise-heavy traction must
+   NOT trigger a fault (that low voltage is load-explained). Requiring a sustained low-load tail means the
+   LDC has had ≥ 15 s of spare capacity and the rail still hasn't recovered above 13.2 V → genuine fault.
+
+`value = fault ? 0 : 1`. Any ignition-off sample, any recovery ≥ 13.2, a purely-heavy-traction 60 s, or a
+mere brief low-load blip all yield `1`.
+
+### `derived/aux12v_drop` (published every valid sample)
+
+Instantaneous sag detection:
+- **Fast sag:** `prevMax` = `max(aux_12v)` over samples with `rxTs ∈ [now − fastDropWindowMs, now)`
+  (excludes current). If `prevMax − currentAux ≥ fastDropVolts` → sag.
+- **Slow parked drift:** only when the current sample's `state === 'parked'`. `ref` = oldest **parked**
+  sample with `rxTs ≥ now − sustainMs` (scoped to parked samples so an `active→parked` transition doesn't
+  mix a driving voltage into the rate). If `now − ref.rxTs ≥ slowDropMinSpanMs` and
+  `(ref.aux_12v − currentAux) / ((now − ref.rxTs)/60000) ≥ slowDropRatePerMin` → sag.
+
+**Latched output:** on any sag, set `auxDropLatchUntil = now + auxDropHoldMs`. Then
+`value = (sag || now < auxDropLatchUntil) ? 1 : 0`. The latch holds the pulse high for 60 s so a
+`SELECT last("value")` Grafana rule polling at 1 m cadence reliably catches an otherwise sub-5-s edge
+(keeps the umbrella-mandated `last()` query; a bare non-latched pulse would be missed most of the time).
+After the hold elapses with no new sag, the signal returns to 0 and the alert clears.
+
+### Payload shape (both signals, convention §3)
+
+```js
+mqtt.publish(topic, { _type: 'ioniq', group: 'derived/<name>', state, ts, value })
+```
+
+`state`/`ts` pass through from the triggering sample. `_bot`/`_tz` are injected by the framework.
+
+### Robustness
+
+A sample is **valid** only if `aux_12v`, `ignition`, `hv_kw` are finite numbers. Null/partial payloads
+(missing fields, non-numeric) are ignored — not added to the window, no emission. This prevents a
+malformed sample from corrupting the window or emitting a spurious signal.
+
+## 4. Grafana rules — `config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml`
+
+Clone the `ioniq-12v-alerts.yaml` shape. Two rules, folder `Ioniq EV`, group `interval: 1m`, datasource
+UID `P3C6603E967DC8568`, `classic_conditions` only, explicit `time >= now() - <window>` bound,
+`noDataState: OK`, `execErrState: Alerting`, labels `severity/device: ioniq/subsystem: 12v`, `🚗` prefix,
+static annotation text, full `__expr__` node model.
+
+- `🚗 Ioniq LDC Not Charging` — `SELECT last("value") FROM "ioniq" WHERE "group"='derived/ldc_ok' AND
+  time >= now() - 10m`; evaluator `lt [1]`; `for: 60s`; severity warning. (The `for: 60s` per umbrella
+  §4.2 double-debounces on top of the bot's internal 60 s sustain — intentional extra safety for a
+  low-frequency, high-annoyance alert; total latency ≈ bot 60 s + Grafana 60 s + poll, acceptable.)
+- `🚗 Ioniq 12V Sag` — `SELECT last("value") FROM "ioniq" WHERE "group"='derived/aux12v_drop' AND time
+  >= now() - 10m`; evaluator `gt [0]`; `for: 0s`; severity warning. Relies on the bot-side 60 s latch
+  (above) so `last()` catches the pulse.
+
+🚗 appears in both `title` and `summary` per umbrella §5.
+
+**Scope note:** neither signal covers `state === 'charging'` (ignition off there, so `ldc_ok`'s gate
+never applies; `aux12v_drop`'s slow branch is parked-only). Grid charging holds `aux_12v` at ~14.4 V
+(confirmed in prod), so there is nothing to detect in that state. `ldc_ok` emits `1` throughout charging.
+
+## 5. Deliverables
+
+- `docker/automations/bots/ioniq-12v-ldc.js` + `.test.js` (TDD).
+- Register `ioniq12vLdc` in `config/automations/config.js` after the `ioniqDtc` block.
+- `config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml`.
+- `docs/influxdb-schema.md` — document `derived/ldc_ok` and `derived/aux12v_drop` (follow the
+  `derived/dtc_count` precedent).
+
+## 6. Test scenarios (TDD)
+
+1. Subscribes to `inputTopic` only (exact match, no wildcard).
+2. `ldc_ok = 1` under heavy traction low voltage: 60 s of `aux_12v` 12.9, `ignition=1`, `hv_kw=8` → **no
+   fault** (load never low).
+3. `ldc_ok = 0` sustained: 60 s of `aux_12v` 12.9, `ignition=1`, `hv_kw=0.2` → fault once ≥60 s covered
+   and the trailing 15 s is all low-load.
+4. `ldc_ok = 1` before 60 s elapses (coverage gate) even with fault-shaped samples.
+5. `ldc_ok = 1` when a recovery sample ≥ 13.2 appears within the trailing 60 s.
+6. `ldc_ok = 1` when ignition drops to 0 within the trailing 60 s.
+7. **Single low-load blip in heavy traction does NOT fault:** 60 s of `hv_kw=8` @ 12.9 V with one
+   `hv_kw=0.2` sample mid-window → `ldc_ok = 1` (loadTail not all-low-load). This is the review-item-4
+   false-positive guard.
+8. `ldc_ok = 1` when the last 15 s has a high-load sample even though 60 s of voltage < 13.2 (loadTail
+   gate).
+9. `aux12v_drop = 1` fast: 13.0 → 12.1 within 5 s. `= 0` when drop < 0.8 V.
+10. `aux12v_drop = 1` slow parked: 12.8 → 12.4 over 60 s while `state='parked'`. `= 0` for same drift
+    while `active`.
+11. **Slow-parked ref scoping:** an `active` sample immediately before parking does not corrupt the drift
+    rate right after the `active→parked` transition.
+12. `aux12v_drop` latch: after a fast sag the signal stays `1` across subsequent non-sag samples for the
+    hold window, then returns to `0`.
+13. Null/partial payload ignored (no throw, no publish, window unchanged).
+14. Payload shape: `_type:'ioniq'`, correct `group`, `state`/`ts` passthrough, numeric `value`.
+15. Window bounded (age + length pruning).


### PR DESCRIPTION
## What

New `ioniq-12v-ldc` automations bot (phase-3 umbrella §4.2) subscribing to `ioniq/parsed/bms/2101`. It reduces the 12 V / LDC (DC-DC converter) telemetry to two numeric derived signals the `mqtt-influx-ioniq` bridge writes to InfluxDB, where Grafana thresholds them trivially:

- **`derived/ldc_ok`** (0/1) — `0` (LDC not charging) only when `aux_12v` held **< 13.2 V for ≥ 60 s while ignition on AND HV load stayed low (< 0.5 kW) for a sustained trailing 15 s**; else `1`.
- **`derived/aux12v_drop`** (0/1) — `1` on a fast sag (≥ 0.8 V within 5 s) or a slow parked drift (≥ 0.3 V/min), latched high 60 s so a 1 m Grafana `last()` poll catches the pulse.

Also: registration in `config/automations/config.js`, `config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml` (two `classic_conditions` rules), and `docs/influxdb-schema.md` docs for the two new `derived/*` groups. Per-bot spec + plan under `docs/superpowers/`.

## Why

The hard requirement is **not false-alarming on normal behaviour**. Under heavy traction the LDC de-prioritises 12 V charging (load priority), so `aux_12v` legitimately floats down to ~12.8–13.0 V — not a fault. The bot gates the low-voltage judgement on a *sustained low HV load*, the only regime where a healthy LDC unambiguously holds the rail high.

## Prod evidence (read-only queries on routy, 30 d, `group='bms/2101'`, `ignition=1`)

| load band (hv_kw) | aux_12v min | mean | max |
|---|---|---|---|
| `< 0.5` (idle/coast) | 12.1 | **13.69** | 14.7 |
| `0.5–3.0` | 12.8 | ~13.40 | 14.7 |
| `> 3` (heavy traction) | 12.8 | **13.28** | 14.5 |

`aux_12v` is only clearly high (13.69) below **0.5 kW**; across 0.5–3 kW it already sits ~13.4 with sags to 12.8, and under heavy traction averages 13.28 (below 13.2). This grounds the conservative `lowHvKwThreshold = 0.5 kW`. All fields (`aux_12v`, `ignition`, `hv_kw`, `charging`, `state`) confirmed present with realistic values.

## Test evidence

- 19 TDD tests (mocked MQTT + Jest fake timers), all green. Cover: no false fault under heavy-traction low voltage; sustained low-voltage-at-low-load fault ≥ 60 s; single low-load blip does NOT fault; trailing-15 s high-load gate; recovery/ignition-off resets; fast & slow-parked sag edges; parked-scoped drift ref; latch hold/clear; null/partial payloads; payload shape; window bounding; and a regression for a lone fresh sample after a telemetry gap.
- Full automations suite green: **414/414** across 14 suites.
- Module resolves via the bots resolver (no `MODULE_NOT_FOUND`); config.js and the Grafana YAML parse.

## Review verdict

Two independent fresh-subagent review gates (spec/plan review + adversarial whole-branch review). The spec review caught the coverage formula and a Grafana pulse-detection mismatch; the branch review caught a telemetry-gap false-fault edge (S1) and a tautological test (S2). **All findings addressed**: two-part coverage check (history-exists + dense trailing window), 60 s sag latch so `last()` catches the pulse, sustained-low-load gate against single blips, parked-scoped slow-drift ref, `lowHvKwThreshold` re-grounded to 0.5 kW with full-band prod data, and S2 test rewritten + S1 regression added. Umbrella §3 payload and §5 Grafana compliance verified field-by-field.

Verdict: **GOOD TO MERGE**.

Note: base includes the shared phase-3 umbrella commit (present in all three phase-3 worktrees); the three PRs append disjoint blocks to `config.js` and `influxdb-schema.md` and merge one at a time.

https://claude.ai/code/session_01Nk34deVYZngF9BUeWJ6oJN