### PR TITLE
fix(ioniq): stop tpms alerts from paging on query-error, not real low pressure

### DIFF
--- a/config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-dtc-alerts.yaml
@@ -36,7 +36,7 @@ groups:
                   type: query
               expression: dtc
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: dtc }
         annotations:

--- a/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
@@ -36,7 +36,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -73,7 +73,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
@@ -110,7 +110,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
@@ -147,7 +147,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -184,7 +184,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -221,7 +221,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
@@ -258,7 +258,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
@@ -295,7 +295,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -332,7 +332,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -369,7 +369,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
@@ -406,7 +406,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
@@ -443,7 +443,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -480,7 +480,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -517,7 +517,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
@@ -554,7 +554,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
@@ -591,7 +591,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -628,7 +628,7 @@ groups:
                   type: query
               expression: q
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:

--- a/docker/automations/bots/ioniq-tpms.js
+++ b/docker/automations/bots/ioniq-tpms.js
@@ -17,6 +17,7 @@ const stringify = require('fast-json-stable-stringify')
 const WHEELS = ['fl', 'fr', 'rl', 'rr']
 const TEMP_COEFF = 0.18 // psi per °C
 const REF_TEMP_C = 15 // cold reference temperature
+const AMBIENT_MAX_AGE_MS = 30 * 60 * 1000 // ambient older than this is not a reasonable reference
 
 const isFiniteNum = (x) => typeof x === 'number' && Number.isFinite(x)
 const round2 = (x) => Math.round(x * 100) / 100
@@ -34,6 +35,7 @@ module.exports = function createIoniqTpms (name, config = {}) {
   const tpmsTopic = config.tpmsTopic || 'ioniq/parsed/tpms'
   const ambientTopic = config.ambientTopic || 'ioniq/parsed/ambient'
   const prefix = config.outputTopicPrefix || 'ioniq/parsed/derived/'
+  const ambientMaxAgeMs = config.ambientMaxAgeMs || AMBIENT_MAX_AGE_MS
   const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
 
   return {
@@ -48,7 +50,13 @@ module.exports = function createIoniqTpms (name, config = {}) {
     start: async ({ mqtt, persistedCache }) => {
       // Latest ambient temperature, used as a per-wheel fallback when a wheel's
       // own temperature is missing. Not persisted — it refills on the next sample.
+      // ambientAtMs bounds how long a cached reading stays usable: the car may not
+      // report ambient temp again for hours after it sleeps, and compensating a
+      // fresh, real psi reading against a stale (e.g. yesterday-afternoon-warm)
+      // ambient temp silently skews psi_cold low — any reasonable reference beats
+      // none, but a many-hours-old one is not reasonable.
       let ambientC = null
+      let ambientAtMs = null
 
       const publish = (signal, base, value, extra) => {
         mqtt.publish(prefix + signal, {
@@ -85,13 +93,16 @@ module.exports = function createIoniqTpms (name, config = {}) {
         //  - compTemp: ownTemp, else the cached ambient temp. Used only to
         //    temperature-compensate pressure (psi_cold), where any reasonable
         //    reference temperature is better than none.
+        const ambientFresh = isFiniteNum(ambientC) && ambientAtMs !== null &&
+          (Date.now() - ambientAtMs) <= ambientMaxAgeMs
+
         const ownTemp = {}
         const compTemp = {}
         const cold = {}
         for (const w of WHEELS) {
           const wt = raw[`${w}.c`]
           if (isFiniteNum(wt)) ownTemp[w] = wt
-          const t = isFiniteNum(wt) ? wt : (isFiniteNum(ambientC) ? ambientC : null)
+          const t = isFiniteNum(wt) ? wt : (ambientFresh ? ambientC : null)
           if (t !== null) compTemp[w] = t
 
           const psi = raw[`${w}.psi`]
@@ -128,7 +139,10 @@ module.exports = function createIoniqTpms (name, config = {}) {
       }
 
       await mqtt.subscribe(ambientTopic, (payload) => {
-        ambientC = payload && isFiniteNum(payload.c) ? payload.c : ambientC
+        if (payload && isFiniteNum(payload.c)) {
+          ambientC = payload.c
+          ambientAtMs = Date.now()
+        }
         log('ambient', ambientC)
       })
       await mqtt.subscribe(tpmsTopic, onTpms)

--- a/docker/automations/bots/ioniq-tpms.test.js
+++ b/docker/automations/bots/ioniq-tpms.test.js
@@ -207,6 +207,31 @@ describe('ioniq-tpms bot', () => {
       expect(published(mqtt, 'tire_fl_psi_cold')).toBeUndefined()
     })
 
+    it('ignores an ambient reading older than 30 minutes', async () => {
+      jest.useFakeTimers()
+      try {
+        await mqtt._trigger(AMBIENT, { c: 25 })
+        jest.advanceTimersByTime(30 * 60 * 1000 + 1)
+        await mqtt._trigger(TPMS, sample({ fl: { psi: 36.6 } }))
+        // ambient is stale → no valid temp for fl → no psi_cold
+        expect(published(mqtt, 'tire_fl_psi_cold')).toBeUndefined()
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it('still uses ambient just under the 30 minute staleness bound', async () => {
+      jest.useFakeTimers()
+      try {
+        await mqtt._trigger(AMBIENT, { c: 25 })
+        jest.advanceTimersByTime(30 * 60 * 1000 - 1)
+        await mqtt._trigger(TPMS, sample({ fl: { psi: 36.6 } }))
+        expect(published(mqtt, 'tire_fl_psi_cold').value).toBe(34.8)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
     it('tolerates a wheel key that is absent entirely', async () => {
       await mqtt._trigger(TPMS, sample({ fl: undefined }))
       expect(published(mqtt, 'tire_fl_psi_cold')).toBeUndefined()

--- a/docs/superpowers/specs/2026-07-14-ioniq-tpms-design.md
+++ b/docs/superpowers/specs/2026-07-14-ioniq-tpms-design.md
@@ -92,7 +92,10 @@ Rationale for 6 h (not longer): the derived signals are only trustworthy for the
 after the car sleeps for hours the reading is stale and would false-alarm on a cooled tire, so we
 deliberately let it age out (the driver's own dash TPMS light is the primary safety indicator; this
 alert is a backstop that fires while data is fresh). Every rule MUST set both `noDataState: OK` and
-`execErrState: Alerting`. Every `__expr__` node: `datasource:{type:__expr__,uid:__expr__}`,
+`execErrState: OK` (updated 2026-07-17: a brand-new/sparse derived signal queried over a still-empty
+window can surface as a Grafana query error rather than clean no-data; `execErrState: Alerting`
+paged on that error exactly like a real sub-threshold reading — see the fix on
+`fix/ioniq-tpms-nodata-false-alarm`). Every `__expr__` node: `datasource:{type:__expr__,uid:__expr__}`,
 `intervalMs:1000`, `maxDataPoints:43200`, `refId:A`, `hide:false`. Datasource UID `P3C6603E967DC8568`,
 folder `Ioniq EV`, group `interval: 1m`. `🚗` prefix; labels `severity`/`device: ioniq`/`subsystem: tpms`.
 Static annotations. Rules (17 total):


### PR DESCRIPTION
## Summary

Two tire-pressure alerts (FL critical <26 psi, RR warning <30 psi) fired at 01:12-01:14 UTC on 2026-07-17 with no real low pressure behind them.

**Root cause — confirmed against live production (routy), not theorized:**

Grafana's own logs for that window show `msg="Failed getting data source" err="database is locked"` and `msg="Failed to build rule evaluator" error="... database is locked"` for `ioniq-tpms-fl-psi-crit` and `ioniq-tpms-rr-psi-low`, immediately followed by `Sending alerts to local notifier`. Grafana's internal SQLite database (`grafana.db`, the ngalert store — not InfluxDB) was locked at that instant; the query never ran. More than two rules hit the same lock event (`ioniq-pack-temp-critical`, `ioniq-tpms-fr-psi-crit`, and an unrelated boiler rule all errored in the same window), but only these two *paged*, because they failed at the build-evaluator pipeline stage (which routes through `execErrState`), while the others failed later at save-state (a different, non-paging code path). It's coincidence that FL/RR were the two unlucky ones — not anything specific to those wheels. Last real values that evening (InfluxDB, verified separately) were FL=32.46 psi / RR=31.88 psi, both healthy; all 17 rules had already aged out cleanly to `Normal (NoData)` ~73 minutes earlier with no issue.

`execErrState: Alerting` meant this internal-lock execution error paged as if it were a real threshold breach. Commit 1 fixes exactly this by flipping `execErrState` to `OK` on all 17 tpms rules.

**Three commits:**
1. `execErrState: Alerting → OK` on all 17 tpms rules — the actual, confirmed fix for this incident.
2. A 30-minute staleness bound on the ambient-temperature fallback in `docker/automations/bots/ioniq-tpms.js` — an independently real code gap found during multi-agent review (an unbounded stale fallback could silently skew cold-compensated pressure), but **confirmed NOT a contributor to this specific incident** (the last real sample had all four wheels' own temperatures present; no ambient fallback was invoked that night, and no numeric evaluation happened at all — the query never ran). Kept as unrelated, safe hardening.
3. Same `execErrState` fix applied to `ioniq-dtc-present`, the one sibling rule sharing the identical `noDataState: OK` + `execErrState: Alerting` + `for: 0s` (no-debounce) exposure. The other sibling ioniq alert files (battery, cell-health, 12v-ldc) all have `for:` sustain windows of 1m-1h, which would filter out a single-tick lock/error glitch — not equally exposed.

## Follow-ups identified but out of scope for this PR

- **Recurring Grafana SQLite lock contention**: `database is locked` on the ngalert store appeared ~16 times between 18:00 and 08:00 (clustered, not a one-off). Worth its own investigation (WAL mode, reducing ngalert DB pressure, disk I/O contention) since it can still silently drop rule evaluations (non-paging ones) even after this fix.
- **`boiler-controller-emergency-heating` / `boiler-solar-circulation-stuck` are failing every single evaluation** with `invalid evaluator type: gte/lte` — discovered incidentally while investigating the above. This looks like a real, continuously-broken alert on a safety-relevant system, unrelated to Ioniq/tpms. Flagging for separate follow-up.

## Test plan
- [x] `ioniq-tpms.test.js`: 27/27 passing (25 original + 2 new for the ambient staleness bound)
- [x] Full `automations` suite: 455/455 passing, no regressions
- [x] Root cause confirmed against live production Grafana logs + InfluxDB (routy), not just inferred
- [x] CI green on all commits
- [ ] Watch for a quiet night with no false pages