### PR TITLE
fix(grafana): enable SQLite WAL mode to prevent ngalert "database is locked" errors

### DIFF
--- a/config/grafana/CLAUDE.md
+++ b/config/grafana/CLAUDE.md
@@ -324,6 +324,16 @@ contactPoints:
 - Implement escalation for critical alerts
 - Use mute timings for maintenance windows
 
+## Database Configuration
+
+Grafana's own internal state (users, dashboard metadata, alert rule state, ngalert scheduler bookkeeping) lives in its own SQLite store (`grafana.db`, under `GRAFANA_DATA_PATH`) -- this is separate from InfluxDB, which only holds time-series sensor data.
+
+**WAL mode (`config.ini` `[database]` section):**
+- `wal = true` enables SQLite Write-Ahead Logging so the ngalert scheduler's reads aren't blocked by concurrent writes (alert state, annotations, session cleanup).
+- Without it, Grafana 9.5.21's default rollback-journal mode takes an exclusive lock on the whole file per write, which intermittently produced "database is locked" errors and silently missed rule evaluations (issue #1404).
+- `cache_mode` and the `max_open_conn` / `max_idle_conn` / `conn_max_lifetime` pool settings are intentionally left at Grafana defaults -- see the comment in `config.ini` for why they wouldn't help here.
+- **Requires a restart**: `[database]` settings, including `wal`, are read only at Grafana startup and are not hot-reloadable. Recreate/restart the `grafana` container (e.g. `docker compose up -d --build grafana`) for the change to take effect -- editing `config.ini` alone does nothing until the process restarts.
+
 ## Development Workflow
 
 ### Dashboard Development
@@ -408,6 +418,12 @@ contactPoints:
 - **GitHub Issues**: Known problems documented in issues #77466 and #8195
 - **Testing**: Use data source query editor to validate syntax before provisioning
 - **Verification**: Check alert instances via `/api/alertmanager/grafana/api/v2/alerts` for error details
+
+**"database is locked" Errors (ngalert scheduler):**
+- **Symptoms**: Grafana logs show `database is locked` errors, alert rule evaluations silently missed
+- **Cause**: SQLite (`grafana.db`) in default rollback-journal mode takes an exclusive whole-file lock per write, blocking the ngalert scheduler's concurrent reads
+- **Fix**: Enable WAL mode via `[database] wal = true` in `config.ini` (see "Database Configuration" above), then restart/recreate the `grafana` container -- the setting is not hot-reloadable
+- **If it recurs after WAL is enabled**: Confirm `GRAFANA_DATA_PATH` is a local filesystem, not a network mount (NFS/SMB) -- WAL relies on shared-memory locking that networked filesystems don't support correctly
 
 **$timeFilter Variable Limitations:**
 - **Grafana 9.5+ Alerting**: `$timeFilter` gets stripped or causes evaluation failures

--- a/config/grafana/config.ini
+++ b/config/grafana/config.ini
@@ -3,3 +3,35 @@
 [paths]
 provisioning = /etc/grafana/provisioning
 
+[database]
+# Grafana 9.5.21 defaults to SQLite (grafana.db) in rollback-journal mode,
+# where every write takes an exclusive lock on the whole database file and
+# blocks all concurrent readers. The ngalert scheduler reads this same file
+# on every rule-evaluation tick, so routine writes (alert state, annotations,
+# session cleanup) intermittently collide with scheduler reads and raise
+# "database is locked" errors, causing silently missed rule evaluations
+# (issue #1404).
+#
+# Enabling Write-Ahead Logging (WAL) lets readers proceed without waiting on
+# the single writer, which is Grafana's own documented mitigation for this
+# class of SQLite contention. Supported for the sqlite3 backend since
+# Grafana 8.0 (still valid for 9.5.21):
+# https://grafana.com/docs/grafana/v9.5/setup-grafana/configure-grafana/#wal
+#
+# NOTE: [database] settings, including wal, are read only at Grafana startup
+# and are not in Grafana's runtime hot-reload allow-list. Applying this
+# change requires restarting/recreating the grafana container
+# (`docker compose up -d --build grafana` or equivalent) -- editing this
+# file alone has no effect on an already-running instance.
+#
+# Deliberately NOT changed:
+# - cache_mode: left at the default "private". "shared" trades per-file
+#   locking for table-level locking, which increases contention risk
+#   instead of reducing it (only recommended as a fallback when grafana.db
+#   lives on a network filesystem where WAL can't be used).
+# - max_open_conn / max_idle_conn / conn_max_lifetime: left at Grafana
+#   defaults. Grafana already serializes SQLite writes internally; capping
+#   the pool here would only reduce read concurrency without addressing the
+#   write-lock contention that WAL already fixes.
+wal = true
+


### PR DESCRIPTION
## Root cause

Grafana 9.5.21 uses the default rollback-journal mode for its SQLite `grafana.db`. Under concurrent access from ngalert (the unified alerting engine) and other Grafana subsystems, the rollback-journal locking model produces intermittent `database is locked` errors, since only one writer can hold the database lock at a time and readers can block writers.

## Fix

Enable SQLite WAL (Write-Ahead Logging) mode via the `[database]` section:

```
[database]
wal = true
```

WAL mode allows readers and a single writer to proceed concurrently, which eliminates the `database is locked` errors seen with ngalert.

## Verification

Ran a throwaway container with the updated config and confirmed:
- `grafana.db-wal` (and `grafana.db-shm`) files are present alongside `grafana.db`, confirming WAL mode is active.
- Grafana started up cleanly with no `database is locked` errors in the logs.

## Deployment note

`[database]` settings are read only at Grafana startup. Applying this fix in production requires **recreating** the grafana container (not just restarting it in place) so the new config is picked up.

Fixes #1404