### PR TITLE
feat(ioniq): trip/charge/park session segmentation bot + ingestion

### DIFF
--- a/config/automations/config.js
+++ b/config/automations/config.js
@@ -507,6 +507,38 @@ module.exports = {
       ldcOkTopic: 'ioniq/parsed/derived/ldc_ok',
       auxDropTopic: 'ioniq/parsed/derived/aux12v_drop',
     },
+    ioniqSessions: {
+      type: 'ioniq-sessions',
+      bmsTopic: 'ioniq/parsed/bms/2101',        // ignition, speed_kph, soc, hv_kw, aux_12v, cum_* counters, ts
+      vmcuTopic: 'ioniq/parsed/vmcu',           // gear (P/N/D/R string), speed_kph — gear is HERE, not bms/2101
+      gearParkValue: 'P',                       // verified string 'P' = parked
+      odometerTopic: 'ioniq/parsed/odometer',   // km (sparse ~1/82min)
+      connectorTopic: 'ioniq/parsed/bcm_b00e',  // charge_connector (sparse corroborator / awake-charge bound)
+      ambientTopic: 'ioniq/parsed/ambient',     // optional; ambient_c best-effort
+      chargerMeterTopic: '/modbus/monitoring/charger/reading', // charger or-we-526; fields ap(W), act(kWh); home-charge bound + AC kWh
+      tripTopic: 'ioniq/derived/trip',
+      chargeTopic: 'ioniq/derived/charge',
+      parkTopic: 'ioniq/derived/park',
+      // thresholds (PROVISIONAL — re-tune after ~2 weeks of history, spec §11)
+      speedMovingKph: 3,           // > this = moving (rejects standstill jitter)
+      minRestSplitMs: 180000,      // 3 min OBSERVED stationary-awake splits a trip
+      restGapMs: 300000,           // 5 min gap = sleep/rest boundary (above the 1-3 min reboot band + 1 min slow cadence)
+      rebootMaxGapMs: 300000,      // gaps below this with ignition on both sides = reboot, NOT a rest
+      silenceTimeoutMs: 300000,    // 5 min silence closes a trailing session (> reboot band)
+      minTripDurationMs: 60000,
+      minTripSamples: 3,           // reject degenerate single-sample jitter "trips"
+      chargeMinKwh: 0.3,
+      chargeMinAh: 1,
+      chargeMinSocPct: 2,          // any ⇒ the rest contained a charge
+      chargerMeterOnW: 150,        // >150W sustained = charging (0W baseline + 3 tiers 1.2/1.9/2.6kW verified over 2yr)
+      chargerMeterOnMinMs: 60000,  // on: >150W sustained >60s
+      chargerMeterOffMinMs: 120000, // off: <150W for >2min (rides the multi-step end taper)
+      drainMinDurationMs: 3600000, // 1 h min park before %/day drain is meaningful
+      maxPlausibleStepKwh: 40,
+      maxPlausibleStepKm: 400,
+      maxPlausibleStepAh: 150,     // corruption ceilings ONLY (above a full-range trip / bulk charge / above the ~120 Ah pack nominal)
+      socField: 'soc',            // 'soc' (dense, default) vs 'soc_display' (dash) — documented switch, §4.1
+    },
   },
   gates: {
     mqtt: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -834,6 +834,34 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  mqtt-influx-ioniq-sessions:
+    image: ghcr.io/groupsky/homy/mqtt-influx:${IMAGE_TAG:-latest}
+    build: docker/mqtt-influx
+    depends_on:
+      - broker
+      - influxdb
+    restart: unless-stopped
+    networks:
+      - automation
+      - egress
+    security_opt:
+      - no-new-privileges:true
+    secrets:
+      - influxdb_write_user
+      - influxdb_write_user_password
+    environment:
+      - BROKER=mqtt://broker
+      - TOPIC=ioniq/derived/#
+      - MQTT_CLIENT_ID=mqtt-influx-ioniq-sessions
+      - INFLUXDB_URL=http://influxdb:8086
+      - INFLUXDB_USERNAME_FILE=/run/secrets/influxdb_write_user
+      - INFLUXDB_PASSWORD_FILE=/run/secrets/influxdb_write_user_password
+      - INFLUXDB_DATABASE=${INFLUXDB_DATABASE}
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   automation-events-processor:
     image: ghcr.io/groupsky/homy/automation-events-processor:${IMAGE_TAG:-latest}
     build: docker/automation-events-processor

--- a/docker/automations/bots/ioniq-sessions.js
+++ b/docker/automations/bots/ioniq-sessions.js
@@ -1,0 +1,815 @@
+// ioniq-sessions: segments the Ioniq telemetry stream into discrete sessions
+// and emits ONE summary record per closed session for the "Trips & charging"
+// dashboard and parasitic-drain analysis.
+//
+// Three session kinds cover the timeline with no gaps:
+//   trip   — a period of real motion (a fine-grained drive segment)
+//   charge — a rest during which energy entered the pack
+//   park   — a rest during which no charging occurred
+//
+// Why the obvious design is wrong (see the design spec §0): the logger only
+// lives while ignition is on, so real park/charge periods are DATA GAPS (zero
+// samples), and the `state` tag never marks them. Segmentation therefore keys
+// off: gear (vmcu, primary drive/park signal), ignition (awake delimiter),
+// speed_kph (drive vs idle), inter-sample gaps (rest detection) and cumulative
+// pack-counter / SoC deltas (charge detection), with the always-on household
+// charger energy meter bounding home charges.
+//
+// Correctness principles that most edge-cases follow from:
+//   * A rest boundary requires the car to actually be AT REST on the far side
+//     of a gap — you cannot fall asleep and wake up mid-motion.
+//   * Never fabricate a metric: null-not-zero for distance, timing null on an
+//     unbounded sleep charge, negative counter delta -> null.
+//   * All time math uses receipt time (Date.now()); start_ts/end_ts carry the
+//     source payload ts so a session is stamped where it actually happened.
+//
+// State is kept as small snapshots + reducers + meter edges (NOT a raw sample
+// window) so the cache stays tiny and a mid-session restart is cheap.
+
+const SCHEMA_VERSION = 1
+// Hard cap on the persisted charger-meter edge record so it can never grow
+// unbounded (edges are also pruned per rest close / trip start).
+const MAX_METER_EDGES = 64
+
+function isFiniteNum (v) {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+// Config defaults (all PROVISIONAL — re-tune after ~2 weeks of history, spec §11).
+const DEFAULTS = {
+  bmsTopic: 'ioniq/parsed/bms/2101',
+  vmcuTopic: 'ioniq/parsed/vmcu',
+  gearParkValue: 'P',
+  odometerTopic: 'ioniq/parsed/odometer',
+  connectorTopic: 'ioniq/parsed/bcm_b00e',
+  ambientTopic: 'ioniq/parsed/ambient',
+  chargerMeterTopic: '/modbus/monitoring/charger/reading',
+  tripTopic: 'ioniq/derived/trip',
+  chargeTopic: 'ioniq/derived/charge',
+  parkTopic: 'ioniq/derived/park',
+  speedMovingKph: 3,
+  minRestSplitMs: 180000,
+  restGapMs: 300000,
+  rebootMaxGapMs: 300000,
+  silenceTimeoutMs: 300000,
+  minTripDurationMs: 60000,
+  minTripSamples: 3,
+  chargeMinKwh: 0.3,
+  chargeMinAh: 1,
+  chargeMinSocPct: 2,
+  chargerMeterOnW: 150,
+  chargerMeterOnMinMs: 60000,
+  chargerMeterOffMinMs: 120000,
+  drainMinDurationMs: 3600000,
+  maxPlausibleStepKwh: 40,
+  maxPlausibleStepKm: 400,
+  maxPlausibleStepAh: 150,
+  socField: 'soc',
+  // How far a meter power-on/off edge may sit outside the rest window and still
+  // bound it. The meter and car share the same server clock but the handshake /
+  // end-taper misaligns edges by a few minutes (spec §0.1: aligned within ~5-9 min).
+  meterMatchToleranceMs: 900000
+}
+
+module.exports = function createIoniqSessions (name, userConfig = {}) {
+  const config = { ...DEFAULTS, ...userConfig }
+  const log = (...args) => { if (config.verbose) console.log(`[${name}]`, ...args) }
+
+  const emptyMeterState = () => ({ on: false, aboveSince: null, aboveAct: null, belowSince: null, belowAct: null })
+
+  // A monotonic-counter delta that refuses to fabricate. Returns null when a
+  // boundary is missing (incomplete), the delta is negative (a counter reset or
+  // bad baseline) or the positive jump exceeds the corruption ceiling. `maxStep`
+  // is a corruption guard set ABOVE a full-range trip / bulk charge, never used
+  // to cap normal use.
+  const safeDelta = (start, end, maxStep) => {
+    if (!isFiniteNum(start) || !isFiniteNum(end)) return { value: null, incomplete: true }
+    const d = end - start
+    if (d < 0) return { value: null, incomplete: true } // reset / bad baseline
+    if (isFiniteNum(maxStep) && d > maxStep) return { value: null, incomplete: true } // corruption
+    return { value: d, incomplete: false }
+  }
+
+  return {
+    persistedCache: {
+      version: 1,
+      // Small state: the single open session (trip or rest) with its start
+      // snapshot + running reducers, the charger-meter on/off edge record
+      // spanning the current rest, the last-sample bookkeeping used for gap and
+      // ignition-edge detection, the de-dup ledger and the emit sequence.
+      default: {
+        open: null,
+        meterEdges: [],
+        meterState: emptyMeterState(),
+        lastSampleRxTs: null,
+        lastSampleTs: null,
+        lastIgnition: null,
+        lastEmitted: null,
+        seq: 0
+      },
+      migrate: ({ state, defaultState }) => {
+        for (const k of Object.keys(defaultState)) {
+          if (!(k in state)) state[k] = defaultState[k]
+        }
+        if (!Array.isArray(state.meterEdges)) state.meterEdges = []
+        if (!state.meterState) state.meterState = emptyMeterState()
+        return state
+      }
+    },
+
+    start: async ({ mqtt, persistedCache }) => {
+      // Merged latest-view across frames: gear+speed come from vmcu; ignition,
+      // soc, hv_kw, counters, aux_12v come from bms/2101; odometer/connector/
+      // ambient refresh their own fields. Rebuilt from incoming samples after a
+      // restart (the open session's snapshots carry what the metrics need).
+      const merged = {}
+      let silenceTimer = null
+      // The session that was already open when the bot resumed. Only the close of
+      // THAT specific session counts as a restart lazy-close (spec §5.4). A trip
+      // that resumes and keeps driving "goes live" and clears this, so a normal
+      // close long after the restart is not mislabelled restart_lazy_close.
+      let restartSession = persistedCache.open
+      let restarted = !!restartSession
+      const closedByFor = (normal, session) => {
+        if (restarted && session === restartSession) {
+          restarted = false
+          restartSession = null
+          return 'restart_lazy_close'
+        }
+        return normal
+      }
+
+      const socOf = (p) => (p ? p[config.socField] : undefined)
+
+      // Snapshot of the boundary-relevant fields, as they stand in the merged
+      // view, stamped with this evaluation's payload ts / receipt time.
+      const snapshot = (ts, rxTs) => ({
+        soc: isFiniteNum(merged.soc) ? merged.soc : null,
+        cum_out_kwh: isFiniteNum(merged.cum_out_kwh) ? merged.cum_out_kwh : null,
+        cum_in_kwh: isFiniteNum(merged.cum_in_kwh) ? merged.cum_in_kwh : null,
+        cum_chg_ah: isFiniteNum(merged.cum_chg_ah) ? merged.cum_chg_ah : null,
+        odometer: isFiniteNum(merged.odometer) ? merged.odometer : null,
+        aux_12v: isFiniteNum(merged.aux_12v) ? merged.aux_12v : null,
+        connector: isFiniteNum(merged.connector) ? merged.connector : null,
+        ambient: isFiniteNum(merged.ambient) ? merged.ambient : null,
+        ts: isFiniteNum(ts) ? ts : null
+      })
+
+      // Classify the current merged view. Motion is detected first: gear D/R OR
+      // speed above the moving floor. Speed above the floor wins even over a
+      // gear=P reading, because you cannot physically move in park — a P with real
+      // speed is a stale gear frame (gear is otherwise the authoritative
+      // drive/park signal, P=parked, N=ambiguous continuation).
+      const motionState = () => {
+        const moving = merged.gear === 'D' || merged.gear === 'R' ||
+          (isFiniteNum(merged.speed) && merged.speed > config.speedMovingKph)
+        if (moving) return 'moving'
+        if (merged.gear === config.gearParkValue) return 'park'
+        if (merged.gear === 'N') return 'ambiguous'
+        return 'stationary'
+      }
+
+      const armSilenceTimer = () => {
+        if (silenceTimer) clearTimeout(silenceTimer)
+        silenceTimer = setTimeout(onSilence, config.silenceTimeoutMs)
+      }
+
+      // --- session open helpers ------------------------------------------------
+
+      const newTrip = (ts, rxTs) => {
+        const snap = snapshot(ts, rxTs)
+        return {
+          kind: 'trip',
+          start_ts: ts,
+          startSnapshot: snap,
+          motionSnapshot: snap, // last IN-MOTION snapshot -> distance/energy end
+          lastMotionTs: ts,
+          lastSnapshot: snap,
+          lastRxTs: rxTs,
+          sampleCount: 1,
+          maxGapMs: 0,
+          speedSum: isFiniteNum(merged.speed) ? merged.speed : 0,
+          speedCount: isFiniteNum(merged.speed) ? 1 : 0,
+          speedMax: isFiniteNum(merged.speed) ? merged.speed : null,
+          powerMax: isFiniteNum(merged.hv_kw) ? merged.hv_kw : null,
+          odometerReadings: [],
+          // regen accounting: cum_in credits both regen and a plugged top-up; we
+          // only accumulate cum_in over intervals where the connector is NOT
+          // plugged, so a mid-trip charge is never reported as regen.
+          regenCumIn: 0,
+          prevCumIn: isFiniteNum(merged.cum_in_kwh) ? merged.cum_in_kwh : null,
+          prevConnector: isFiniteNum(merged.connector) ? merged.connector : null,
+          containedPlugged: merged.connector === 1,
+          stationarySince: null,
+          emitted: false
+        }
+      }
+
+      const recordOdometer = (trip) => {
+        if (!trip || trip.kind !== 'trip') return
+        if (!isFiniteNum(merged.odometer)) return
+        const readings = trip.odometerReadings
+        const last = readings.length ? readings[readings.length - 1] : null
+        if (!last || last.km !== merged.odometer) {
+          readings.push({ km: merged.odometer, ts: isFiniteNum(merged.ts) ? merged.ts : null })
+        }
+      }
+
+      const newRest = (startTs, startSnap, startRxTs) => ({
+        kind: 'rest',
+        start_ts: startTs,
+        startSnapshot: startSnap,
+        lastSnapshot: startSnap,
+        lastRxTs: startRxTs,
+        end_ts: startTs,
+        sampleCount: 0, // 0 for a pure sleep rest (all metrics boundary-derived)
+        maxGapMs: 0,
+        // Genuine intermediate awake coverage: contiguous in-session samples
+        // (gap < restGapMs), EXCLUDING the resuming boundary sample. These pin an
+        // awake-mode charge's timing; a lone post-sleep wake sample is not coverage.
+        coverageSamples: 0,
+        coverageFirstTs: null,
+        coverageLastTs: null,
+        // charge_connector 0->1 / 1->0 edge timestamps captured within the rest;
+        // both are needed to bound a charge to the connector.
+        connectorEdges: [],
+        connectorPrev: isFiniteNum(startSnap.connector) ? startSnap.connector : null,
+        connectorSeen1: startSnap.connector === 1,
+        connectorSeenAny: isFiniteNum(startSnap.connector),
+        aux12vStart: startSnap.aux_12v,
+        emitted: false
+      })
+
+      // --- reducers ------------------------------------------------------------
+
+      const accumulate = (open, ts, rxTs, isAwakeSample) => {
+        const gap = (open.lastRxTs != null && isFiniteNum(rxTs)) ? rxTs - open.lastRxTs : null
+        if (gap != null && gap > open.maxGapMs) open.maxGapMs = gap
+        open.lastRxTs = rxTs
+        open.lastSnapshot = snapshot(ts, rxTs)
+        open.end_ts = isFiniteNum(ts) ? ts : open.end_ts
+        if (open.kind === 'trip') {
+          if (isAwakeSample) open.sampleCount++
+          if (isFiniteNum(merged.speed)) {
+            open.speedSum += merged.speed
+            open.speedCount++
+            open.speedMax = open.speedMax == null ? merged.speed : Math.max(open.speedMax, merged.speed)
+          }
+          if (isFiniteNum(merged.hv_kw)) {
+            open.powerMax = open.powerMax == null ? merged.hv_kw : Math.max(open.powerMax, merged.hv_kw)
+          }
+          // Regen accounting (cum_in only while unplugged).
+          if (isFiniteNum(merged.cum_in_kwh)) {
+            if (isFiniteNum(open.prevCumIn)) {
+              const d = merged.cum_in_kwh - open.prevCumIn
+              if (d >= 0 && open.prevConnector !== 1) open.regenCumIn += d
+            }
+            open.prevCumIn = merged.cum_in_kwh
+          }
+          if (isFiniteNum(merged.connector)) open.prevConnector = merged.connector
+          if (merged.connector === 1) open.containedPlugged = true
+          recordOdometer(open)
+        } else {
+          if (isAwakeSample) open.sampleCount++
+          // Count only genuine intermediate awake coverage: an awake sample that
+          // arrived CONTIGUOUSLY (gap < restGapMs). A sample after a sleep gap is a
+          // post-sleep resume boundary, not coverage of the charge.
+          if (isAwakeSample && (gap == null || gap < config.restGapMs)) {
+            open.coverageSamples = (open.coverageSamples || 0) + 1
+            if (!isFiniteNum(open.coverageFirstTs) && isFiniteNum(ts)) open.coverageFirstTs = ts
+            if (isFiniteNum(ts)) open.coverageLastTs = ts
+          }
+          if (merged.connector === 1) open.connectorSeen1 = true
+          if (isFiniteNum(merged.connector)) open.connectorSeenAny = true
+        }
+      }
+
+      const advanceMotion = (trip, ts, rxTs) => {
+        trip.lastMotionTs = isFiniteNum(ts) ? ts : trip.lastMotionTs
+        trip.motionSnapshot = snapshot(ts, rxTs)
+        trip.stationarySince = null
+      }
+
+      // --- emit ----------------------------------------------------------------
+
+      const topicFor = (kind) => (kind === 'trip' ? config.tripTopic : kind === 'charge' ? config.chargeTopic : config.parkTopic)
+
+      const emit = (kind, record) => {
+        const prev = persistedCache.lastEmitted
+        // De-dup key = (kind, start_ts, end_ts): consecutive sessions can share a
+        // boundary timestamp, so start_ts alone is not enough.
+        if (prev && prev.kind === kind && prev.start_ts === record.start_ts && prev.end_ts === record.end_ts) {
+          log('suppressing duplicate emit', kind, record.start_ts, record.end_ts)
+          return
+        }
+        const seq = persistedCache.seq + 1
+        record.seq = seq
+        // Set the de-dup marker in the SAME mutation, BEFORE publishing, so a
+        // crash between publish and the async cache flush replays as
+        // already-emitted (InfluxDB is idempotent on kind+start_ts; Mongo is
+        // at-least-once — documented, not solved here).
+        persistedCache.seq = seq
+        persistedCache.lastEmitted = { kind, start_ts: record.start_ts, end_ts: record.end_ts, seq }
+        mqtt.publish(topicFor(kind), { _type: 'ioniq-session', ...record })
+      }
+
+      // --- trip finalize -------------------------------------------------------
+
+      const buildTrip = (trip, closedBy, endTs, gearAtClose) => {
+        const start = trip.startSnapshot
+        const end = trip.motionSnapshot
+        let complete = true
+        const flagIncomplete = (r) => { if (r.incomplete) complete = false; return r.value }
+
+        const energyOut = flagIncomplete(safeDelta(start.cum_out_kwh, end.cum_out_kwh, config.maxPlausibleStepKwh))
+        const cumInDelta = safeDelta(start.cum_in_kwh, end.cum_in_kwh, config.maxPlausibleStepKwh)
+        // energy_regen = cum_in delta with any plugged-in interval excluded.
+        // regenCumIn accumulates only the unplugged cum_in gains, so for an
+        // all-unplugged trip it equals the raw delta, and for a trip with a mid-stop
+        // top-up it is strictly less (that charge energy is not reported as regen).
+        // Null only when the delta itself is unusable (missing boundary / reset).
+        const energyRegen = cumInDelta.incomplete ? null : trip.regenCumIn
+        if (cumInDelta.incomplete) complete = false
+        const energyNet = (isFiniteNum(energyOut) && isFiniteNum(energyRegen)) ? energyOut - energyRegen : null
+
+        // Distance needs >=2 DISTINCT odometer readings, else null (never last-first=0).
+        const distinct = trip.odometerReadings
+        let distanceKm = null
+        let odometerCoverage = null
+        if (distinct.length >= 2) {
+          const first = distinct[0]
+          const last = distinct[distinct.length - 1]
+          const dd = safeDelta(first.km, last.km, config.maxPlausibleStepKm)
+          if (dd.incomplete) complete = false
+          distanceKm = dd.value
+          if (isFiniteNum(first.ts) && isFiniteNum(last.ts) && endTs > trip.start_ts) {
+            const span = (last.ts - first.ts) / 1000
+            const dur = (endTs - trip.start_ts) / 1000
+            odometerCoverage = dur > 0 ? Math.max(0, Math.min(1, span / dur)) : null
+          }
+        }
+
+        // Efficiency guarded against null / 0 / NaN / Infinity distance.
+        let efficiency = null
+        if (isFiniteNum(energyNet) && isFiniteNum(distanceKm) && distanceKm > 0) {
+          const e = energyNet / distanceKm * 1000
+          if (Number.isFinite(e)) efficiency = e
+        }
+
+        const socStart = start.soc
+        const socEnd = end.soc
+        const socDelta = (isFiniteNum(socStart) && isFiniteNum(socEnd)) ? socEnd - socStart : null
+        if (!isFiniteNum(socStart) || !isFiniteNum(socEnd)) complete = false
+
+        return {
+          kind: 'trip',
+          start_ts: trip.start_ts,
+          end_ts: endTs,
+          duration_sec: (endTs - trip.start_ts) / 1000,
+          distance_km: distanceKm,
+          odometer_coverage: odometerCoverage,
+          energy_out_kwh: energyOut,
+          energy_regen_kwh: energyRegen,
+          energy_net_kwh: energyNet,
+          efficiency_wh_per_km: efficiency,
+          soc_start: socStart,
+          soc_end: socEnd,
+          soc_delta_pct: socDelta,
+          speed_avg_kph: trip.speedCount > 0 ? trip.speedSum / trip.speedCount : null,
+          speed_max_kph: trip.speedMax,
+          power_max_kw: trip.powerMax,
+          ambient_c: isFiniteNum(end.ambient) ? end.ambient : (isFiniteNum(start.ambient) ? start.ambient : null),
+          contained_plugged: !!trip.containedPlugged,
+          start_truncated: true, // logger powers on ~1-2 min after ignition (spec §0.1)
+          complete,
+          sample_count: trip.sampleCount,
+          max_gap_sec: trip.maxGapMs / 1000,
+          closed_by: closedBy,
+          gear_at_close: gearAtClose == null ? null : gearAtClose,
+          schema_version: SCHEMA_VERSION
+        }
+      }
+
+      const isDegenerateTrip = (trip, endTs) => {
+        const duration = endTs - trip.start_ts
+        return duration < config.minTripDurationMs && trip.sampleCount < config.minTripSamples
+      }
+
+      // Close the open trip and open a fresh rest starting at the trip end. A
+      // degenerate single-sample jitter "trip" is discarded (no record), which
+      // also removes the shared-timestamp collision with the following rest.
+      const closeTripOpenRest = (trip, closedBy, endTs, gearAtClose, rxTs) => {
+        if (!isDegenerateTrip(trip, endTs)) {
+          emit('trip', buildTrip(trip, closedBy, endTs, gearAtClose))
+        } else {
+          log('rejecting degenerate trip', trip.start_ts, endTs)
+        }
+        // The rest's pre-gap snapshot is the trip's LAST-KNOWN sample (which may
+        // carry an awake-idle plug-in / drift after motion ended), not the
+        // last-motion snapshot used for the trip's own distance/energy.
+        const rest = newRest(endTs, trip.lastSnapshot, rxTs)
+        persistedCache.open = rest
+        return rest
+      }
+
+      // --- rest finalize -------------------------------------------------------
+
+      // Find a charger-meter on/off pair that brackets a power-on interval inside
+      // (within tolerance of) the rest window.
+      const findMeterInterval = (startTs, endTs) => {
+        const edges = persistedCache.meterEdges
+        const tol = config.meterMatchToleranceMs
+        const onEdge = edges.find((e) => e.type === 'on' && e.ts >= startTs - tol && e.ts <= endTs + tol)
+        if (!onEdge) return null
+        const offEdge = edges.find((e) => e.type === 'off' && e.ts > onEdge.ts && e.ts <= endTs + tol)
+        if (!offEdge) return null
+        return { onEdge, offEdge }
+      }
+
+      const buildCharge = (rest, closedBy) => {
+        const start = rest.startSnapshot
+        const end = rest.lastSnapshot
+        let complete = true
+        const flagIncomplete = (r) => { if (r.incomplete) complete = false; return r.value }
+
+        const energyIn = flagIncomplete(safeDelta(start.cum_in_kwh, end.cum_in_kwh, config.maxPlausibleStepKwh))
+        const chargeAh = flagIncomplete(safeDelta(start.cum_chg_ah, end.cum_chg_ah, config.maxPlausibleStepAh))
+        const socStart = start.soc
+        const socEnd = end.soc
+        const socDelta = (isFiniteNum(socStart) && isFiniteNum(socEnd)) ? socEnd - socStart : null
+        if (!isFiniteNum(socStart) || !isFiniteNum(socEnd)) complete = false
+
+        // Timing bounding, in priority order. Energy/Ah/SoC deltas above stay valid
+        // regardless; only *timing* (duration/power) needs a real bound. When none
+        // is available the charge is UNBOUNDED (power null) — never a fabricated
+        // drive-to-drive rate over the whole multi-hour rest span (spec §3.5/§4.2).
+        let bounds = 'unbounded'
+        let durationSec = (rest.end_ts - rest.start_ts) / 1000 // whole-rest span; only reported for unbounded
+        let powerAvgKw = null
+        let acEnergyKwh = null
+        let chargeEfficiency = null
+
+        const meter = findMeterInterval(rest.start_ts, rest.end_ts)
+        const cEdges = Array.isArray(rest.connectorEdges) ? rest.connectorEdges : []
+        const cOn = cEdges.find((e) => e.type === 'on')
+        const cOff = cOn ? cEdges.find((e) => e.type === 'off' && e.ts > cOn.ts) : null
+        // Awake-mode coverage is only trustworthy when the rest was logged
+        // CONTINUOUSLY — no internal sleep gap >= restGapMs (spec BLOCKER fix).
+        const continuous = (rest.maxGapMs || 0) < config.restGapMs
+        const coverage = (rest.coverageSamples || 0) > 0 && continuous &&
+          isFiniteNum(rest.coverageFirstTs) && isFiniteNum(rest.coverageLastTs) &&
+          rest.coverageLastTs > rest.coverageFirstTs
+
+        if (meter) {
+          bounds = 'meter'
+          durationSec = (meter.offEdge.ts - meter.onEdge.ts) / 1000
+          const acDelta = safeDelta(meter.onEdge.act, meter.offEdge.act, config.maxPlausibleStepKwh)
+          acEnergyKwh = acDelta.value
+          if (isFiniteNum(energyIn) && isFiniteNum(acEnergyKwh) && acEnergyKwh > 0) {
+            chargeEfficiency = energyIn / acEnergyKwh
+          }
+        } else if (cOn && cOff) {
+          // Both plug and unplug edges captured -> bound to the connector window.
+          bounds = 'connector'
+          durationSec = (cOff.ts - cOn.ts) / 1000
+        } else if (coverage) {
+          // Continuous powered-mode coverage -> bound to first/last genuine awake sample.
+          bounds = 'awake'
+          durationSec = (rest.coverageLastTs - rest.coverageFirstTs) / 1000
+        }
+
+        const durationIsCharge = bounds !== 'unbounded'
+        if (durationIsCharge && durationSec > 0 && isFiniteNum(energyIn)) {
+          powerAvgKw = energyIn / (durationSec / 3600)
+        }
+
+        return {
+          kind: 'charge',
+          start_ts: rest.start_ts,
+          end_ts: rest.end_ts,
+          energy_in_kwh: energyIn,
+          charge_ah: chargeAh,
+          soc_start: socStart,
+          soc_end: socEnd,
+          soc_delta_pct: socDelta,
+          bounds,
+          duration_is_charge: durationIsCharge,
+          duration_sec: durationSec,
+          power_avg_kw: powerAvgKw,
+          connector_confirmed: !!rest.connectorSeen1,
+          ac_energy_kwh: acEnergyKwh,
+          charge_efficiency: chargeEfficiency,
+          charge_type: 'unknown',
+          complete,
+          // Genuine in-session coverage samples (0 for a pure sleep charge).
+          sample_count: rest.coverageSamples || 0,
+          max_gap_sec: rest.maxGapMs / 1000,
+          closed_by: closedBy,
+          gear_at_close: null,
+          schema_version: SCHEMA_VERSION
+        }
+      }
+
+      const buildPark = (rest, closedBy) => {
+        const start = rest.startSnapshot
+        const end = rest.lastSnapshot
+        let complete = true
+        const socStart = start.soc
+        const socEnd = end.soc
+        const socDelta = (isFiniteNum(socStart) && isFiniteNum(socEnd)) ? socEnd - socStart : null
+        if (!isFiniteNum(socStart) || !isFiniteNum(socEnd)) complete = false
+        const durationSec = (rest.end_ts - rest.start_ts) / 1000
+
+        // %/day drain only meaningful for a park longer than the floor.
+        let drainPerDay = null
+        if (isFiniteNum(socDelta) && (rest.end_ts - rest.start_ts) >= config.drainMinDurationMs && durationSec > 0) {
+          drainPerDay = -socDelta / (durationSec / 86400)
+        }
+
+        return {
+          kind: 'park',
+          start_ts: rest.start_ts,
+          end_ts: rest.end_ts,
+          duration_sec: durationSec,
+          soc_start: socStart,
+          soc_end: socEnd,
+          soc_delta_pct: socDelta,
+          soc_drain_pct_per_day: drainPerDay,
+          aux12v_start: isFiniteNum(rest.aux12vStart) ? rest.aux12vStart : null,
+          aux12v_end: isFiniteNum(end.aux_12v) ? end.aux_12v : null,
+          // A park should not be plugged: confirmed when the connector never read 1.
+          connector_confirmed: !rest.connectorSeen1,
+          complete,
+          sample_count: rest.coverageSamples || 0,
+          max_gap_sec: rest.maxGapMs / 1000,
+          closed_by: closedBy,
+          gear_at_close: null,
+          schema_version: SCHEMA_VERSION
+        }
+      }
+
+      // Classify a closed rest as charge or park by pack-counter / SoC deltas,
+      // then emit. Energy/Ah/SoC deltas are always valid (differences of monotonic
+      // readings), robust even across a total sleep gap.
+      const finalizeRest = (rest, closedBy) => {
+        const start = rest.startSnapshot
+        const end = rest.lastSnapshot
+        const dIn = safeDelta(start.cum_in_kwh, end.cum_in_kwh, config.maxPlausibleStepKwh)
+        const dAh = safeDelta(start.cum_chg_ah, end.cum_chg_ah, config.maxPlausibleStepAh)
+        const dSoc = (isFiniteNum(start.soc) && isFiniteNum(end.soc)) ? end.soc - start.soc : null
+        const isCharge =
+          (isFiniteNum(dIn.value) && dIn.value >= config.chargeMinKwh) ||
+          (isFiniteNum(dAh.value) && dAh.value >= config.chargeMinAh) ||
+          (isFiniteNum(dSoc) && dSoc >= config.chargeMinSocPct)
+
+        if (isCharge) {
+          emit('charge', buildCharge(rest, closedBy))
+        } else {
+          emit('park', buildPark(rest, closedBy))
+        }
+        // Consume the meter edges that belong to this closed rest.
+        persistedCache.meterEdges = persistedCache.meterEdges.filter((e) => e.ts > rest.end_ts)
+      }
+
+      const closeRestOpenTrip = (rest, ts, rxTs, closedBy) => {
+        finalizeRest(rest, closedBy || 'motion_resume')
+        persistedCache.open = newTrip(ts, rxTs)
+        recordOdometer(persistedCache.open)
+      }
+
+      // --- silence timer -------------------------------------------------------
+
+      // Fires silenceTimeoutMs after the last sample. Closes a trailing trip at
+      // its LAST-MOTION time (never "now") and opens a pending rest; if a rest is
+      // already open it is left as-is (idempotent — never a second rest).
+      function onSilence () {
+        silenceTimer = null
+        const open = persistedCache.open
+        if (!open) return
+        if (open.kind === 'trip') {
+          const endTs = open.lastMotionTs
+          const gearAtClose = merged.gear === config.gearParkValue ? config.gearParkValue : null
+          closeTripOpenRest(open, closedByFor('silence_timeout', open), endTs, gearAtClose, open.lastRxTs)
+          log('silence closed trailing trip at', endTs)
+        } else {
+          log('silence: rest already open, extending (no second rest)')
+        }
+      }
+
+      // --- core evaluation (per vmcu / bms sample) -----------------------------
+
+      const evaluate = (ts, rxTs) => {
+        const prevRxTs = persistedCache.lastSampleRxTs
+        const prevIgnition = persistedCache.lastIgnition
+        const gap = prevRxTs != null && isFiniteNum(rxTs) ? rxTs - prevRxTs : null
+        const st = motionState()
+        const gearP = st === 'park'
+        const ignitionEdge = prevIgnition === 1 && merged.ignition === 0
+        const gearAtClose = merged.gear === config.gearParkValue ? config.gearParkValue : null
+        let open = persistedCache.open
+
+        if (!open) {
+          // Cold start: open a trip if moving, else a rest (park by default).
+          if (st === 'moving') {
+            open = newTrip(ts, rxTs)
+            recordOdometer(open)
+            persistedCache.open = open
+          } else {
+            // Seed lastRxTs from the previous sample's receipt time (if any) so a
+            // gap that opened this rest is measured; on a true cold start there is
+            // no prior reference (null -> the first gap is simply not counted).
+            const seedRxTs = isFiniteNum(prevRxTs) ? prevRxTs : rxTs
+            open = newRest(ts, snapshot(ts, rxTs), seedRxTs)
+            persistedCache.open = open
+          }
+        } else if (open.kind === 'trip') {
+          if (st === 'moving') {
+            // Cannot sleep mid-motion: continue the trip regardless of gap length
+            // (a highway reboot / tunnel is moving on both sides). A trip that
+            // resumes moving after a restart is a LIVE trip, not a lazy-close.
+            if (open === restartSession) { restarted = false; restartSession = null }
+            accumulate(open, ts, rxTs, gap == null || gap < config.rebootMaxGapMs)
+            advanceMotion(open, ts, rxTs)
+          } else if (gearP) {
+            accumulate(open, ts, rxTs, false)
+            open = closeTripOpenRest(open, closedByFor('gear_park', open), open.lastMotionTs, gearAtClose, rxTs)
+          } else if (ignitionEdge) {
+            accumulate(open, ts, rxTs, false)
+            open = closeTripOpenRest(open, closedByFor('ignition_edge', open), open.lastMotionTs, gearAtClose, rxTs)
+          } else if (gap != null && gap >= config.restGapMs) {
+            // Long gap with a stationary far side = a genuine rest boundary. Close
+            // the trip at its last-motion sample; this stationary sample opens the
+            // rest and refreshes its snapshot. Seed the rest's lastRxTs from the
+            // TRIP's pre-gap receipt time (not this far-side sample's rxTs) so the
+            // opening sleep gap lands in maxGapMs and `continuous` becomes false —
+            // otherwise coverage-bounding would fabricate a whole-span rate.
+            const rest = closeTripOpenRest(open, closedByFor('gap_stationary', open), open.lastMotionTs, gearAtClose, open.lastRxTs)
+            accumulate(rest, ts, rxTs, true)
+            open = rest
+          } else if (st === 'ambiguous') {
+            // gear=N (neutral at a light / rolling) is never a split on its own.
+            accumulate(open, ts, rxTs, true)
+          } else {
+            // Stationary (gear absent, low speed), short gap: still the same trip
+            // until the OBSERVED stationary stretch exceeds minRestSplitMs.
+            accumulate(open, ts, rxTs, true)
+            if (open.stationarySince == null) open.stationarySince = rxTs
+            if (isFiniteNum(rxTs) && rxTs - open.stationarySince > config.minRestSplitMs) {
+              // Seed the rest's lastRxTs from the trip's pre-close receipt time so
+              // inter-sample gaps are measured continuously across the boundary.
+              const rest = closeTripOpenRest(open, closedByFor('idle_split', open), open.lastMotionTs, gearAtClose, open.lastRxTs)
+              accumulate(rest, ts, rxTs, true)
+              open = rest
+            }
+          }
+        } else { // open.kind === 'rest'
+          if (st === 'moving') {
+            // Motion resumes -> the rest ends at THIS sample and is classified.
+            // The resuming sample is a boundary, NOT an intermediate awake sample,
+            // so it does not count toward sample_count / bounds classification.
+            accumulate(open, ts, rxTs, false)
+            closeRestOpenTrip(open, ts, rxTs, closedByFor('motion_resume', open))
+            open = persistedCache.open
+          } else {
+            // Still at rest (awake-idle or asleep): extend the rest, refresh its
+            // snapshot. A stationary resume does NOT split / close an ongoing rest.
+            accumulate(open, ts, rxTs, true)
+          }
+        }
+
+        persistedCache.lastSampleRxTs = rxTs
+        persistedCache.lastSampleTs = ts
+        if (isFiniteNum(merged.ignition)) persistedCache.lastIgnition = merged.ignition
+        armSilenceTimer()
+      }
+
+      // --- telemetry ingestion -------------------------------------------------
+
+      const onBms = (payload) => {
+        if (!payload || typeof payload !== 'object') return
+        const soc = socOf(payload)
+        // Require at least one usable numeric field to advance state.
+        const hasUsable = isFiniteNum(payload.ignition) || isFiniteNum(payload.speed_kph) ||
+          isFiniteNum(soc) || isFiniteNum(payload.cum_in_kwh) || isFiniteNum(payload.cum_out_kwh)
+        if (!hasUsable) { log('ignoring malformed bms payload'); return }
+        if (isFiniteNum(payload.ignition)) merged.ignition = payload.ignition
+        if (isFiniteNum(payload.speed_kph)) merged.speed = payload.speed_kph
+        if (isFiniteNum(soc)) merged.soc = soc
+        if (isFiniteNum(payload.hv_kw)) merged.hv_kw = payload.hv_kw
+        if (isFiniteNum(payload.aux_12v)) merged.aux_12v = payload.aux_12v
+        if (isFiniteNum(payload.cum_out_kwh)) merged.cum_out_kwh = payload.cum_out_kwh
+        if (isFiniteNum(payload.cum_in_kwh)) merged.cum_in_kwh = payload.cum_in_kwh
+        if (isFiniteNum(payload.cum_chg_ah)) merged.cum_chg_ah = payload.cum_chg_ah
+        const ts = isFiniteNum(payload.ts) ? payload.ts : Date.now()
+        merged.ts = ts
+        evaluate(ts, Date.now())
+      }
+
+      const onVmcu = (payload) => {
+        if (!payload || typeof payload !== 'object') return
+        const hasUsable = typeof payload.gear === 'string' || isFiniteNum(payload.speed_kph)
+        if (!hasUsable) { log('ignoring malformed vmcu payload'); return }
+        if (typeof payload.gear === 'string') merged.gear = payload.gear
+        if (isFiniteNum(payload.speed_kph)) merged.speed = payload.speed_kph
+        const ts = isFiniteNum(payload.ts) ? payload.ts : Date.now()
+        merged.ts = ts
+        evaluate(ts, Date.now())
+      }
+
+      // odometer / connector / ambient refresh their fields (and the open
+      // session's boundary tracking) but do NOT trigger a state evaluation.
+      const onOdometer = (payload) => {
+        if (!payload || typeof payload !== 'object') return
+        const km = isFiniteNum(payload.odometer) ? payload.odometer : payload.km
+        if (!isFiniteNum(km)) return
+        merged.odometer = km
+        if (isFiniteNum(payload.ts)) merged.ts = payload.ts
+        recordOdometer(persistedCache.open)
+      }
+
+      const onConnector = (payload) => {
+        if (!payload || typeof payload !== 'object') return
+        if (!isFiniteNum(payload.charge_connector)) return
+        merged.connector = payload.charge_connector
+        const open = persistedCache.open
+        if (open && open.kind === 'rest') {
+          if (!Array.isArray(open.connectorEdges)) open.connectorEdges = []
+          const ts = isFiniteNum(payload.ts) ? payload.ts : Date.now()
+          const prev = isFiniteNum(open.connectorPrev) ? open.connectorPrev : null
+          // Capture the plug (0->1) and unplug (1->0) edges so a charge can be
+          // bounded to when the connector was actually engaged.
+          if (prev !== 1 && payload.charge_connector === 1) open.connectorEdges.push({ type: 'on', ts })
+          else if (prev === 1 && payload.charge_connector === 0) open.connectorEdges.push({ type: 'off', ts })
+          open.connectorPrev = payload.charge_connector
+          open.connectorSeenAny = true
+          if (payload.charge_connector === 1) open.connectorSeen1 = true
+        } else if (open && open.kind === 'trip') {
+          if (payload.charge_connector === 1) open.containedPlugged = true
+          open.prevConnector = payload.charge_connector
+        }
+      }
+
+      const onAmbient = (payload) => {
+        if (!payload || typeof payload !== 'object') return
+        const a = isFiniteNum(payload.ambient_c) ? payload.ambient_c : payload.ambient
+        if (isFiniteNum(a)) merged.ambient = a
+      }
+
+      // Charger meter (a separate always-on Modbus device): debounce its power
+      // crossings into on/off EDGES, each storing {ts, act}. Two edges are all a
+      // metered charge needs; storing edges (not a raw buffer) lets an on-edge at
+      // the START of a 10 h overnight charge survive to rest-close and a restart.
+      const onChargerMeter = (payload) => {
+        if (!payload || typeof payload !== 'object') return
+        if (!isFiniteNum(payload.ap)) return
+        const ts = isFiniteNum(payload.ts) ? payload.ts : Date.now()
+        const act = isFiniteNum(payload.act) ? payload.act : null
+        const ms = persistedCache.meterState
+        if (!ms.on) {
+          if (payload.ap > config.chargerMeterOnW) {
+            if (ms.aboveSince == null) { ms.aboveSince = ts; ms.aboveAct = act } else if (ts - ms.aboveSince >= config.chargerMeterOnMinMs) {
+              ms.on = true
+              persistedCache.meterEdges.push({ type: 'on', ts: ms.aboveSince, act: ms.aboveAct })
+              ms.belowSince = null
+            }
+          } else {
+            ms.aboveSince = null
+          }
+        } else {
+          if (payload.ap < config.chargerMeterOnW) {
+            if (ms.belowSince == null) { ms.belowSince = ts; ms.belowAct = act } else if (ts - ms.belowSince >= config.chargerMeterOffMinMs) {
+              ms.on = false
+              persistedCache.meterEdges.push({ type: 'off', ts: ms.belowSince, act: ms.belowAct })
+              ms.aboveSince = null
+            }
+          } else {
+            ms.belowSince = null
+          }
+        }
+        // Persist the mutated meterState (reactivity tracks the assignment).
+        persistedCache.meterState = ms
+
+        // Keep the edge record bounded. Edges are consumed on rest close, but while
+        // a trip is open any edge older than the trip start belongs to an
+        // already-closed rest and is stale; drop those, then hard-cap the length so
+        // pathological meter toggling can never grow the cache without limit.
+        const open = persistedCache.open
+        let edges = persistedCache.meterEdges
+        if (open && open.kind === 'trip' && isFiniteNum(open.start_ts)) {
+          edges = edges.filter((e) => e.ts >= open.start_ts)
+        }
+        if (edges.length > MAX_METER_EDGES) edges = edges.slice(edges.length - MAX_METER_EDGES)
+        persistedCache.meterEdges = edges
+      }
+
+      await Promise.all([
+        mqtt.subscribe(config.bmsTopic, onBms),
+        mqtt.subscribe(config.vmcuTopic, onVmcu),
+        mqtt.subscribe(config.odometerTopic, onOdometer),
+        mqtt.subscribe(config.connectorTopic, onConnector),
+        mqtt.subscribe(config.ambientTopic, onAmbient),
+        mqtt.subscribe(config.chargerMeterTopic, onChargerMeter)
+      ])
+    }
+  }
+}

--- a/docker/automations/bots/ioniq-sessions.test.js
+++ b/docker/automations/bots/ioniq-sessions.test.js
@@ -1,0 +1,641 @@
+const { afterEach, beforeEach, describe, expect, it, jest } = require('@jest/globals')
+const createIoniqSessions = require('./ioniq-sessions')
+
+// Real prod topic shapes (spec §7 / §8): gear lives on vmcu, ignition/soc/counters
+// on bms/2101, odometer/connector/ambient on their own frames, and the always-on
+// household charger meter on the modbus monitoring topic.
+const BMS = 'ioniq/parsed/bms/2101'
+const VMCU = 'ioniq/parsed/vmcu'
+const ODO = 'ioniq/parsed/odometer'
+const CONN = 'ioniq/parsed/bcm_b00e'
+const AMBIENT = 'ioniq/parsed/ambient'
+const METER = '/modbus/monitoring/charger/reading'
+const TRIP = 'ioniq/derived/trip'
+const CHARGE = 'ioniq/derived/charge'
+const PARK = 'ioniq/derived/park'
+const BASE = 1700000000000
+
+describe('ioniq-sessions bot', () => {
+  let mqtt, persistedCache, bot
+
+  function makeMqtt () {
+    const cbs = {}
+    return {
+      _cbs: cbs,
+      subscribe: jest.fn().mockImplementation((topic, cb) => { cbs[topic] = cb; return Promise.resolve() }),
+      // Capture the de-dup marker AT PUBLISH TIME so tests can assert it was set
+      // in the pre-publish mutation (exactly-once mitigation, spec §5.5).
+      publish: jest.fn().mockImplementation((topic, payload) => {
+        mqtt._published.push({
+          topic,
+          payload,
+          lastEmittedAtPublish: persistedCache.lastEmitted ? { ...persistedCache.lastEmitted } : null
+        })
+        return Promise.resolve()
+      }),
+      _published: [],
+      _emit: (topic, msg) => (cbs[topic] ? cbs[topic](msg) : undefined)
+    }
+  }
+
+  function makeCache () {
+    return {
+      open: null,
+      meterEdges: [],
+      meterState: { on: false, aboveSince: null, aboveAct: null, belowSince: null, belowAct: null },
+      lastSampleRxTs: null,
+      lastSampleTs: null,
+      lastIgnition: null,
+      lastEmitted: null,
+      seq: 0
+    }
+  }
+
+  const start = async (cache) => {
+    persistedCache = cache
+    bot = createIoniqSessions('ioniq-sessions', {})
+    await bot.start({ mqtt, persistedCache })
+  }
+
+  // Feed a frame at receipt (fake) time BASE+offset, payload ts = same.
+  const at = (offset) => jest.setSystemTime(BASE + offset)
+  const bms = (offset, fields) => { at(offset); return mqtt._emit(BMS, { ts: BASE + offset, ...fields }) }
+  const vmcu = (offset, fields) => { at(offset); return mqtt._emit(VMCU, { ts: BASE + offset, ...fields }) }
+  const odo = (offset, km) => { at(offset); return mqtt._emit(ODO, { ts: BASE + offset, odometer: km }) }
+  const conn = (offset, v) => { at(offset); return mqtt._emit(CONN, { ts: BASE + offset, charge_connector: v }) }
+  const ambient = (offset, c) => { at(offset); return mqtt._emit(AMBIENT, { ts: BASE + offset, ambient_c: c }) }
+  const meter = (offset, ap, act) => { at(offset); return mqtt._emit(METER, { ts: BASE + offset, ap, act }) }
+
+  const published = (topic) => mqtt._published.filter((p) => p.topic === topic).map((p) => p.payload)
+  const lastOn = (topic) => { const a = published(topic); return a.length ? a[a.length - 1] : undefined }
+
+  beforeEach(async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(BASE)
+    mqtt = makeMqtt()
+    await start(makeCache())
+  })
+  afterEach(() => { jest.useRealTimers() })
+
+  it('subscribes to all six input topics', () => {
+    expect(mqtt.subscribe).toHaveBeenCalledWith(BMS, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(VMCU, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(ODO, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(CONN, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(AMBIENT, expect.any(Function))
+    expect(mqtt.subscribe).toHaveBeenCalledWith(METER, expect.any(Function))
+  })
+
+  describe('trip segmentation', () => {
+    it('emits one clean trip with correct deltas, closed by ignition edge', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 73, hv_kw: 30, cum_out_kwh: 100, cum_in_kwh: 10, cum_chg_ah: 5 })
+      odo(0, 1000)
+      ambient(0, 21)
+      bms(60000, { ignition: 1, speed_kph: 45, soc: 67, hv_kw: 25, cum_out_kwh: 102, cum_in_kwh: 10, cum_chg_ah: 5 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 61, hv_kw: 20, cum_out_kwh: 104.7, cum_in_kwh: 10, cum_chg_ah: 5 })
+      odo(120000, 1040)
+      // ignition 1->0 with the car stopped closes the awake session at the last motion sample.
+      bms(130000, { ignition: 0, speed_kph: 0, soc: 61, hv_kw: 0, cum_out_kwh: 104.7, cum_in_kwh: 10, cum_chg_ah: 5 })
+
+      const trips = published(TRIP)
+      expect(trips).toHaveLength(1)
+      const t = trips[0]
+      expect(t._type).toBe('ioniq-session')
+      expect(t.kind).toBe('trip')
+      expect(t.start_ts).toBe(BASE + 0)
+      expect(t.end_ts).toBe(BASE + 120000)
+      expect(t.duration_sec).toBe(120)
+      expect(t.distance_km).toBeCloseTo(40, 5)
+      expect(t.energy_out_kwh).toBeCloseTo(4.7, 5)
+      expect(t.soc_start).toBe(73)
+      expect(t.soc_end).toBe(61)
+      expect(t.soc_delta_pct).toBe(-12)
+      expect(t.efficiency_wh_per_km).toBeCloseTo(117.5, 3)
+      expect(t.speed_max_kph).toBe(45)
+      expect(t.power_max_kw).toBe(30)
+      expect(t.ambient_c).toBe(21)
+      expect(t.closed_by).toBe('ignition_edge')
+      expect(t.complete).toBe(true)
+      expect(t.start_truncated).toBe(true)
+      expect(t.schema_version).toBe(1)
+    })
+
+    it('closes a trip immediately on gear=P before minRestSplit elapses', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 58 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 56 })
+      vmcu(125000, { gear: 'P', speed_kph: 0 })
+
+      const trips = published(TRIP)
+      expect(trips).toHaveLength(1)
+      expect(trips[0].closed_by).toBe('gear_park')
+      expect(trips[0].gear_at_close).toBe('P')
+      expect(trips[0].end_ts).toBe(BASE + 120000)
+    })
+
+    it('does not split a trip when stopped in gear D past minRestSplit (red light)', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      vmcu(60000, { gear: 'D', speed_kph: 0 })
+      vmcu(200000, { gear: 'D', speed_kph: 0 })
+      vmcu(400000, { gear: 'D', speed_kph: 0 }) // well past minRestSplit, still in D
+      vmcu(410000, { gear: 'P', speed_kph: 0 })
+
+      expect(published(TRIP)).toHaveLength(1)
+      expect(published(PARK)).toHaveLength(0)
+    })
+
+    it('does not split a trip on gear=N (ambiguous) past minRestSplit', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 59 })
+      vmcu(120000, { gear: 'N', speed_kph: 0 })
+      vmcu(320000, { gear: 'N', speed_kph: 0 }) // past minRestSplit
+      vmcu(330000, { gear: 'P', speed_kph: 0 })
+
+      expect(published(TRIP)).toHaveLength(1)
+    })
+
+    it('splits on a stationary stretch beyond minRestSplit when gear is absent', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 59 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 58 })
+      // stationary, gear absent
+      bms(130000, { ignition: 1, speed_kph: 0, soc: 58 })
+      bms(200000, { ignition: 1, speed_kph: 0, soc: 58 })
+      bms(320000, { ignition: 1, speed_kph: 0, soc: 58 }) // 190s stationary > minRestSplit
+
+      const trips = published(TRIP)
+      expect(trips).toHaveLength(1)
+      expect(trips[0].closed_by).toBe('idle_split')
+      expect(trips[0].end_ts).toBe(BASE + 120000)
+    })
+
+    it('does not split a trip across a reboot gap with motion on both sides', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 45, soc: 59 })
+      // gap of 400s (>= restGapMs) but the far side is MOVING -> cannot wake mid-motion.
+      bms(460000, { ignition: 1, speed_kph: 50, soc: 55 })
+      bms(520000, { ignition: 1, speed_kph: 40, soc: 54 })
+      vmcu(525000, { gear: 'P', speed_kph: 0 })
+
+      const trips = published(TRIP)
+      expect(trips).toHaveLength(1)
+      expect(trips[0].end_ts).toBe(BASE + 520000)
+      expect(published(PARK)).toHaveLength(0)
+    })
+
+    it('does not split a trip on a 2-minute reboot gap with a brief stationary reading', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 45, soc: 59 })
+      // 2-min reboot gap (< rebootMaxGapMs), momentary 0 speed as the logger comes up.
+      bms(180000, { ignition: 1, speed_kph: 0, soc: 58 })
+      bms(185000, { ignition: 1, speed_kph: 45, soc: 58 })
+      vmcu(200000, { gear: 'P', speed_kph: 0 })
+
+      expect(published(TRIP)).toHaveLength(1)
+      expect(published(PARK)).toHaveLength(0)
+    })
+
+    it('rejects a degenerate single-sample jitter trip (no record, no timestamp collision)', () => {
+      bms(0, { ignition: 1, speed_kph: 0, soc: 60 }) // stationary -> opens a rest (park)
+      bms(60000, { ignition: 1, speed_kph: 5, soc: 60 }) // lone jitter above 3 km/h -> opens a trip
+      bms(65000, { ignition: 0, speed_kph: 0, soc: 60 }) // ignition edge closes the 1-sample trip
+
+      expect(published(TRIP)).toHaveLength(0)
+    })
+  })
+
+  describe('rest classification', () => {
+    it('emits an UNBOUNDED charge across a sleep gap without fabricating a rate', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 100, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 102, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 104, cum_in_kwh: 20, cum_chg_ah: 100 })
+      // silence closes the trailing trip at the last motion sample, opening a pending rest.
+      jest.advanceTimersByTime(300000)
+      // plug in (captured while the logger briefly lingers), then long sleep.
+      conn(430000, 1)
+      // resume ~overnight later, moving, with a big SoC / cum_in jump = invisible charge.
+      bms(500000, { ignition: 1, speed_kph: 5, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      expect(published(TRIP)).toHaveLength(1)
+      expect(published(TRIP)[0].closed_by).toBe('silence_timeout')
+      expect(published(TRIP)[0].end_ts).toBe(BASE + 120000)
+
+      const charges = published(CHARGE)
+      expect(charges).toHaveLength(1)
+      const c = charges[0]
+      expect(c.kind).toBe('charge')
+      expect(c.energy_in_kwh).toBeCloseTo(10.1, 5)
+      expect(c.soc_delta_pct).toBe(32)
+      expect(c.bounds).toBe('unbounded')
+      expect(c.duration_is_charge).toBe(false)
+      expect(c.power_avg_kw).toBeNull() // never a fabricated ~1 kW drive-to-drive rate
+      expect(c.connector_confirmed).toBe(true)
+      expect(published(PARK)).toHaveLength(0)
+    })
+
+    it('emits a METER-BOUNDED home charge with real power, AC energy and efficiency', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 100, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 102, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 104, cum_in_kwh: 20, cum_chg_ah: 100 })
+      vmcu(122000, { gear: 'P', speed_kph: 0 }) // park closes trip, opens rest
+      conn(123000, 1)
+      // charger meter: power on 200s..300s (debounced), then off.
+      meter(200000, 1200, 1000)
+      meter(260000, 1200, 1000.5) // sustained >60s -> ON edge at 200000
+      meter(300000, 0, 1012.46)
+      meter(420000, 0, 1012.46) // below >120s -> OFF edge at 300000
+      bms(430000, { ignition: 1, speed_kph: 5, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      const charges = published(CHARGE)
+      expect(charges).toHaveLength(1)
+      const c = charges[0]
+      expect(c.bounds).toBe('meter')
+      expect(c.duration_is_charge).toBe(true)
+      expect(c.energy_in_kwh).toBeCloseTo(10.1, 5)
+      expect(c.ac_energy_kwh).toBeCloseTo(12.46, 5)
+      expect(c.charge_efficiency).toBeCloseTo(10.1 / 12.46, 5)
+      expect(c.duration_sec).toBe(100)
+      expect(typeof c.power_avg_kw).toBe('number')
+      expect(Number.isFinite(c.power_avg_kw)).toBe(true)
+      expect(c.connector_confirmed).toBe(true)
+    })
+
+    it('does not fabricate a rate on a realistic overnight charge (stationary wake before motion)', () => {
+      // The logger boots ~1-2 min AFTER ignition, so the first post-sleep sample
+      // is STATIONARY (driver has not pulled away yet). That trailing wake sample
+      // must not be mistaken for genuine intermediate charge coverage.
+      bms(0, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 100, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 102, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 104, cum_in_kwh: 20, cum_chg_ah: 100 })
+      jest.advanceTimersByTime(300000) // silence closes trip, opens pending rest
+      conn(430000, 1) // plugged, no OFF edge captured (logger slept through unplug)
+      // resume: stationary wake sample first, THEN motion — realistic ordering.
+      bms(500000, { ignition: 1, speed_kph: 0, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+      expect(published(CHARGE)).toHaveLength(0) // stationary resume must not close the rest
+      bms(560000, { ignition: 1, speed_kph: 5, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      const charges = published(CHARGE)
+      expect(charges).toHaveLength(1)
+      const c = charges[0]
+      expect(c.bounds).toBe('unbounded')
+      expect(c.power_avg_kw).toBeNull() // NOT a fabricated ~74 kW rate over the whole rest span
+      expect(c.duration_is_charge).toBe(false)
+      expect(c.energy_in_kwh).toBeCloseTo(10.1, 5) // energy still valid
+    })
+
+    it('bounds a charge to captured connector edges (bounds:connector), not the whole rest', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 52, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 52, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 52, cum_in_kwh: 20, cum_chg_ah: 100 })
+      vmcu(122000, { gear: 'P', speed_kph: 0 }) // close trip, open rest
+      conn(150000, 0)
+      conn(180000, 1) // 0->1 ON edge at 180000
+      bms(200000, { ignition: 1, speed_kph: 0, soc: 70, cum_in_kwh: 25, cum_chg_ah: 115 })
+      bms(260000, { ignition: 1, speed_kph: 0, soc: 80, cum_in_kwh: 29, cum_chg_ah: 125 })
+      conn(300000, 0) // 1->0 OFF edge at 300000
+      bms(360000, { ignition: 1, speed_kph: 5, soc: 84, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      const c = published(CHARGE)
+      expect(c).toHaveLength(1)
+      expect(c[0].bounds).toBe('connector')
+      expect(c[0].duration_sec).toBe(120) // 180000..300000, NOT the ~238s whole-rest span
+      expect(c[0].energy_in_kwh).toBeCloseTo(10.1, 5)
+      expect(typeof c[0].power_avg_kw).toBe('number')
+    })
+
+    it('bounds a continuous powered-mode charge to intermediate awake samples (bounds:awake)', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 52, cum_in_kwh: 20 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 52, cum_in_kwh: 20 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 52, cum_in_kwh: 20 })
+      vmcu(122000, { gear: 'P', speed_kph: 0 })
+      // continuous awake coverage (no sleep gap), NO connector edges, NO meter
+      bms(180000, { ignition: 1, speed_kph: 0, soc: 60, cum_in_kwh: 22 })
+      bms(240000, { ignition: 1, speed_kph: 0, soc: 66, cum_in_kwh: 24 })
+      bms(300000, { ignition: 1, speed_kph: 0, soc: 70, cum_in_kwh: 26 })
+      bms(360000, { ignition: 1, speed_kph: 5, soc: 70, cum_in_kwh: 26 }) // resume moving
+
+      const c = published(CHARGE)
+      expect(c).toHaveLength(1)
+      expect(c[0].bounds).toBe('awake')
+      expect(c[0].duration_sec).toBe(120) // coverage span 180000..300000, NOT whole-rest span
+      expect(typeof c[0].power_avg_kw).toBe('number')
+    })
+
+    it('does not fabricate a rate when a charge opens via gap_stationary (opening gap recorded)', () => {
+      // Closes via gap_stationary (NOT the silence timer): a single gap >= restGapMs
+      // whose far side is stationary and carries the charge energy, then a
+      // continuous awake tail, then motion. The opening sleep gap MUST land in
+      // maxGapMs so `continuous` is false and the charge degrades to unbounded.
+      bms(0, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 100, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 102, cum_in_kwh: 20, cum_chg_ah: 100 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 52, cum_out_kwh: 104, cum_in_kwh: 20, cum_chg_ah: 100 })
+      // 340s gap (>= restGapMs) with the charge landing in it; far side stationary.
+      bms(460000, { ignition: 1, speed_kph: 0, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+      // continuous awake tail (contiguous samples)
+      bms(520000, { ignition: 1, speed_kph: 0, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+      bms(580000, { ignition: 1, speed_kph: 0, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+      bms(640000, { ignition: 1, speed_kph: 5, soc: 84, cum_out_kwh: 104, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      const c = published(CHARGE)
+      expect(c).toHaveLength(1)
+      expect(c[0].bounds).toBe('unbounded')
+      expect(c[0].power_avg_kw).toBeNull() // NOT a fabricated ~600 kW rate
+      expect(c[0].duration_is_charge).toBe(false)
+      expect(c[0].energy_in_kwh).toBeCloseTo(10.1, 5)
+      expect(c[0].max_gap_sec).toBe(340) // the real opening gap, not ~0/30
+    })
+
+    it('classifies a parasitic-drain park and computes %/day drain', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 60 })
+      vmcu(122000, { gear: 'P', speed_kph: 0, aux_12v: 12.8 })
+      bms(123000, { ignition: 1, speed_kph: 0, soc: 60, aux_12v: 12.8 })
+      // resume 2h later, SoC drained 5% -> park, negative delta.
+      bms(120000 + 7200000, { ignition: 1, speed_kph: 5, soc: 55, aux_12v: 12.4 })
+
+      const parks = published(PARK)
+      expect(parks).toHaveLength(1)
+      const p = parks[0]
+      expect(p.kind).toBe('park')
+      expect(p.soc_delta_pct).toBe(-5)
+      expect(p.soc_drain_pct_per_day).toBeCloseTo(60, 1) // 5% over 2h -> 60%/day
+      expect(p.connector_confirmed).toBe(true)
+    })
+
+    it('nulls %/day drain for a park shorter than drainMinDurationMs', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 60 })
+      vmcu(122000, { gear: 'P', speed_kph: 0 })
+      // resume only 30 min later (< 1 h floor).
+      bms(120000 + 1800000, { ignition: 1, speed_kph: 5, soc: 59 })
+
+      const parks = published(PARK)
+      expect(parks).toHaveLength(1)
+      expect(parks[0].soc_drain_pct_per_day).toBeNull()
+    })
+
+    it('collapses awake-idle + sleep into exactly one rest', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 60 })
+      // awake-idle stationary long enough to split the trip -> opens a rest
+      bms(130000, { ignition: 1, speed_kph: 0, soc: 60 })
+      bms(200000, { ignition: 1, speed_kph: 0, soc: 60 })
+      bms(320000, { ignition: 1, speed_kph: 0, soc: 60 }) // idle_split
+      bms(380000, { ignition: 1, speed_kph: 0, soc: 60 }) // still awake-idle, in the rest
+      // then the car sleeps: silence timer fires -> must NOT create a second rest
+      jest.advanceTimersByTime(300000)
+      // resume moving -> exactly one rest is closed
+      bms(700000, { ignition: 1, speed_kph: 5, soc: 60 })
+
+      expect(published(TRIP)).toHaveLength(1)
+      expect(published(PARK)).toHaveLength(1)
+      expect(published(CHARGE)).toHaveLength(0)
+    })
+  })
+
+  describe('missing-data & counter guards', () => {
+    it('nulls distance and efficiency with fewer than 2 distinct odometer readings', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60, cum_out_kwh: 100, cum_in_kwh: 10 })
+      odo(0, 1000) // only ONE odometer reading
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 58, cum_out_kwh: 102, cum_in_kwh: 10 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 56, cum_out_kwh: 104, cum_in_kwh: 10 })
+      vmcu(125000, { gear: 'P', speed_kph: 0 })
+
+      const t = published(TRIP)[0]
+      expect(t.distance_km).toBeNull() // never last-first = 0
+      expect(t.efficiency_wh_per_km).toBeNull() // guarded against Infinity/NaN
+    })
+
+    it('reports approximate distance with low odometer_coverage for interior readings', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60, cum_out_kwh: 100, cum_in_kwh: 10 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 58, cum_out_kwh: 102, cum_in_kwh: 10 })
+      odo(60000, 1000) // interior readings only
+      odo(90000, 1040)
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 56, cum_out_kwh: 104, cum_in_kwh: 10 })
+      vmcu(125000, { gear: 'P', speed_kph: 0 })
+
+      const t = published(TRIP)[0]
+      expect(t.distance_km).toBeCloseTo(40, 5)
+      expect(t.odometer_coverage).toBeLessThan(0.5) // 30s span of a 120s trip
+    })
+
+    it('nulls a metric on a negative counter delta (reset) and marks incomplete', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60, cum_out_kwh: 100 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 58, cum_out_kwh: 98 }) // counter went DOWN
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 56, cum_out_kwh: 95 })
+      vmcu(125000, { gear: 'P', speed_kph: 0 })
+
+      const t = published(TRIP)[0]
+      expect(t.energy_out_kwh).toBeNull()
+      expect(t.complete).toBe(false)
+    })
+
+    it('does NOT null a large but legitimate jump (60 km trip, 10 kWh charge)', () => {
+      bms(0, { ignition: 1, speed_kph: 90, soc: 90, cum_out_kwh: 100, cum_in_kwh: 20 })
+      odo(0, 1000)
+      bms(60000, { ignition: 1, speed_kph: 90, soc: 70, cum_out_kwh: 110, cum_in_kwh: 20 })
+      odo(60000, 1060) // +60 km, legitimate
+      vmcu(65000, { gear: 'P', speed_kph: 0 })
+
+      const t = published(TRIP)[0]
+      expect(t.distance_km).toBeCloseTo(60, 5) // 60 < maxPlausibleStepKm (400)
+      expect(t.energy_out_kwh).toBeCloseTo(10, 5) // 10 < maxPlausibleStepKwh (40)
+      expect(t.complete).toBe(true)
+    })
+
+    it('marks a rest incomplete with null soc when the pre-gap boundary is missing', async () => {
+      // Bot started mid-gap: an open rest exists but its start snapshot is null.
+      const cache = makeCache()
+      cache.open = {
+        kind: 'rest',
+        start_ts: BASE + 100000,
+        startSnapshot: { soc: null, cum_out_kwh: null, cum_in_kwh: null, cum_chg_ah: null, odometer: null, aux_12v: null, connector: null, ambient: null, ts: null },
+        lastSnapshot: { soc: null, cum_out_kwh: null, cum_in_kwh: null, cum_chg_ah: null, odometer: null, aux_12v: null, connector: null, ambient: null, ts: null },
+        lastRxTs: BASE + 100000,
+        end_ts: BASE + 100000,
+        sampleCount: 0,
+        maxGapMs: 0,
+        connectorSeen1: false,
+        connectorSeenAny: false,
+        aux12vStart: null,
+        emitted: false
+      }
+      mqtt = makeMqtt()
+      await start(cache)
+      bms(500000, { ignition: 1, speed_kph: 5, soc: 84, cum_in_kwh: 30 })
+
+      const parks = published(PARK)
+      expect(parks).toHaveLength(1)
+      expect(parks[0].complete).toBe(false)
+      expect(parks[0].soc_start).toBeNull()
+    })
+
+    it('ignores malformed / partial payloads without corrupting state', () => {
+      bms(0, null)
+      bms(1000, {})
+      bms(2000, { foo: 'bar' })
+      vmcu(3000, { nogear: true })
+      expect(mqtt.publish).not.toHaveBeenCalled()
+      expect(persistedCache.open).toBeNull()
+    })
+  })
+
+  describe('restart safety (lazy close)', () => {
+    const openRestCache = (extra = {}) => {
+      const cache = makeCache()
+      cache.open = {
+        kind: 'rest',
+        start_ts: BASE + 120000,
+        startSnapshot: { soc: 52, cum_out_kwh: 104, cum_in_kwh: 20, cum_chg_ah: 100, odometer: 1040, aux_12v: 12.8, connector: 1, ambient: null, ts: BASE + 120000 },
+        lastSnapshot: { soc: 52, cum_out_kwh: 104, cum_in_kwh: 20, cum_chg_ah: 100, odometer: 1040, aux_12v: 12.8, connector: 1, ambient: null, ts: BASE + 120000 },
+        lastRxTs: BASE + 120000,
+        end_ts: BASE + 120000,
+        sampleCount: 0,
+        maxGapMs: 0,
+        coverageSamples: 0,
+        coverageFirstTs: null,
+        coverageLastTs: null,
+        connectorEdges: [],
+        connectorPrev: 1,
+        connectorSeen1: true,
+        connectorSeenAny: true,
+        aux12vStart: 12.8,
+        emitted: false
+      }
+      return { ...cache, ...extra }
+    }
+
+    it('preserves an unbounded charge across a mid-gap restart; stationary resume does not split', async () => {
+      mqtt = makeMqtt()
+      await start(openRestCache())
+      // stationary resume after restart must NOT close/split the rest
+      bms(500000, { ignition: 1, speed_kph: 0, soc: 84, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+      expect(published(CHARGE)).toHaveLength(0)
+      expect(published(PARK)).toHaveLength(0)
+      // motion resume closes it as ONE charge (delta from persisted pre-gap snapshot)
+      bms(510000, { ignition: 1, speed_kph: 5, soc: 84, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      const charges = published(CHARGE)
+      expect(charges).toHaveLength(1)
+      expect(charges[0].energy_in_kwh).toBeCloseTo(10.1, 5)
+      expect(charges[0].bounds).toBe('unbounded') // sleep gap -> no awake/connector coverage
+      expect(charges[0].power_avg_kw).toBeNull() // no fabricated drive-to-drive rate
+      expect(charges[0].closed_by).toBe('restart_lazy_close')
+      expect(published(PARK)).toHaveLength(0)
+    })
+
+    it('keeps bounds:meter when the persisted on-edge survives a mid-charge restart', async () => {
+      const cache = openRestCache()
+      cache.meterEdges = [{ type: 'on', ts: BASE + 200000, act: 1000 }]
+      cache.meterState = { on: true, aboveSince: null, aboveAct: null, belowSince: null, belowAct: null }
+      mqtt = makeMqtt()
+      await start(cache)
+      // meter turns off after the restart -> off edge
+      meter(300000, 0, 1012.46)
+      meter(420000, 0, 1012.46)
+      bms(430000, { ignition: 1, speed_kph: 5, soc: 84, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      const charges = published(CHARGE)
+      expect(charges).toHaveLength(1)
+      expect(charges[0].bounds).toBe('meter')
+      expect(charges[0].ac_energy_kwh).toBeCloseTo(12.46, 5)
+    })
+
+    it('does not mislabel a normal close long after a restart (live trip -> gear_park)', async () => {
+      // Restart with an OPEN trip; the car keeps driving (goes live), then parks
+      // normally much later. That close is gear_park, not restart_lazy_close.
+      const cache = makeCache()
+      cache.open = {
+        kind: 'trip',
+        start_ts: BASE + 0,
+        startSnapshot: { soc: 60, cum_out_kwh: 100, cum_in_kwh: 10, cum_chg_ah: 5, odometer: 1000, aux_12v: 13, connector: null, ambient: null, ts: BASE + 0 },
+        motionSnapshot: { soc: 60, cum_out_kwh: 100, cum_in_kwh: 10, cum_chg_ah: 5, odometer: 1000, aux_12v: 13, connector: null, ambient: null, ts: BASE + 0 },
+        lastMotionTs: BASE + 0,
+        lastSnapshot: { soc: 60, cum_out_kwh: 100, cum_in_kwh: 10, cum_chg_ah: 5, odometer: 1000, aux_12v: 13, connector: null, ambient: null, ts: BASE + 0 },
+        lastRxTs: BASE + 0,
+        sampleCount: 1,
+        maxGapMs: 0,
+        speedSum: 40, speedCount: 1, speedMax: 40, powerMax: 20,
+        odometerReadings: [],
+        regenCumIn: 0, prevCumIn: 10, prevConnector: null, containedPlugged: false,
+        stationarySince: null, emitted: false
+      }
+      mqtt = makeMqtt()
+      await start(cache)
+      bms(30000, { ignition: 1, speed_kph: 45, soc: 58 }) // resumes moving -> live trip
+      bms(90000, { ignition: 1, speed_kph: 45, soc: 56 })
+      vmcu(95000, { gear: 'P', speed_kph: 0 }) // normal park close
+
+      const trips = published(TRIP)
+      expect(trips).toHaveLength(1)
+      expect(trips[0].closed_by).toBe('gear_park')
+    })
+
+    it('degrades gracefully to bounds:unbounded when the on-edge is absent, energy still valid', async () => {
+      const cache = openRestCache() // no meter edges
+      mqtt = makeMqtt()
+      await start(cache)
+      bms(430000, { ignition: 1, speed_kph: 5, soc: 84, cum_in_kwh: 30.1, cum_chg_ah: 127.5 })
+
+      const charges = published(CHARGE)
+      expect(charges).toHaveLength(1)
+      expect(charges[0].bounds).toBe('unbounded')
+      expect(charges[0].energy_in_kwh).toBeCloseTo(10.1, 5)
+      expect(charges[0].power_avg_kw).toBeNull()
+    })
+  })
+
+  describe('exactly-once & de-dup', () => {
+    it('sets the de-dup marker BEFORE publishing (exactly-once mitigation)', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 58 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 56 })
+      vmcu(125000, { gear: 'P', speed_kph: 0 })
+
+      const rec = mqtt._published.find((p) => p.topic === TRIP)
+      expect(rec.lastEmittedAtPublish).toEqual({ kind: 'trip', start_ts: BASE + 0, end_ts: BASE + 120000, seq: 1 })
+    })
+
+    it('does not drop a rest whose start_ts equals the prior trip end_ts', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 60 })
+      vmcu(122000, { gear: 'P', speed_kph: 0 }) // trip end_ts = 120000, rest start_ts = 120000
+      bms(500000, { ignition: 1, speed_kph: 5, soc: 60 }) // resume -> park
+
+      const trips = published(TRIP)
+      const parks = published(PARK)
+      expect(trips).toHaveLength(1)
+      expect(parks).toHaveLength(1)
+      expect(trips[0].end_ts).toBe(BASE + 120000)
+      expect(parks[0].start_ts).toBe(BASE + 120000)
+    })
+  })
+
+  describe('silence timer', () => {
+    it('closes a trailing trip at the last-sample time, not "now"', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(60000, { ignition: 1, speed_kph: 40, soc: 58 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 56 })
+      jest.advanceTimersByTime(300000) // fires at fake-clock 420000
+
+      const trips = published(TRIP)
+      expect(trips).toHaveLength(1)
+      expect(trips[0].closed_by).toBe('silence_timeout')
+      expect(trips[0].end_ts).toBe(BASE + 120000) // last motion sample, not 420000
+    })
+
+    it('a late stationary straggler after the timer does not close a second session', () => {
+      bms(0, { ignition: 1, speed_kph: 40, soc: 60 })
+      bms(120000, { ignition: 1, speed_kph: 40, soc: 56 })
+      jest.advanceTimersByTime(300000)
+      // late stationary sample only refreshes the still-open rest snapshot
+      bms(500000, { ignition: 1, speed_kph: 0, soc: 56 })
+      expect(published(PARK)).toHaveLength(0)
+      expect(published(CHARGE)).toHaveLength(0)
+    })
+  })
+})

--- a/docker/mqtt-influx/CLAUDE.md
+++ b/docker/mqtt-influx/CLAUDE.md
@@ -14,6 +14,7 @@ The mqtt-influx service bridges MQTT messages to InfluxDB time-series storage. M
 - **mqtt-influx-tetriary**: Additional power monitoring points (`/modbus/tetriary/+/+`)
 - **mqtt-influx-dry-switches**: Digital I/O bus (`/modbus/dry-switches/+/reading`) — decomposes packed input/output words into per-bit boolean fields for contact-sensor and RS485 bus-health diagnostics
 - **mqtt-influx-ioniq**: Hyundai Ioniq OBD telemetry (`ioniq/parsed/#`) → `ioniq` measurement
+- **mqtt-influx-ioniq-sessions**: Ioniq session records from the `ioniq-sessions` automations bot (`ioniq/derived/#`) → `ioniq_sessions` measurement (one record per closed trip/charge/park session)
 - **Water System Integration**: See `docs/water_system_spec.md` for complete MQTT topic mappings for pumps, boiler, and heat pump energy monitoring
 
 ### Data Flow
@@ -51,6 +52,7 @@ module.exports = (data) => {
 - **dds519mr**: DDS519MR energy meter data  
 - **ex9em**: EX9EM energy meter data
 - **ioniq**: Hyundai Ioniq OBD telemetry — recursively-typed/flattened parsed frames into the `ioniq` measurement (tags `group`, `state`)
+- **ioniq-session**: Ioniq session records (`_type: 'ioniq-session'`) — one closed trip/charge/park record per emit into the `ioniq_sessions` measurement (tag `kind`; timestamp `start_ts`; `end_ts` and all other §4 metrics as typed fields, null metrics omitted)
 - **mbsl32di**: MBSL32DI digital-input module — raw word + per-input boolean fields (`dry_switch_input`)
 - **or-we-514**: OR-WE-514 energy meter data
 - **sdm630**: SDM630 three-phase energy meter data

--- a/docker/mqtt-influx/converters/__tests__/ioniq-session.test.js
+++ b/docker/mqtt-influx/converters/__tests__/ioniq-session.test.js
@@ -1,0 +1,114 @@
+const ioniqSession = require('../ioniq-session')
+
+describe('ioniq-session converter', () => {
+    // a closed trip record as published by the ioniq-sessions bot, spec §4.1/§4.4
+    const trip = {
+        _type: 'ioniq-session', kind: 'trip', start_ts: 1720000000000, end_ts: 1720002496000,
+        duration_sec: 2496, distance_km: 40, odometer_coverage: 0.8,
+        energy_out_kwh: 4.7, energy_regen_kwh: 0.5, energy_net_kwh: 4.2,
+        efficiency_wh_per_km: 105, soc_start: 73, soc_end: 61, soc_delta_pct: -12,
+        speed_avg_kph: 45.2, speed_max_kph: 98.1, power_max_kw: 62.3, ambient_c: 21.5,
+        complete: true, sample_count: 812, max_gap_sec: 45,
+        closed_by: 'gear_park', gear_at_close: 'P', seq: 17, schema_version: 1,
+        start_truncated: true, contained_plugged: false,
+        _bot: 'ioniq-sessions', _tz: 'Europe/Sofia',
+    }
+
+    it('returns exactly one Point', () => {
+        const points = ioniqSession(trip)
+        expect(Array.isArray(points)).toBe(true)
+        expect(points).toHaveLength(1)
+    })
+
+    it('uses measurement ioniq_sessions with kind as the only tag', () => {
+        const lp = ioniqSession(trip)[0].toLineProtocol()
+        expect(lp).toMatch(/^ioniq_sessions,kind=trip /)
+    })
+
+    it('uses start_ts as the point timestamp', () => {
+        const lp = ioniqSession(trip)[0].toLineProtocol()
+        expect(lp.endsWith(' 1720000000000')).toBe(true)
+    })
+
+    it('carries end_ts as a field, not the timestamp', () => {
+        const lp = ioniqSession(trip)[0].toLineProtocol()
+        expect(lp).toContain('end_ts=1720002496000')
+    })
+
+    it('types numbers as floats (no integer i-suffix)', () => {
+        const lp = ioniqSession(trip)[0].toLineProtocol()
+        expect(lp).toContain('duration_sec=2496')
+        expect(lp).toContain('distance_km=40')
+        expect(lp).toContain('soc_delta_pct=-12')
+        expect(lp).not.toContain('duration_sec=2496i')
+    })
+
+    it('types booleans as boolean fields', () => {
+        const lp = ioniqSession(trip)[0].toLineProtocol()
+        expect(lp).toContain('complete=T')
+        expect(lp).toContain('start_truncated=T')
+        expect(lp).toContain('contained_plugged=F')
+    })
+
+    it('types strings as quoted string fields', () => {
+        const lp = ioniqSession(trip)[0].toLineProtocol()
+        expect(lp).toContain('closed_by="gear_park"')
+        expect(lp).toContain('gear_at_close="P"')
+    })
+
+    it('excludes kind, _bot, and _tz from the fields set (they are tag/envelope metadata)', () => {
+        const fields = ioniqSession(trip)[0].toLineProtocol().split(' ')[1]
+        expect(fields).not.toMatch(/(^|,)kind=/)
+        expect(fields).not.toMatch(/(^|,)_bot=/)
+        expect(fields).not.toMatch(/(^|,)_tz=/)
+    })
+
+    it('also excludes the ioniq.js RESERVED keys (_type, group, state, ts)', () => {
+        const withLegacyReserved = {...trip, group: 'bms/2101', state: 'active', ts: 999}
+        const fields = ioniqSession(withLegacyReserved)[0].toLineProtocol().split(' ')[1]
+        expect(fields).not.toMatch(/(^|,)group=/)
+        expect(fields).not.toMatch(/(^|,)state=/)
+        expect(fields).not.toMatch(/(^|,)ts=/)
+    })
+
+    it('omits null/undefined metrics rather than writing a sentinel (unbounded charge shape, §3.3)', () => {
+        // an unbounded sleep charge: energy valid, timing/power intentionally null (§4.2)
+        const charge = {
+            _type: 'ioniq-session', kind: 'charge', start_ts: 1720010000000, end_ts: 1720047080000,
+            energy_in_kwh: 10.1, charge_ah: 27.5, soc_start: 52, soc_delta_pct: 32.5, soc_end: 84.5,
+            bounds: 'unbounded', duration_is_charge: false, duration_sec: 37080,
+            power_avg_kw: null, connector_confirmed: true, ac_energy_kwh: null, charge_efficiency: null,
+            charge_type: undefined, complete: true, sample_count: 0, max_gap_sec: 37080,
+            closed_by: 'silence_timeout', gear_at_close: null, seq: 18, schema_version: 1,
+        }
+        const lp = ioniqSession(charge)[0].toLineProtocol()
+        const fields = lp.split(' ')[1]
+        expect(fields).toContain('energy_in_kwh=10.1')
+        expect(fields).not.toContain('power_avg_kw')
+        expect(fields).not.toContain('ac_energy_kwh')
+        expect(fields).not.toContain('charge_efficiency')
+        expect(fields).not.toContain('charge_type')
+        expect(fields).not.toContain('gear_at_close')
+        expect(lp).toMatch(/^ioniq_sessions,kind=charge /)
+    })
+
+    it('types the park kind correctly (negative drain, boolean corroborator)', () => {
+        const park = {
+            _type: 'ioniq-session', kind: 'park', start_ts: 1720050000000, end_ts: 1720057200000,
+            duration_sec: 7200, soc_start: 84, soc_end: 83, soc_delta_pct: -1,
+            soc_drain_pct_per_day: -0.33, aux12v_start: 12.6, aux12v_end: 12.4,
+            connector_confirmed: false, complete: true, sample_count: 3, max_gap_sec: 60,
+            closed_by: 'gap_stationary', gear_at_close: 'P', seq: 19, schema_version: 1,
+        }
+        const lp = ioniqSession(park)[0].toLineProtocol()
+        expect(lp).toMatch(/^ioniq_sessions,kind=park /)
+        expect(lp).toContain('soc_drain_pct_per_day=-0.33')
+        expect(lp).toContain('connector_confirmed=F')
+    })
+
+    it('does not throw on a minimal payload with only identity fields', () => {
+        const frame = {_type: 'ioniq-session', kind: 'park', start_ts: 1720060000000}
+        expect(() => ioniqSession(frame)).not.toThrow()
+        expect(ioniqSession(frame)).toHaveLength(1)
+    })
+})

--- a/docker/mqtt-influx/converters/ioniq-session.js
+++ b/docker/mqtt-influx/converters/ioniq-session.js
@@ -1,0 +1,83 @@
+const {Point} = require('@influxdata/influxdb-client')
+
+// Payload keys that map to the measurement's identity, not to fields.
+// Beyond converters/ioniq.js's RESERVED set, this also excludes `kind` (the
+// only tag on this measurement, per the design spec §6.2) and the framework's
+// auto-added `_bot`/`_tz` envelope metadata, so neither leaks in as a spurious
+// string field (a pre-existing quirk of the `ioniq` converter deliberately not
+// replicated here).
+const RESERVED = new Set(['_type', 'group', 'state', 'ts', 'kind', '_bot', '_tz'])
+
+/**
+ * Adds one payload leaf to the point, choosing the InfluxDB field type by the
+ * JS runtime type. Mirrors the typing discipline of converters/ioniq.js:
+ * numbers are stored uniformly as floats (even integral ones) so a field that
+ * is sometimes an int and sometimes a float never triggers an InfluxDB
+ * int/float type conflict; nested objects are flattened recursively into
+ * dotted keys and arrays are JSON-stringified into one string field, though
+ * the §4 session metrics are all flat scalars in practice. null/undefined
+ * leaves are skipped so a null metric simply omits its field rather than
+ * writing a sentinel. Unknown types fall back to a string so a future payload
+ * shape can never crash the bridge.
+ */
+function addField(point, key, value) {
+    if (value === null || value === undefined) {
+        return
+    }
+    switch (typeof value) {
+        case 'number':
+            if (Number.isFinite(value)) {
+                point.floatField(key, value)
+            }
+            break
+        case 'boolean':
+            point.booleanField(key, value)
+            break
+        case 'string':
+            point.stringField(key, value)
+            break
+        case 'object':
+            if (Array.isArray(value)) {
+                point.stringField(key, JSON.stringify(value))
+            } else {
+                for (const [childKey, childValue] of Object.entries(value)) {
+                    addField(point, `${key}.${childKey}`, childValue)
+                }
+            }
+            break
+        default:
+            point.stringField(key, String(value))
+    }
+}
+
+/**
+ * Converts an `ioniq-session` payload (one closed trip/charge/park record
+ * from the `ioniq-sessions` automations bot, published to
+ * `ioniq/derived/{trip,charge,park}`) into a single InfluxDB point in the
+ * `ioniq_sessions` measurement.
+ *
+ * Tag: `kind` (`trip` | `charge` | `park` — low-cardinality; the only tag).
+ * Timestamp: `start_ts` (epoch ms) — records are back-dated to session start
+ * so a "trips over time" axis places each session where it began. `end_ts`
+ * is carried as a field, not the timestamp.
+ * Fields: every other payload key, typed by JS runtime type (see addField).
+ */
+module.exports = function ioniqSession(data) {
+    const point = new Point('ioniq_sessions')
+
+    if (data.kind !== undefined && data.kind !== null) {
+        point.tag('kind', String(data.kind))
+    }
+    if (data.start_ts !== undefined && data.start_ts !== null) {
+        point.timestamp(data.start_ts)
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+        if (RESERVED.has(key)) {
+            continue
+        }
+        addField(point, key, value)
+    }
+
+    return [point]
+}

--- a/docker/mqtt-influx/index.js
+++ b/docker/mqtt-influx/index.js
@@ -25,6 +25,7 @@ const converters = {
     dds519mr: require('./converters/dds519mr'),
     ex9em: require('./converters/ex9em'),
     ioniq: require('./converters/ioniq'),
+    'ioniq-session': require('./converters/ioniq-session'),
     mbsl32di: require('./converters/mbsl32di'),
     'or-we-514': require('./converters/or-we-514'),
     sdm630: require('./converters/sdm630'),

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -63,6 +63,7 @@ All modbus-serial instances write directly to InfluxDB using environment-configu
 - **mqtt-influx-tetriary**: `/modbus/tetriary/+/+` → InfluxDB (bridges tetriary bus MQTT to InfluxDB)
 - **mqtt-influx-dry-switches**: `/modbus/dry-switches/+/reading` → InfluxDB (`dry_switch_input` / `dry_switch_relay` measurements; decomposes packed input/output words into per-bit boolean fields for diagnostics)
 - **mqtt-influx-ioniq**: `ioniq/parsed/#` → InfluxDB (`ioniq` measurement; decoded Hyundai Ioniq OBD telemetry, tags `group`/`state`)
+- **mqtt-influx-ioniq-sessions**: `ioniq/derived/#` → InfluxDB (`ioniq_sessions` measurement; one record per closed trip/charge/park session from the `ioniq-sessions` bot, tag `kind`)
 - **automation-events-processor**: `homy/automation/+/status` → InfluxDB (dedicated service for automation decision events)
 
 ### Specialized Monitoring
@@ -236,6 +237,48 @@ query this measurement's `v` field. See
 - Representative fields: `soc`, `hv_v`, `hv_a`, `12v`, `speed`, `relays.main`, `dtc`
 **Retention**: kept indefinitely (compact numeric data). The bulky raw archive lives separately in MongoDB (`ioniq` collection, 90-day TTL on `_ts`) — see `docker/mqtt-mongo/CLAUDE.md`.
 **Use Cases**: Hyundai Ioniq OBD time-series (SoC, HV pack, speed, temps, TPMS) for Grafana and InfluxQL trip/charging analysis
+
+#### `ioniq_sessions` Measurement
+**Source**: `mqtt-influx-ioniq-sessions` → `ioniq/derived/#` (converter `converters/ioniq-session.js`,
+`_type: "ioniq-session"`). Published by the `ioniq-sessions` automations bot, one record per closed
+session — a low-rate, wide, categorical *records table*, deliberately kept out of the 2 Hz `ioniq`
+measurement (see `docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md` §6).
+**Tag Structure**:
+- `kind`: `trip` | `charge` | `park` — low-cardinality (3 values); the only tag, what dashboards
+  filter/group by
+**Timestamp**: `start_ts` (epoch ms), written at `ms` precision. Records are intentionally **back-dated to
+session start** (not write/emit time) so a "sessions over time" axis places each session where it began —
+this matters most for sleep-gap `charge`/`park` rests, which are only computed (and published) retrospectively
+on resume, well after `start_ts`. `end_ts` is carried as a field, not the timestamp.
+**Fields**: every other payload key, typed by JS runtime type (same discipline as the `ioniq` converter):
+numbers → float (uniformly, even integers); booleans → boolean; strings → string; `null`/`undefined` metrics
+are **omitted** (no sentinel — a session with an unmeasurable metric simply has no field for it, never a
+fabricated `0`). `_type`, `group`, `state`, `ts`, `kind`, `_bot`, `_tz` are excluded from fields (identity/tag/
+envelope metadata, not measurement data).
+- **Common fields** (all `kind`s): `end_ts` (epoch ms), `duration_sec` (s), `complete` (bool — both boundary
+  samples present), `sample_count`, `max_gap_sec` (s), `closed_by` (`gear_park` \| `ignition_edge` \|
+  `idle_split` \| `gap_stationary` \| `motion_resume` \| `silence_timeout` \| `restart_lazy_close`), `gear_at_close`, `seq`
+  (monotonic per-emit counter), `schema_version`.
+- **`trip` fields**: `distance_km` (km; null unless ≥2 distinct odometer readings), `odometer_coverage`
+  (0–1), `energy_out_kwh` / `energy_regen_kwh` / `energy_net_kwh` (kWh), `efficiency_wh_per_km` (Wh/km; null
+  if `distance_km` null), `soc_start` / `soc_end` / `soc_delta_pct` (%), `speed_avg_kph` / `speed_max_kph`
+  (km/h), `power_max_kw` (kW), `ambient_c` (°C, best-effort), `start_truncated` (bool), `contained_plugged`
+  (bool).
+- **`charge` fields**: `energy_in_kwh` (kWh into pack; always valid), `charge_ah` (Ah; always valid),
+  `soc_start` / `soc_delta_pct` / `soc_end` (%), `bounds` (`meter` \| `connector` \| `awake` \| `unbounded`),
+  `duration_is_charge` (bool), `power_avg_kw` (kW; null when unbounded), `connector_confirmed` (bool),
+  `ac_energy_kwh` (kWh; null without a home-meter match), `charge_efficiency` (0–1; null without meter),
+  `charge_type` (`AC` \| `DC` \| `unknown`).
+- **`park` fields**: `soc_start` / `soc_end` / `soc_delta_pct` (%), `soc_drain_pct_per_day` (%/day; null if
+  `duration_sec` below the config drain-minimum), `aux12v_start` / `aux12v_end` (V, best-effort),
+  `connector_confirmed` (bool).
+**Retention**: kept indefinitely (compact, one row per session). Session records also reach MongoDB via the
+existing `mqtt-mongo-ioniq` (`ioniq/#`) subscription — append-only, so downstream consumers there must
+de-dup on `(kind, start_ts, end_ts)`.
+**Use Cases**: per-trip distance/energy/efficiency, charge-session energy/power/efficiency, parasitic-drain
+analysis, and the "Trips & charging" Grafana dashboard (`docs/ioniq-monitoring-alerting-spec.md` §7) — this
+measurement is its data source, unblocking the dashboard that was previously deferred for lack of session
+boundaries.
 
 ### Automation System Monitoring
 

--- a/docs/ioniq-monitoring-alerting-spec.md
+++ b/docs/ioniq-monitoring-alerting-spec.md
@@ -164,7 +164,9 @@ Keying: use ingest `time` (Influx) / `_ts` (Mongo) for liveness — the LWT payl
 | AC charge power | reduced-rate charge | `ac_port=1 & |hv_kw|<3 kW` sustained (this session was ~1 kW granny) | info | 10m | **Bot** → `derived/charge_reduced_rate` |
 | SoC slope while parked | parasitic drain | `> 2%/day` across parked spans | warning | — | **Bot**/Grafana `derivative` |
 
-Cross-reference: AC-side charge energy is available from the household **`charger` ORNO meter** (monitoring bus) — verify it's live (see Open Items) and, if so, use it for charge kWh/efficiency rather than decoding the OBC AC side.
+Cross-reference: AC-side charge energy is available from the household **`charger` ORNO meter** — confirmed
+live (measurement `xymd1`, see §10) — used for charge kWh/efficiency rather than decoding the OBC AC side;
+the `ioniq-sessions` bot already does this for home charges (`bounds:meter`, §7).
 
 ---
 
@@ -245,6 +247,17 @@ New `Ioniq EV` dashboard family (JSON under `config/grafana/dashboards/`, provid
 | **12 V / LDC** | `aux_12v` timeseries banded by state; per-drive LDC on-voltage ceiling; parked resting-voltage trend (daily min/median); derived `ldc_ok`. |
 | **Tires** | Per-wheel `psi_cold` trend; inter-wheel spread; per-wheel temp vs ambient; over/under-inflation bands. |
 | **Trips & charging** | State timeline (active/charging/parked); per-trip distance/energy/efficiency (kWh/100 km); regen recovery %; charge sessions (AC/DC, kWh, avg power); SoC-at-park distribution; charger-meter AC power overlay (if live). |
+
+> **Data source (2026-07-18):** this dashboard was previously **deferred** — per-trip distance/energy/
+> efficiency, regen-recovery %, and charge-session breakdowns need trip/charge **session boundaries** that
+> no bot emitted, and pure-InfluxQL session math is fragile and unvalidatable
+> (`docs/superpowers/specs/2026-07-15-ioniq-monitoring-phase4-dashboards-design.md` §1). It is now unblocked:
+> the **`ioniq-sessions`** automations bot segments the telemetry stream into `trip`/`charge`/`park` sessions
+> and the **`ioniq_sessions`** InfluxDB measurement (tag `kind`, back-dated `start_ts`) is this dashboard's
+> data source — see
+> `docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md` and
+> `docs/influxdb-schema.md` (`ioniq_sessions` measurement). Building the dashboard panels themselves remains
+> a separate, not-yet-started deliverable (design spec §1, §9 PR3).
 | **Pipeline health** | Samples/min per group; per-group last-seen; connectivity transitions; Influx/Mongo growth; DTC history. |
 
 Link the family with a dashboard-links row (overview ↔ detail), per repo navigation standard.
@@ -293,7 +306,16 @@ Each rule's `annotations.description` should carry the first action. Summary tab
 
 ## 10. Open items / dependencies
 
-- **Verify the `charger` ORNO meter is live.** It's configured (monitoring bus, `or-we-526`) but no current readings were found under the expected Influx tags; needed for AC-side charge energy/efficiency. (OVMS, which previously covered this, is dead as of ~2025-09-24.)
+- ~~Verify the `charger` ORNO meter is live.~~ **Resolved (2026-07-18):** it *is* live — verified over 609
+  days (2024-11 → 2026-07) of continuous ~8 s-cadence data. The original query found nothing because it
+  looked under `monitoring`/`charger`-named Influx tags/measurements; the meter actually writes to
+  measurement **`xymd1`** (tags `device.name=charger`; fields `ap`=W instantaneous power, `act`=cumulative
+  kWh), a naming mismatch, not a dead device. It has a 0 W idle baseline (99.98% of idle samples exactly
+  0 W), three observed charging tiers (~1.2 / 1.9 / 2.6 kW), and no daytime other-load on the circuit —
+  clean enough to bound home charges by a relative power threshold. Now used by the `ioniq-sessions` bot
+  (design spec `docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md` §3.3, §0.1) as
+  the preferred `bounds:meter` source for AC-side charge energy/efficiency. (OVMS, which previously covered
+  this, is dead as of ~2025-09-24.)
 - **`brakes_on` is unreliable** (logger #9) — don't build braking alerts on it; use `brake_lamp`.
 - **New signals unlock new alerts** once logger tickets land: motor/inverter over-temp (#5), cabin over-temp / preconditioning verify (#6), direct LDC current/temp (#8), body/security (door-left-unlocked, window-open) (#13).
 - **Decide** dedicated vs shared Telegram channel (§3) before wide rollout.

--- a/docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md
+++ b/docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md
@@ -356,7 +356,7 @@ meter (home charge — preferred), or by captured `charge_connector` edges / int
 | `complete` | both start and end boundary samples were present (else metrics that need the missing side are null) |
 | `sample_count` | in-session samples seen (0 for a pure sleep rest — all metrics boundary-derived) |
 | `max_gap_sec` | largest inter-sample gap inside the session (0 if <2 samples) |
-| `closed_by` | `gear_park` \| `ignition_edge` \| `idle_split` \| `gap_stationary` \| `silence_timeout` \| `restart_lazy_close` |
+| `closed_by` | `gear_park` \| `ignition_edge` \| `idle_split` \| `gap_stationary` \| `motion_resume` (rest→drive) \| `silence_timeout` \| `restart_lazy_close` |
 | `gear_at_close` | the `gear` value that closed the trip, or null if closed without gear | audit/tuning |
 | `seq` | monotonic per-emit counter; with `(kind,start_ts,end_ts)` forms the de-dup key (§5.6) |
 | `schema_version` | integer, for downstream forward-compat |
@@ -648,6 +648,11 @@ string literals single-quoted; no `$timeFilter` — use explicit `WHERE time >= 
    tiers cleanly. **Calibration path:** the operator can re-exercise all 3 settings and (rarely) a
    powered-mode charge for simultaneous meter + car-side measurements to refine the AC→pack efficiency curve.
    `charge_type` stays `unknown` unless a powered-mode charge decodes it (§4.2).
+   - *Known minor approximation (rare `bounds:awake` only):* `power_avg_kw` = whole-rest `energy_in_kwh` ÷
+     coverage-span `duration_sec`, so if coverage starts after the rest opens (e.g. a cold-start powered-mode
+     charge) the rate can over-estimate. Spec-conformant with §4.2; affects only the no-meter/no-connector
+     powered-mode path, never the unbounded/meter/connector paths. A future refinement is to attribute only
+     coverage-span energy on this path.
 4. **`speed_kph` / `ignition` trustworthiness** — `speedMovingKph` hysteresis mitigates standstill jitter;
    ignition is operator-confirmed trustworthy as the awake delimiter but its 1→0 edge is only *sometimes*
    captured before power-off, so the silence timer remains the backstop. Validate both floors during tuning.

--- a/docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md
+++ b/docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md
@@ -1,0 +1,677 @@
+# Ioniq EV — Session Segmentation Bot (`ioniq-sessions`) Design
+
+**Date:** 2026-07-18
+**Status:** Draft (design), pending user review → implementation plan
+**Spec reference:** `docs/ioniq-monitoring-alerting-spec.md` §4.6 (usage/charging), §7 (Trips & charging dashboard), §10 (open items); deferral note in `docs/superpowers/specs/2026-07-15-ioniq-monitoring-phase4-dashboards-design.md` §1.
+**Bot pattern templates:** `docker/automations/bots/ioniq-12v-ldc.js` (rolling window, receipt-time math, persisted cache, latch), `docker/automations/bots/ioniq-cell-health.js` (cross-frame merge, never-overwrite-good-with-bad).
+**Converter/bridge templates:** `docker/mqtt-influx/converters/ioniq.js`, `docker-compose.yml` service `mqtt-influx-ioniq`.
+
+---
+
+## 0. Context & data reality (why the obvious design is wrong)
+
+The alerting spec assumed trips/charges could be segmented from the `state` tag (active/charging/parked).
+**Production data proves that assumption false.** A read-only investigation of the full `ioniq`
+measurement on prod (routy) on 2026-07-18 found:
+
+> **Data-depth caveat:** the entire `ioniq` series begins 2026-07-14 (~4.2 days at investigation time).
+> Every threshold in this spec is therefore **provisional** and MUST be re-tuned after ~2 weeks of history
+> accrues. Sample sizes (≈19 driving runs, 20 park blips, 3 charge blips, 1 overnight charge) are
+> suggestive, not statistically solid.
+
+Findings (each backed by InfluxQL run against prod; queries reproduced in §11):
+
+1. **`parked` never persists.** All observed `parked` runs lasted 0–35 s (median 1.4 s) — single
+   "last gasp" blips as the logger sleeps. **Real park/sleep is a data gap** (zero samples), observed up
+   to **12.2 h** long.
+2. **`charging` (tag and field) only catches trivial handshake blips** (~24 min, ~0.5 kWh). It does **not**
+   mark real charge sessions.
+3. **A single `active` run bundles a full drive *plus* a full charge** with no tag change. Worked example:
+   the run `2026-07-15T17:44→07-16T05:28` (tagged `active` throughout) contained a 3 h multi-stop drive,
+   then a **10.3 h gap with zero data**, then resume with **SoC jumped 52% → 84.5%** — an invisible
+   overnight charge, never tagged `charging`.
+4. **The one trustworthy plug signal is `charge_connector`** (group `bcm_b00e`, field `charge_connector`
+   0/1). Sparse (~135 pts/400 d) but it flipped `0→1` at charge start and `1→0` at charge end in the
+   worked example. It sleeps with everything else, so it is a **corroborator, not a trigger**. (It is
+   already reachable under `ioniq/parsed/#` — alerting-spec prerequisite P0-1 has landed; the §0
+   investigation queried it live on prod, so no logger work blocks this bot.)
+5. **No backwards/duplicate timestamps** in 11,069 rows. Cadence: sub-second–3 s while genuinely driving,
+   ~20–45 s while awake-but-idle, **zero** once asleep.
+
+### 0.1 Logger operating behavior (authoritative — operator, 2026-07-18)
+
+These facts override the investigation's inferences where they conflict and are load-bearing for the
+algorithm:
+
+- **The logger only lives while the car's ignition is on.** It powers **on ~1–2 min *after* ignition-on**
+  and powers **off shortly after ignition-off.** So: (a) every drive's **first 1–2 min are missing** — the
+  trip's start `soc`/`odometer`/counters are captured slightly late, so distance/energy **slightly
+  undercount** the true drive and are flagged accordingly (§5); (b) **a data gap = ignition-off = the car
+  is parked/charging.** The multi-hour gaps in §0 are ignition-off periods.
+- **`ignition` is trustworthy** as the awake/session signal (the investigation called it "unreliable" only
+  because it reads 1 through *stationary-but-on* stretches — which is correct: the car is on, just not
+  moving). Because the logger runs only under ignition, `ignition ≈ 1` for essentially every logged
+  sample; its value to us is the **1→0 edge at session end** (often captured as the brief `parked`
+  "last gasp") and **continuity across short gaps** (§3).
+- **`gear` is trustworthy** and the *cleanest* drive/park signal — better than speed alone. **Verified on
+  prod:** string values `P`/`N`/`D`/`R`, on **group `vmcu`** (NOT `bms/2101` — the bot must subscribe
+  `ioniq/parsed/vmcu`), densely populated (every `vmcu` sample, no gaps), and cleanly correlated (`P`⇔
+  stopped/parked, `D`⇔forward, `R`⇔reverse, incl. `D→R→D` parking maneuvers). `gear=P` = definitive
+  **parked** (trip ended); `D`/`R` = driving; `N` = ambiguous (continuation). It ends a trip the instant the
+  driver parks — no waiting out `minRestSplitMs` — and stops a long red light (stopped, still in `D`) from
+  splitting a trip. Top-priority boundary signal; speed + `minRestSplitMs` is the fallback when gear is
+  absent. (`speed_kph` is on both `vmcu` and `bms/2101`.)
+- **Configurable fetch cadence:** fast-changing signals ~2 s, slower signals ~1 min. So a ~1-min gap on a
+  given field is *normal cadence*, not a rest — gap thresholds must sit comfortably above 1 min. **The
+  operator can raise the cadence of specific fields on request — see §7.1 for the prioritized list** (most
+  impactfully `odometer`, whose sparsity is the single biggest metric-quality limit).
+- **Mid-drive reboots happen**, causing gaps **usually 1–3 min** (occasionally more). These occur with
+  ignition on throughout and must **not** split a trip (validates §3.2's moving/ignition-continuity rule;
+  and note the "43 s max dropout" figure was a 4.2-day fluke — real dropouts reach 1–3 min).
+- **Charging signal, in strength order:** **(1) positive SoC change across an ignition-off gap** is a
+  reliable charge indicator; **(2) the household charger energy meter** — `charger`/`or-we-526`, MQTT
+  `/modbus/monitoring/charger/reading`, a separate always-on Modbus device that **keeps logging while the
+  car sleeps** — is a **very strong** corroborator that **time-bounds** a home charge and gives AC-side
+  kWh. **Verified on prod over 609 days (2024-11 → 2026-07):** live and dense (~8 s ticks), writes to
+  InfluxDB measurement **`xymd1`** (tags `device.name=charger`; fields `ap`=W, `act`=cumulative kWh),
+  **0 W idle baseline** (99.98% of idle samples exactly 0 W), **three charging tiers ~1.2 / 1.9 / 2.6 kW**
+  (the two higher fell out of recent use — hence a 30-day glance sees only 1.2 kW), **no daytime other-load**
+  on the circuit in the whole window, and its on/off edges matched the known overnight charge to within
+  ~5–9 min on the same clock (AC 12.46 kWh → pack 10.1 kWh = 81% efficiency). The bot uses a **relative**
+  power threshold (150 W), not hard-coded tiers, so it stays correct across all tiers (§3.3, §12).
+
+**Design consequence:** segmentation **must not key off the `state` tag.** It keys off **`ignition`
+(awake/session delimiter) + `speed_kph` (drive vs idle within awake) + inter-sample gaps (rest detection) +
+cumulative-counter / SoC deltas (charge detection)**, with the **charger energy meter** bounding home
+charges. The `state` tag is at most a weak secondary hint, never a boundary.
+
+---
+
+## 1. Goal & scope
+
+Deliver **`ioniq-sessions`**, an automations bot that segments the Ioniq telemetry stream into discrete
+**sessions** and emits **one summary record per completed session** for the deferred "Trips & charging"
+Grafana dashboard (spec §7 row 5) and parasitic-drain analysis (spec §4.6).
+
+### In scope
+- **Three session kinds**, covering the timeline with no gaps:
+  - `trip` — a period of real motion (a fine-grained drive segment).
+  - `charge` — a rest during which energy entered the pack.
+  - `park` — a rest during which no charging occurred.
+- **Aggregation only.** One record emitted per closed session, with per-session metrics and data-quality
+  metadata.
+- **Robust missing-data handling** (§5) — the logger sleeps mid-session and data gaps are the norm.
+- New InfluxDB **records** measurement `ioniq_sessions` + a dedicated mqtt-influx bridge instance (§6).
+
+### Explicitly out of scope (non-goals)
+- **No alerting.** No thresholds, no Telegram, no derived 0/1 flags. Charge-stall / low-SoC-at-park
+  alerting remains the separately-planned `ioniq-charge-guard` bot (alerting spec §4.6, §5). This bot and
+  charge-guard are independent; neither depends on the other.
+- **No coarse "journey" aggregation.** Merging fine `trip` segments separated by short stops into one
+  logical journey (the VW-style "reset only after 30–60 min of ignition-off") is a **followup bot** that
+  consumes `ioniq_sessions`. This bot emits the atomic, well-bounded unit; policy-layer coalescing is
+  someone else's job. (Naming: the fine session is a **`trip`**; a future coalesced unit is a **journey**.)
+- **No AC/DC charge-*type* decode.** OBC `dc_*` only populates during rare handshake blips, so `charge_type`
+  stays `unknown` (a charger-meter match implies AC). Pack-side counters give charge *energy* always; the
+  verified home **charger meter** additionally gives AC energy/efficiency and time-bounds home charges
+  (§3.3) — that is in scope. Away-from-home charges without a meter stay energy-only (`bounds:unbounded`).
+- **No Grafana dashboard in this spec.** The "Trips & charging" dashboard is a separate deliverable that
+  consumes this measurement (out of scope here; unblocked by it).
+- **No logger-side changes.**
+
+---
+
+## 2. Architecture
+
+```
+logger ──MQTT──> ioniq/parsed/#  ──> (existing per-sample telemetry pipeline, unchanged)
+                      │
+                      ├─> mqtt-influx-ioniq ──> InfluxDB "ioniq"        (2 Hz telemetry, unchanged)
+                      │
+   automations ─subscribe ioniq/parsed/{vmcu,bms/2101,odometer,bcm_b00e,ambient}┐
+   bot: ioniq-sessions   + /modbus/monitoring/charger/reading (meter)   │  gear+ignition+motion+gap+counter,
+                      │  emits ONE record per closed session            │  meter-bounds home charges
+                      ▼                                                  ▼
+             ioniq/derived/{trip,charge,park}  ──> mqtt-influx-ioniq-sessions ──> InfluxDB "ioniq_sessions"
+                      │                                (NEW bridge instance)         (records table)
+                      └────────────────────────────> mqtt-mongo-ioniq (existing ioniq/# sub) ──> Mongo
+```
+
+- **Bot** lives in `docker/automations/bots/ioniq-sessions.js`, wired in `config/automations/config.js`
+  alongside the other ioniq bots. Follows the repo bot contract
+  `module.exports = (name, config) => ({ persistedCache, start })`.
+- **New bridge** `mqtt-influx-ioniq-sessions` (a second instance of the existing `mqtt-influx` image, no
+  Dockerfile) subscribes `TOPIC=ioniq/derived/#` and routes to a **new converter** keyed by
+  `_type: 'ioniq-session'` that writes measurement **`ioniq_sessions`**.
+- **Why a separate measurement, not `ioniq`:** session records are a low-rate, wide, categorical
+  *records table*, semantically distinct from 2 Hz telemetry. Keeping them out of `ioniq` keeps dashboards
+  simple (query a records table, not filter a firehose) and keeps the existing `ioniq/parsed/#` bridge
+  untouched. (Chosen 2026-07-18.)
+- Session records also reach Mongo automatically via the existing `mqtt-mongo-ioniq` (`TOPIC=ioniq/#`)
+  subscription — free durable record history, no new wiring.
+
+---
+
+## 3. Session model & detection algorithm
+
+### 3.1 The unified model: awake-session → {motion, idle}, sleep-gap → rest
+
+The timeline has two levels. **`ignition`** delimits *awake sessions* (the logger only lives with ignition
+on, §0.1); within an awake session, **`speed_kph`** separates driving from idling; the *sleep gaps between*
+awake sessions are the rests to classify.
+
+- **Awake session** = a contiguous run of samples (ignition on). It begins ~1–2 min after real ignition-on
+  (startup lag → early samples missing) and ends at the `ignition` 1→0 edge (often the brief `parked`
+  "last gasp") or, if that edge isn't captured, at the **silence timeout** (§3.4).
+- **Driving** = `gear ∈ {D, R}` **or** (gear absent and `speed_kph > speedMovingKph`, provisional 3 km/h to
+  reject standstill jitter). Accumulates into an open **`trip`**. A stop still in gear `D`/`R` (red light)
+  is *not* an idle — the trip continues.
+- **Idle / parked** = the drive ended. Triggered, in priority order: **`gear=P`** (definitive, immediate);
+  else, gear absent, an ignition-on **stationary** stretch exceeding `minRestSplitMs` (provisional 3 min).
+  `gear=N` is ambiguous (neutral at a light / rolling) → continuation, never a split on its own. Sub-floor
+  stops don't split — the fine-but-sane floor; coarse journey-merging is the followup bot (§1).
+- **Rest** = a **sleep gap** between awake sessions (ignition off → logger dead → no samples). Classified
+  `charge` or `park` by SoC/energy delta across it, bounded by the charger meter where available (§3.3).
+
+**Reboot continuity (do not mistake a reboot for a rest).** Mid-drive logger reboots produce gaps usually
+1–3 min *with ignition on throughout* (§0.1). A gap does **not** open a rest when either: the post-gap
+sample is **moving** (you cannot wake mid-motion — definitely the same trip), **or** the gap is shorter
+than `rebootMaxGapMs` (provisional 5 min, above the 1–3 min reboot band and the ~1-min slow-field cadence)
+with ignition on on both sides (reboot or a trivial sub-5-min stop — merged into the awake session either
+way). A rest opens only on a gap ≥ `restGapMs` (provisional 5 min) or an observed `ignition` 1→0 edge. The
+gap's own elapsed time never counts toward `minRestSplitMs` (which measures *observed* stationary-awake
+samples, not silence).
+
+`rebootMaxGapMs == restGapMs` (both 5 min) is intentional, not a dead zone: a gap is *either* < 5 min
+(continue) *or* ≥ 5 min (rest if the far side is stationary). The only case needing unconditional
+protection is **moving-both-sides** (a highway reboot/tunnel), which continues regardless of gap length. A
+gap ≥ 5 min with a *stationary* far side is treated as a genuine **short `park`** — and correctly so: the
+car really was at rest for ≥ 5 min, already past the 3-min `minRestSplit` floor, so even a "reboot while
+parked" is indistinguishable from (and equivalent to) a real short stop. No trip is wrongly fragmented,
+because fragmentation only matters when the car kept moving — and that path is protected.
+
+### 3.2 Boundary triggers & finalization
+
+The bot is event-driven on incoming samples plus one silence timer. The single most important rule, from
+which most edge-case correctness follows: **a rest boundary requires the car to actually be at rest —
+`speed_kph ≤ speedMovingKph` — on the far side of the gap. You cannot fall asleep and wake up mid-motion.**
+
+1. **Motion → rest (trip closes):** a `trip` finalizes when the car comes to rest — (a) **`gear=P`**
+   observed (definitive, highest priority); or (b) gear absent and a *stationary* (speed ≤ threshold,
+   ignition on) stretch exceeds `minRestSplitMs`; or (c) the next sample arrives after a gap ≥ `restGapMs`
+   **and that next sample is stationary** (or `gear=P`); or (d) an observed `ignition` 1→0 edge; or (e) the
+   **silence timer** fires (§3.4). Trip `end_ts` = timestamp of the **last in-motion sample** (or the
+   `gear=P` sample), never "now". A stop in gear `D`/`R` never closes the trip.
+   - **Moving-both-sides / reboot ⇒ one trip (no phantom park).** A gap bracketed by motion on both sides,
+     or any gap < `rebootMaxGapMs` with ignition on both sides (§3.1 reboot continuity — reboots run 1–3
+     min, the "43 s max" was a 4.2-day fluke), **continues** the trip. No spurious `park`; `distance`/
+     `energy` not fragmented.
+2. **Rest → motion (rest closes):** when motion resumes (a `speed > threshold` sample) after a significant
+   rest, the open rest finalizes and is classified (§3.3). Rest `start_ts` = last pre-rest (in-motion or
+   last-awake) sample; `end_ts` = the **resuming sample**.
+3. **Rests finalize retrospectively.** Because a sleep rest ends only when data *resumes*, charge/park
+   records are computed on resume by comparing the **last pre-gap snapshot** to the **first post-gap
+   sample**. The pre-gap snapshot (counters, soc, odometer, connector) lives in `persistedCache`, so it
+   survives a mid-gap restart — this is what makes the invisible overnight charge (§0 finding 3) detectable
+   *and* restart-safe (§5).
+
+### 3.3 Rest classification & sub-segmentation (park / charge / park)
+
+A real overnight rest is physically **park → charge → park** (the car parks, sits, charges, then sits
+again until morning). Treating the whole rest as one `charge` would report the *drive-to-drive interval* as
+the charge — e.g. the §3.5 example's 10.1 kWh over 10.3 h yields a nonsense **0.98 kW** "charge rate" (a
+real Ioniq OBC does 3.3–6.6 kW). So classification is **energy-triggered but connector-bounded**, and it
+is honest about what it cannot measure:
+
+**Step 1 — is there a charge at all?** Yes if, across the rest, `Δcum_in_kwh ≥ chargeMinKwh` (0.3) **or**
+`Δcum_chg_ah ≥ chargeMinAh` (1) **or** `Δsoc ≥ chargeMinSocPct` (+2%). Energy/Ah/SoC deltas from the pack
+counters are **always valid** (they're the difference of two monotonic readings) — a charge's *magnitude*
+is robust even across a total sleep gap.
+
+**Step 2 — can we bound *when* the charge happened?** (in priority order)
+- **`bounds: meter` (home charge — preferred, verified over 2 years of meter data).** The household charger
+  meter (`charger` / `or-we-526`, MQTT `/modbus/monitoring/charger/reading`, a **separate always-on Modbus
+  device that keeps logging while the car sleeps**) has a **0 W idle baseline** (99.98% of idle samples
+  exactly 0 W) and **three charging tiers ~1.2 / 1.9 / 2.6 kW** with **no daytime other-load** on the
+  circuit in 609 days — a clean single-purpose signal. The bot keeps a persisted record of meter power
+  on/off **edges** (with the `act` cumulative-kWh counter at each edge). On rest close, if the meter shows a
+  power-on interval inside the rest window — power `> chargerMeterOnW` (150 W, above the ≤5 W noise floor and
+  below every tier) sustained `> chargerMeterOnMinMs` (60 s), ending when power stays `< chargerMeterOnW` for
+  `chargerMeterOffMinMs` (2 min, to ride the observed multi-step end-taper) — that interval **bounds the
+  charge**: real `duration_sec`, `power_avg_kw`, `ac_energy_kwh = Δact`, and `charge_efficiency =
+  energy_in_kwh / ac_energy_kwh` (verified overnight case: 10.1 kWh pack / 12.46 kWh AC = 81%). A **relative**
+  threshold (not tier-hardcoded) keeps this correct across all three tiers and any future one.
+  `duration_is_charge: true`. (Meter and car share the same server clock; edges aligned within ~5–9 min.)
+- **`bounds: connector` / `bounds: awake`.** No meter match (away-from-home charge, or meter gap), but the
+  rest contains captured `charge_connector` `0→1`/`1→0` edges or intermediate awake samples → bound the
+  charge at those edges. `duration_is_charge: true` (`ac_energy_kwh`/`charge_efficiency` null — no meter).
+- **`bounds: unbounded` (pure sleep charge, no meter/edges — the away-charge worst case).** The logger
+  slept through plug-in→charge→unplug and no home meter saw it (`charge_connector` reads 1 pre-gap and 0
+  only on resume — real unplug time unknown). Emit **one** `charge` for the whole rest with valid
+  `energy_in_kwh`/`charge_ah`/`soc_delta_pct` but `duration_is_charge: false`, `power_avg_kw: null`, and
+  `soc_end` flagged post-rest (reflects post-charge drain, not charge-complete SoC). **No fabricated
+  0.98 kW.** We do not invent park sub-sessions we cannot measure; the pre/post-charge park time is
+  acknowledged as absorbed and unmeasurable in v1.
+
+**No-charge rest ⇒ `park`** (including SoC-flat and the normal parasitic-drain case where SoC drifts
+*down*). Because a rest has **no motion**, a charge rest's `Δcum_in_kwh` is ~pure charge energy (no regen) —
+this is why segmenting by session, not by a naive time window, avoids the regen-overcount the investigation
+warned about.
+
+### 3.4 Silence timer (trailing session close) — idempotent w.r.t. an already-open rest
+
+A `trip` or awake-idle rest that is the **last activity before sleep** never sees a "next sample". A
+wall-clock timer (receipt-time, the `timeout-emit` pattern) is (re)armed on every sample for
+`silenceTimeoutMs` (provisional 5 min, above the reboot band). When it fires:
+- if a **`trip`** is open, finalize it (end = last in-motion sample) and open a **pending rest** covering
+  everything after that sample;
+- if a **rest is already open** (awake-idle that then fell asleep), **do not create a second rest** — just
+  mark the existing open rest pending (extend it). Opening-a-pending-rest is idempotent: at most one rest
+  is ever open. (Fixes the double-rest / back-to-back-rests artifact.)
+
+The pending rest stays open in `persistedCache` and is finalized+classified on the next motion resume, or
+lazily on restart (§5). A late straggler *stationary* sample arriving after the timer fired simply updates
+the still-open rest's snapshot; it does not close anything (only motion or a subsequent timeout closes a
+rest).
+
+### 3.5 Worked mapping against the real data
+
+The problematic `active` run from §0 finding 3 decomposes correctly:
+`trip` (17:44→18:32, motion) → silence timer fires 5 min after the last moving sample, `trip` finalized,
+**pending rest** opened (pre-gap snapshot: `cum_in`, `soc=52`, `connector=1`) → 10.3 h sleep gap (survives
+any restart via the persisted snapshot) → resume 04:55 (stationary) with `Δcum_in_kwh +10.1`,
+`Δcum_chg_ah +27.5`, `Δsoc +32.5` → rest classified **`charge`**; no intermediate samples ⇒ **unbounded**:
+`energy_in_kwh=10.1` (valid), `power_avg_kw=null`, `duration_is_charge=false`, `connector_confirmed=true` →
+next `speed>3` sample opens a new `trip`. Clean, honest records where the `state` tag produced one
+meaningless 704-minute blob.
+
+---
+
+## 4. Per-session metrics (all fields verified present on prod, 2026-07-18)
+
+All numeric metrics are **null when their source is missing or a boundary sample is absent** (§5) — never
+zero, never fabricated. Deltas are `last_in_session − first_in_session` unless stated.
+
+### 4.1 `trip`
+| Field | Source | Unit / note |
+|---|---|---|
+| `duration_sec` | end_ts − start_ts | s |
+| `distance_km` | `odometer` (group `odometer`) Δ | km; **null unless ≥2 distinct readings** (never 0); known-approximate (§5.3) |
+| `odometer_coverage` | odometer span ÷ `duration_sec` | 0–1; lets a consumer discount low-coverage distance |
+| `energy_out_kwh` | `cum_out_kwh` (bms/2101) Δ | kWh discharged |
+| `energy_regen_kwh` | `cum_in_kwh` (bms/2101) Δ, **minus any `charge_connector==1` interval** | kWh; a sub-`minRestSplitMs` plugged top-up mid-trip must not be mislabeled regen (§4.1 note) |
+| `energy_net_kwh` | `energy_out_kwh − energy_regen_kwh` | kWh |
+| `efficiency_wh_per_km` | `energy_net_kwh / distance_km × 1000` | Wh/km; **null if `distance_km` null**; explicitly guarded against `0`/`NaN`/`Infinity` |
+| `soc_start` / `soc_end` / `soc_delta_pct` | `soc` (bms/2101, dense) | % (see SoC note below) |
+| `speed_avg_kph` / `speed_max_kph` | `speed_kph` (bms/2101) | km/h |
+| `power_max_kw` | max `hv_kw` | kW (positive = discharge) |
+| `ambient_c` | `ambient` group if present | °C (best-effort; may be null) |
+
+> **SoC field choice:** all SoC math uses **`soc`** (dense, on `bms/2101` alongside speed/counters), not the
+> sparser `soc_display` (`bms/2105`). `soc` is the BMS true state-of-charge; `soc_display` is the
+> dash-shown, buffer-scaled value. Rationale: co-located density and consistency across all three session
+> kinds. If a *user-facing* %/day or charge-Δ should instead track the dash value, that is a documented
+> config switch, not a silent choice. (Verify both fields' presence/ranges during tuning, §11.)
+
+> **Regen-vs-plugged note (Opus finding 8):** `cum_in_kwh` credits both regen (driving) and charging. A
+> plugged top-up during a stop shorter than `minRestSplitMs` stays inside the trip; the bot subtracts any
+> interval with `charge_connector==1` from `energy_regen_kwh` (and flags the trip `contained_plugged:true`)
+> so charge energy is never reported as regen.
+
+### 4.2 `charge`
+Energy/Ah/SoC deltas are **always valid** (differences of monotonic counters, robust across a full sleep
+gap). *Timing* (`duration`/`power`) is valid only when the charge is **bounded** (§3.3): by the charger
+meter (home charge — preferred), or by captured `charge_connector` edges / intermediate awake samples. An
+**unbounded** sleep charge reports energy but **nulls** timing rather than fabricating a rate.
+
+| Field | Source | Unit / note |
+|---|---|---|
+| `energy_in_kwh` | `cum_in_kwh` Δ across rest | kWh into pack; always valid |
+| `charge_ah` | `cum_chg_ah` Δ | Ah; always valid |
+| `soc_start` / `soc_delta_pct` | `soc` | %; always valid |
+| `soc_end` | `soc` at charge end (bounded) or at resume (unbounded) | %; when unbounded, reflects post-charge drain — flagged |
+| `bounds` | `meter` \| `connector` \| `awake` \| `unbounded` | how (if at all) timing was bounded |
+| `duration_is_charge` | true only when `bounds ≠ unbounded` | boolean |
+| `duration_sec` | plugged interval (bounded) or whole-rest span (unbounded) | s; interpret with `duration_is_charge` |
+| `power_avg_kw` | `energy_in_kwh / (charge_duration/3600)` when bounded, else **null** | kW; **never the drive-to-drive-interval rate** |
+| `connector_confirmed` | `charge_connector` (`bcm_b00e`) == 1 during rest | boolean corroborator |
+| `ac_energy_kwh` | charger meter `act` Δ over the plugged interval (home charge) | kWh; null if meter unavailable (away charge) |
+| `charge_efficiency` | `energy_in_kwh / ac_energy_kwh` | 0–1 wall-to-pack; null without meter |
+| `charge_type` | `obc.dc_*` presence for `bounds:awake`; else `unknown` | `AC`/`DC` only for a rare powered-mode (awake) charge where OBC `dc_*` decodes; a home-meter match implies `AC`; else `unknown` |
+
+### 4.3 `park`
+| Field | Source | Unit / note |
+|---|---|---|
+| `duration_sec` | end_ts − start_ts | s |
+| `soc_start` / `soc_end` / `soc_delta_pct` | `soc` | % (negative delta = parasitic drain) |
+| `soc_drain_pct_per_day` | `−soc_delta_pct / (duration_sec/86400)` | %/day; null if duration < `drainMinDurationMs` |
+| `aux12v_start` / `aux12v_end` | `aux_12v` (bms/2101) | V; best-effort at boundaries |
+| `connector_confirmed` | `charge_connector` == 0 throughout | boolean (sanity: a park should not be plugged) |
+
+### 4.4 Common metadata on **every** record
+| Field | Meaning |
+|---|---|
+| `kind` | `trip` \| `charge` \| `park` (also the InfluxDB tag, §6) |
+| `start_ts` / `end_ts` | epoch ms; `start_ts` is the InfluxDB point timestamp |
+| `complete` | both start and end boundary samples were present (else metrics that need the missing side are null) |
+| `sample_count` | in-session samples seen (0 for a pure sleep rest — all metrics boundary-derived) |
+| `max_gap_sec` | largest inter-sample gap inside the session (0 if <2 samples) |
+| `closed_by` | `gear_park` \| `ignition_edge` \| `idle_split` \| `gap_stationary` \| `silence_timeout` \| `restart_lazy_close` |
+| `gear_at_close` | the `gear` value that closed the trip, or null if closed without gear | audit/tuning |
+| `seq` | monotonic per-emit counter; with `(kind,start_ts,end_ts)` forms the de-dup key (§5.6) |
+| `schema_version` | integer, for downstream forward-compat |
+
+`trip` records additionally carry `start_truncated:true` (the 1–2 min logger startup lag means the first
+moments of the drive are unsampled, so `distance`/`energy` slightly undercount — §0.1).
+
+---
+
+## 5. Missing-data & edge-case policy
+
+The core design principle: **the bot never fabricates a metric, and never silently loses a session.**
+Concretely:
+
+1. **Boundary-derived when asleep.** Sleep rests have `sample_count = 0`; metrics are `pre-gap snapshot`
+   vs `post-gap sample`. If a boundary is absent (bot started mid-gap; pre-sleep sample never seen),
+   affected metrics are **null** and `complete = false`.
+2. **Counter-reset guard = negative delta only.** `cum_*`/`odometer` are monotonic; a **negative** delta
+   ⇒ reset (or bad baseline) ⇒ that metric **null** + `complete = false`. Do **not** cap *positive* jumps
+   at a small value: a 60 km trip is a legitimate +60 km odometer jump, and a bulk charge is a legitimate
+   `cum_in` jump. The plausibility ceiling (`maxPlausibleStepKm`) is set **above a full-range trip**
+   (provisional 400 km, ~1.5× the car's ~250 km range) purely to catch corruption, never normal use.
+3. **Distance needs ≥2 *distinct* odometer readings, else null — never 0.** Odometer is sparse (~1/82 min,
+   §0). A trip with one (or zero) odometer sample yields **null** `distance_km` (not `last−first = 0`), and
+   any metric dividing by it (`efficiency_wh_per_km`) is **null** — explicitly guarded against `0`/`NaN`/
+   `Infinity`. Even with ≥2 readings, both may sit *interior* to the true motion span (start/end minutes
+   unsampled, compounded by the 1–2 min startup lag, §0.1), so distance under-counts and efficiency
+   over-estimates; the record carries `odometer_coverage` (odometer span ÷ trip duration) so a consumer can
+   discount low-coverage figures. Distance is a *known-approximate* metric, flagged, not a precise one.
+4. **Lazy close is session-type-aware (fixes the overnight-charge-loss bug).** The open session + its start
+   snapshot live in `persistedCache`, surviving restarts. On the resume sample after a restart:
+   - open **trip** → finalize (end = last in-motion sample), then process the resume normally;
+   - open **rest** → close it with **end = the resuming sample** (NOT "last recorded sample" — a rest's
+     last recorded sample is the *pre-gap* one, which would make `Δcum_in = 0` and misclassify a real
+     charge as park); and **only if the resume is motion or a fresh gap ≥ `restGapMs` follows**. If the
+     resume sample is still **stationary**, the rest stays open and keeps accumulating — a restart mid-park
+     must not chop one park into two (which would corrupt `soc_drain_pct_per_day`) nor split a charge such
+     that each half falls under `chargeMinKwh`. `closed_by = restart_lazy_close` records the path.
+5. **Exactly-once into InfluxDB; at-least-once into Mongo (honest guarantee).** `persistedCache` persists
+   **asynchronously with debouncing** (automations framework), so a crash between "publish" and "flush"
+   can re-emit a session. InfluxDB is **idempotent** on `(measurement, kind-tag, start_ts-timestamp)` — a
+   re-emit overwrites the same point, harmless. **Mongo (`mqtt-mongo-ioniq`, `ioniq/#`) is append-only, so
+   a re-emit duplicates the record there.** Mitigation: set an `emitted:true` marker on the open session
+   *in the same mutation that computes it, before publishing*, so a replay sees it as already-emitted; this
+   shrinks but does not eliminate the window. Documented, not over-claimed. Downstream Mongo consumers must
+   de-dup on `(kind, start_ts, end_ts)`.
+6. **De-dup key = `(kind, start_ts, end_ts)`, not `start_ts` alone.** Consecutive sessions can legitimately
+   share a boundary timestamp (a rest's `start_ts` = the prior trip's last sample). Keying only on
+   `start_ts` would drop the rest. The bot also **rejects degenerate single-sample "trips"**
+   (`< minTripDurationMs` **and** `< minTripSamples`) — a lone `speed>3` jitter sample at the 3 km/h floor
+   is not a trip — which also removes the same-timestamp collision at the source.
+7. **Malformed/partial payloads** don't advance state (mirrors `ioniq-12v-ldc.isValidSample`), but a
+   payload carrying *some* usable fields still refreshes the boundary snapshot for the fields it has.
+8. **All thresholds are `config`, provisional**, re-tuned after ~2 weeks (§0, §11).
+
+---
+
+## 6. Output schema & ingestion
+
+### 6.1 MQTT
+- Topics: `ioniq/derived/trip`, `ioniq/derived/charge`, `ioniq/derived/park`.
+- Payload: a flat object of the §4 fields plus `_type: 'ioniq-session'` and `kind`. Published via
+  `mqtt.publish(topic, obj)` (framework serializes; objects not strings — automations CLAUDE.md).
+
+### 6.2 Converter — `docker/mqtt-influx/converters/ioniq-session.js` (new)
+- Keyed by `_type: 'ioniq-session'` in `docker/mqtt-influx/index.js` converters map.
+- Emits `new Point('ioniq_sessions')`.
+- **Tag:** `kind` (low-cardinality: 3 values) — the only tag; dashboards filter/group by it.
+- **Timestamp:** `start_ts` (epoch ms). Records are back-dated to session start so a "trips over time"
+  axis places each session where it began. `end_ts` carried as a field.
+- **Fields:** all §4 numeric/boolean/string metrics, typed by JS runtime type (reuse the `addField`
+  typing discipline from `converters/ioniq.js`: finite numbers → float, booleans → boolean, strings →
+  string; null/undefined skipped so a null metric simply omits its field rather than writing a sentinel).
+- **Reserved set:** widen the converter's `RESERVED` set beyond `converters/ioniq.js`'s
+  (`_type, group, state, ts`) to also exclude `kind` (it's the tag) and the framework's auto-added
+  `_bot`/`_tz` envelope metadata — otherwise those leak in as spurious string fields (a pre-existing quirk
+  in the `ioniq` converter we deliberately do not replicate here). `start_ts`/`end_ts` stay as
+  fields/timestamp per above.
+
+### 6.3 New bridge instance — `docker-compose.yml`
+Clone the `mqtt-influx-ioniq` service block verbatim as `mqtt-influx-ioniq-sessions`, changing **only**:
+- `TOPIC=ioniq/derived/#`
+- `MQTT_CLIENT_ID=mqtt-influx-ioniq-sessions`
+
+Everything else is carried forward **unchanged** from `mqtt-influx-ioniq` (do NOT hardcode any of it):
+`image` + `build: docker/mqtt-influx`, `depends_on: [broker, influxdb]`, `networks: [automation, egress]`,
+`security_opt: [no-new-privileges]`, `secrets: [influxdb_write_user, influxdb_write_user_password]`,
+`logging`, and env `BROKER`, `INFLUXDB_URL`, `INFLUXDB_USERNAME_FILE`, `INFLUXDB_PASSWORD_FILE`, and
+`INFLUXDB_DATABASE=${INFLUXDB_DATABASE}` (a variable reference, matching every sibling block — same db,
+different measurement via the converter). No new env-var *names* are introduced, so `example.env` needs no
+change. Add a Dependabot entry only if a new directory is introduced — none is (reuses the `mqtt-influx`
+image; `/docker/mqtt-influx` already has `docker` + `npm` entries in `.github/dependabot.yml`), so no
+`.github/dependabot.yml` change is required.
+
+### 6.4 Documentation deliverables (required by CLAUDE.md)
+- **`docs/influxdb-schema.md`** — document the new `ioniq_sessions` measurement (tag `kind`; all §4 fields
+  with units; back-dated `start_ts` timestamp semantics).
+- **`docker/mqtt-influx/CLAUDE.md`** — add the `ioniq-session` converter and `mqtt-influx-ioniq-sessions`
+  instance to the converter/instance lists.
+- **`docs/ioniq-monitoring-alerting-spec.md`** — flip the §7 "Trips & charging" deferral note to point at
+  this bot as the data source; and **correct §10's "verify the `charger` ORNO meter is live" open item** —
+  it *is* live, it just writes to measurement `xymd1` (not a `monitoring`/`charger`-named one), which is
+  why the original query found nothing.
+
+---
+
+## 7. Bot implementation shape
+
+Config block (in `config/automations/config.js`), all thresholds provisional & overridable:
+
+```javascript
+ioniqSessions: {
+  type: 'ioniq-sessions',
+  bmsTopic: 'ioniq/parsed/bms/2101',        // ignition, speed_kph, soc, hv_kw, aux_12v, cum_* counters, ts
+  vmcuTopic: 'ioniq/parsed/vmcu',           // gear (P/N/D/R string), speed_kph — gear is HERE, not bms/2101
+  gearParkValue: 'P',                       // verified string 'P' = parked
+  odometerTopic: 'ioniq/parsed/odometer',   // km (sparse ~1/82min)
+  connectorTopic: 'ioniq/parsed/bcm_b00e',  // charge_connector (sparse corroborator / awake-charge bound)
+  ambientTopic: 'ioniq/parsed/ambient',     // optional; ambient_c best-effort
+  chargerMeterTopic: '/modbus/monitoring/charger/reading', // charger or-we-526; fields ap(W), act(kWh); home-charge bound + AC kWh
+  tripTopic: 'ioniq/derived/trip',
+  chargeTopic: 'ioniq/derived/charge',
+  parkTopic: 'ioniq/derived/park',
+  // thresholds (PROVISIONAL — re-tune after ~2 weeks of history, §11)
+  speedMovingKph: 3,           // > this = moving (rejects standstill jitter)
+  minRestSplitMs: 180000,      // 3 min OBSERVED stationary-awake splits a trip
+  restGapMs: 300000,           // 5 min gap = sleep/rest boundary (above the 1-3 min reboot band + 1 min slow cadence)
+  rebootMaxGapMs: 300000,      // gaps below this with ignition on both sides = reboot, NOT a rest
+  silenceTimeoutMs: 300000,    // 5 min silence closes a trailing session (> reboot band)
+  minTripDurationMs: 60000, minTripSamples: 3, // reject degenerate single-sample jitter "trips"
+  chargeMinKwh: 0.3, chargeMinAh: 1, chargeMinSocPct: 2,   // any ⇒ the rest contained a charge
+  chargerMeterOnW: 150, chargerMeterOnMinMs: 60000, chargerMeterOffMinMs: 120000, // on: >150W sustained >60s; off: <150W for >2min (rides taper). 0W baseline + 3 tiers (1.2/1.9/2.6kW) verified over 2yr
+  drainMinDurationMs: 3600000, // 1 h min park before %/day drain is meaningful
+  maxPlausibleStepKwh: 40, maxPlausibleStepKm: 400, // corruption ceilings ONLY (above full-range trip/bulk charge)
+  socField: 'soc',            // 'soc' (dense, default) vs 'soc_display' (dash) — documented switch, §4.1
+}
+```
+
+`persistedCache` (version 1, with `migrate`) holds: the open session (kind, start snapshot, running
+reducers — min/max/sum for speed & power, plugged-interval accumulator, first/last snapshots of counters,
+odometer, soc, aux_12v, ignition, connector; sample count; max gap; `emitted` flag §5.5), the pending-rest
+snapshot, the **charger-meter on/off edge record** (`{ts, act}` per edge, spanning the current rest — so a
+metered charge survives restart, else it degrades to `bounds:unbounded`, §5.4), `lastSampleRxTs`/
+`lastSampleTs`, `lastIgnition`, and the de-dup ledger (`lastEmitted: {kind,start_ts,end_ts,seq}`, §5.6).
+Snapshots + reducers + edges (not a raw window — unlike `ioniq-12v-ldc`) keep the cache small and
+restart-cheap.
+
+Subscribe to the input topics and maintain a **merged latest-view** across groups (cell-health-style
+last-known merge, since the boundary signals are split across frames): **`vmcu` carries `gear`+`speed_kph`**
+(the primary motion/park signals) and **`bms/2101` carries `ignition`+`soc`+`hv_kw`+`cum_* counters`**. Each
+`vmcu` or `bms/2101` message updates its fields in the merged view and triggers a state evaluation stamped
+with that message's receipt time; `odometer`/`connector`/`ambient` only refresh their boundary snapshots.
+`chargerMeterTopic` (a *separate always-on Modbus device*, not ioniq telemetry) feeds a **persisted
+power on/off edge record** — each edge stores `{ts, act}` when `ap` crosses `chargerMeterOnW` (debounced by
+`chargerMeterOnMinMs`) — **not** a raw recent-sample buffer. Two edges (on, off) are all §4.2 needs
+(`duration = t_off−t_on`, `ac_energy_kwh = act_off−act_on`, `power_avg_kw`, `charge_efficiency`); storing
+edges (bounded, tiny) means an on-edge at the *start* of a 10 h overnight charge survives to rest-close,
+where a "recent" buffer would have aged it out. The edge record lives in `persistedCache` (below), so it
+survives a mid-charge restart. The bot correlates meter and car by wall-clock; both streams are on the
+same broker/InfluxDB server-time (verified aligned within ~5–9 min, §0.1/§12).
+
+---
+
+### 7.1 Logger enhancement requests (optional — the bot degrades gracefully without them)
+
+The operator can raise the log cadence of specific fields. None of these block v1 (the bot flags the
+affected metric approximate/null when data is thin), but each measurably improves quality. Prioritized:
+
+| # | Field (group) | Current | Requested | Payoff |
+|---|---|---|---|---|
+| 1 | **`odometer`** (`odometer`) | ~1 / 82 min | every ~15–30 s **while `gear ∈ {D,R}`** (or on-change) | The single biggest fix: makes `distance_km` and `efficiency_wh_per_km` reliable instead of frequently null/low-coverage (§5.3). |
+| 2 | **`gear`** (`vmcu`) | dense (verified) | keep it in the ~2 s fast group | Prompt `gear=P` trip-close and red-light-doesn't-split correctness (§3). Already dense — no change likely needed. |
+| 3 | **`charge_connector`** (`bcm_b00e`) | ~135 / 400 d | on-change (0↔1), or ≥ every 30 s while plugged | Better charge corroboration and `bounds:connector` timing for **away** charges (no home meter). |
+| 4 | **`hv_kw`,`cum_in_kwh`,`soc`** during **powered-mode charging** | only when awake | 2 s cadence whenever the car is in powered mode while plugged | The rare powered-mode charge (§0.1: the early short AC/DC charges) becomes a fully **`bounds:awake`** session with a real in-session power curve — precise ground truth to calibrate the meter-side thresholds. |
+
+Rationale for #1: odometer sparsity is called out three times (§4.1, §5.3, §12) as the dominant metric
+limitation; denser odometer during driving removes it without any bot change.
+
+## 8. Testing plan (TDD, Jest, mocked MQTT — repo standard)
+
+Fixtures built from the **real payload shapes** observed on prod (nested where the logger nests; the tpms
+lesson from phase-4 §1.1 — fixtures must match reality or bugs pass review). Fail-before/pass-after per
+`superpowers:test-driven-development`.
+
+Required scenarios (each maps to a design decision / review finding):
+- **Clean trip** → one `trip` with correct deltas (41.6-min worked example: soc 73→61, `cum_out` +4.7 kWh,
+  odo +40 km, sane Wh/km).
+- **Invisible overnight charge, UNBOUNDED** (§3.5): trip → silence timeout → pending rest → 10.3 h gap →
+  stationary resume with SoC jump → one `charge` with valid `energy_in_kwh`, `bounds:unbounded`,
+  `power_avg_kw:null`, `duration_is_charge:false`, `connector_confirmed:true` → fresh `trip`. **Asserts no
+  fabricated ~1 kW rate.**
+- **Home charge, BOUNDED by meter**: same gap but the charger-meter on/off edges show power on 20:00→23:00
+  → `charge` with real `duration_sec`/`power_avg_kw`, `bounds:meter`, `ac_energy_kwh`, `charge_efficiency`.
+- **Restart MID-GAP preserves the charge** (blocker-2): pending rest in cache + restart during the 10.3 h
+  gap + stationary resume → still one `charge` (Δ computed from persisted pre-gap snapshot), **not** a
+  `park`; a stationary resume does **not** prematurely close/split the rest.
+- **Restart mid-metered-charge**: meter on-edge persisted, restart during the plugged interval, resume →
+  `charge` stays `bounds:meter` (edge survived); a separate test where the persisted on-edge is *absent*
+  (started after it) asserts the documented graceful degrade to `bounds:unbounded`, energy still valid.
+- **Awake-idle then sleep = ONE rest** (blocker-3): trip closes on `minRestSplitMs` idle → awake-idle rest
+  opens → car sleeps → silence timer fires → **no second rest**; resume yields exactly one park/charge.
+- **Reboot gap 1–3 min does not split a trip** (moving-both-sides AND ignition-continuity variants).
+- **Ignition 1→0 edge** closes the awake session promptly (`closed_by:ignition_edge`).
+- **`gear=P` closes the trip immediately** (`closed_by:gear_park`), before `minRestSplitMs` elapses.
+- **Stop in gear `D` (red light) does NOT split** the trip even past `minRestSplitMs`; **`gear=N` alone**
+  does not split; **gear absent** → falls back to speed + `minRestSplitMs`.
+- **Single-sample jitter "trip" rejected** (`< minTripDurationMs` & `< minTripSamples`) → no record, no
+  shared-timestamp collision with the following rest.
+- **De-dup on `(kind,start_ts,end_ts)`**: a rest whose `start_ts` equals the prior trip's last sample still
+  emits (not dropped).
+- **Distance honesty**: 1 odometer reading → `distance_km:null` (not 0) and `efficiency:null` (no
+  `Infinity`/`NaN`); ≥2 interior readings → distance flagged low `odometer_coverage`.
+- **Counter reset** (negative Δ) → metric null; **large legit jump** (60 km trip, bulk charge) → NOT nulled.
+- **Missing boundary** (bot starts mid-gap) → `complete:false`, affected metrics null.
+- **Park with parasitic drain** → `park`, negative `soc_delta`, sane `soc_drain_pct_per_day`; park shorter
+  than `drainMinDurationMs` → drain null.
+- **Silence timer** (fake timers) closes at last-sample time, not "now".
+- **Emitted-before-publish**: crash after publish/before flush + restart → InfluxDB overwrites (idempotent);
+  test asserts the `emitted` marker is set in the pre-publish mutation (Mongo at-least-once is documented,
+  not asserted away).
+- **Malformed payload** ignored without corrupting state.
+
+Converter unit tests: `ioniq-session.js` maps a session payload to a `ioniq_sessions` point with the `kind`
+tag, `start_ts` timestamp, correct field types, **omits null metrics** (no sentinel), and **excludes**
+`kind`/`_bot`/`_tz` from fields (§6.2 reserved set).
+
+---
+
+## 9. Delivery — PR granularity
+
+1. **PR1 — the bot.** `docker/automations/bots/ioniq-sessions.js` + tests + `config/automations/config.js`
+   wiring. Self-contained; emits to `ioniq/derived/*`. Reviewable and testable in isolation (no InfluxDB
+   dependency — pure MQTT-in/MQTT-out). Merged & deployed first; verify records appear on `ioniq/derived/*`
+   via `mosquitto_sub` on prod.
+2. **PR2 — ingestion.** `docker/mqtt-influx/converters/ioniq-session.js` + `index.js` registration +
+   converter tests + the `mqtt-influx-ioniq-sessions` compose service + `docs/influxdb-schema.md` +
+   `docker/mqtt-influx/CLAUDE.md` updates. After deploy, confirm `ioniq_sessions` points land in InfluxDB.
+3. **PR3 (optional, later) — dashboard.** The "Trips & charging" Grafana dashboard consuming
+   `ioniq_sessions`. Out of scope for this spec; listed for sequencing only.
+
+PR1 and PR2 touch disjoint files (automations vs mqtt-influx) and can proceed in parallel; only end-to-end
+InfluxDB validation needs both deployed.
+
+## 10. Orchestration & review plan
+
+Per the established ioniq recipe (phase-4 §5):
+- All work via **subagents, model/effort-matched**: haiku for mechanical checks, sonnet standard, opus for
+  the segmentation-algorithm design gate and final verdicts.
+- **Independent fresh subagents at every review gate** (plan review, bot review, converter/bridge review,
+  whole-branch review). The author never reviews itself.
+- **Escalate to the human only** for genuine product/judgment calls.
+- Selective staging only (never `git add .`); every commit body ends with the Claude-Session trailer.
+- Each PR ends **OPEN** with a GOOD-TO-MERGE verdict + evidence; the human decides merges.
+
+## 11. Validation (non-negotiable)
+
+- Segmentation logic validated against **real historical windows** replayed from prod (the 4.2-day dump):
+  the worked trip and the overnight charge must produce the expected records.
+- Every field referenced verified present on prod (recipe below); units confirmed. Already verified:
+  `gear` is a string `P/N/D/R` on group **`vmcu`** (`gearParkValue='P'`); charger tiers ~1.2/1.9/2.6 kW with
+  0 W baseline over 609 days (`chargerMeterOnW=150`). Re-confirm at implementation that no group/field moved.
+- After PR1 deploy: `mosquitto_sub -t 'ioniq/derived/#'` on prod shows well-formed records as the car is
+  driven/charged.
+- After PR2 deploy: `SELECT * FROM ioniq_sessions` returns the records with correct `kind` tag and
+  back-dated timestamps; no InfluxDB write errors in the bridge logs.
+- Re-run the §0 data analysis after ~2 weeks and **re-tune thresholds** before considering the bot final.
+
+### Prod read-only query recipe
+```
+ssh routy 'cd ~/homy && AU=$(cat secrets.local/influxdb_admin_user) AP=$(cat secrets.local/influxdb_admin_password); \
+  docker exec homy_influxdb_1 influx -database homy -username "$AU" -password "$AP" -execute "<InfluxQL>"'
+```
+Creds live in `~/homy/secrets.local/*` (NOT `~/homy/secrets/*`). `"group"` is reserved — double-quote it;
+string literals single-quoted; no `$timeFilter` — use explicit `WHERE time >= now() - <window>`.
+
+## 12. Risks & open items
+
+1. **4.2 days of data only** — all thresholds provisional; §11 re-tune is mandatory before "final".
+2. **Odometer sparsity (~1/82 min)** makes `distance_km`/efficiency frequently null or coarse. Best fix is
+   **logger request §7.1 #1** (denser odometer while driving) — cheap and removes the limitation. Absent
+   that, v1 flags it null/low-coverage; a `speed_kph`-integration distance fallback is deliberately deferred
+   (integration error). Not blocking.
+3. **Charge timing depends on the charger meter (home) or captured edges (away).** Home charges are
+   meter-bounded (AC energy + efficiency + real power — verified). **Away-from-home charges** have no meter
+   and usually no captured connector edges → `bounds:unbounded`: energy still valid, timing/power null.
+   Accepted for v1. **Charger power tiers characterized over 609 days:** three tiers ~1.2 / 1.9 / 2.6 kW
+   (the two higher fell out of recent use, hence only 1.2 kW in the 30-day pull), 0 W idle baseline, and
+   **no daytime other-load** on the circuit — so the relative `chargerMeterOnW=150 W` threshold detects all
+   tiers cleanly. **Calibration path:** the operator can re-exercise all 3 settings and (rarely) a
+   powered-mode charge for simultaneous meter + car-side measurements to refine the AC→pack efficiency curve.
+   `charge_type` stays `unknown` unless a powered-mode charge decodes it (§4.2).
+4. **`speed_kph` / `ignition` trustworthiness** — `speedMovingKph` hysteresis mitigates standstill jitter;
+   ignition is operator-confirmed trustworthy as the awake delimiter but its 1→0 edge is only *sometimes*
+   captured before power-off, so the silence timer remains the backstop. Validate both floors during tuning.
+5. **Counter lifetime resets** (MEMORY "look reset") not observable in 4.2 days — the negative-delta guard
+   (§5.2) is the safeguard; watch after more history.
+6. **Meter↔car time correlation** relies on both being on the same server clock (verified aligned within
+   ~5–9 min). A large clock skew would mis-bound a charge; the ±minutes tolerance in matching absorbs the
+   handshake/taper lag.
+7. **Followup journey bot** (coarse trip merging) and the **Trips & charging dashboard** are separate,
+   unblocked-by-this deliverables.
+
+## 13. Acceptance criteria
+
+- `ioniq-sessions` bot emits one well-formed record per closed `trip`/`charge`/`park` to
+  `ioniq/derived/{trip,charge,park}`, with §4 metrics + quality metadata; **idempotent into InfluxDB**
+  (`kind`+`start_ts`), at-least-once into Mongo with the `emitted` mitigation (§5.5).
+- Canonical scenarios pass with fail-before/pass-after: clean trip; **meter-bounded home charge** (real
+  power + `ac_energy_kwh` + efficiency); **unbounded away charge** (energy valid, power null, no fabricated
+  rate); parasitic-drain park; reboot-gap-does-not-split; awake-idle+sleep = one rest; restart-mid-gap
+  preserves the charge; single-sample jitter rejected; distance null-not-zero on sparse odometer.
+- Missing-data policy (§5) exercised by tests: null-not-fabricate, session-type-aware lazy-close,
+  timer-close at last-sample time, negative-delta-only counter guard, `(kind,start_ts,end_ts)` de-dup.
+- `ioniq-session` converter + `mqtt-influx-ioniq-sessions` bridge land records in a new `ioniq_sessions`
+  measurement (tag `kind`, back-dated `start_ts`); null metrics omit their field; `_bot`/`_tz`/`kind`
+  excluded from fields.
+- `docs/influxdb-schema.md`, `docker/mqtt-influx/CLAUDE.md`, and the alerting-spec §7/§10 updates landed.
+- Two OPEN PRs (bot, ingestion) each carrying an independent GOOD-TO-MERGE verdict with evidence.


### PR DESCRIPTION
## What

Adds **`ioniq-sessions`**, an automations bot that segments the Ioniq EV telemetry stream into discrete **trip / charge / park** session records, plus the InfluxDB ingestion for them (`ioniq_sessions` measurement). This unblocks the long-deferred "Trips & charging" dashboard and parasitic-drain analysis.

Design & full rationale: [`docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md`](../blob/feat/ioniq-session-segmentation/docs/superpowers/specs/2026-07-18-ioniq-session-segmentation-bot-design.md).

## Why the obvious approach doesn't work

Prod data showed the `state` tag is unusable for segmentation: `parked` never persists (0–35 s blips), `charging` only catches trivial handshake blips, and a single `active` run bundles a full drive **plus** an overnight charge. Real park/charge happen while the logger sleeps (multi-hour data gaps).

So segmentation keys off **`ignition` (awake delimiter) + `gear` P/N/D/R (drive/park) + `speed_kph` + data gaps + cumulative-counter/SoC deltas**, and **never fabricates a metric** under missing data.

## Highlights

- **Charge timing** is bounded in priority order: the always-on **home charger energy meter** (real power + AC kWh + wall-to-pack efficiency — verified 81% on a known charge over 609 days of meter history) → captured `charge_connector` edges → continuous awake coverage. A sleep-gap charge that none of these bound reports **energy only**, with `power_avg_kw = null` — no fabricated drive-to-drive rate.
- **Robust to missing data**: session-type-aware lazy-close, silence timer, restart survival via `persistedCache`, `(kind,start_ts,end_ts)` de-dup, negative-delta counter guards, distance `null`-not-zero on sparse odometer.
- **Ingestion**: new `ioniq-session` converter → `ioniq_sessions` measurement (tag `kind`, back-dated `start_ts`, null metrics omitted); new `mqtt-influx-ioniq-sessions` bridge on `ioniq/derived/#`, cloned from `mqtt-influx-ioniq`.

## Scope / follow-ups (per the spec)

- **Aggregation only** — no alerting (charge-guard stays separate). Coarse "journey" merging and the Grafana dashboard itself are separate deliverables.
- **Optional logger enhancements** (spec §7.1) — denser `odometer` while driving would remove the main metric-quality limitation; the bot degrades gracefully without it.
- Thresholds are **provisional** (only ~4 days of car history exists); spec §11 mandates re-tuning after ~2 weeks.

## Testing

- Bot: **32** Jest tests (TDD), incl. the invisible overnight charge, meter-bounded home charge, restart-mid-gap, gear/ignition boundaries, reboot gaps, de-dup, never-fabricate paths.
- Ingestion: **22** Jest tests; `docker compose config` validates the new bridge.
- Built and reviewed by **independent subagents**; three adversarial review passes caught and fixed two blocker-class fabricated-rate bugs before merge.

https://claude.ai/code/session_01DtMpuVeBgw8QMJ2gZLyugq