### PR TITLE
fix(ioniq): ignore garbage all-zero OBD frames instead of false-alarming

### DIFF
--- a/config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-12v-ldc-alerts.yaml
@@ -36,7 +36,7 @@ groups:
                   type: query
               expression: ldc
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 60s
         labels: { severity: warning, device: ioniq, subsystem: 12v }
         annotations:

--- a/config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml
@@ -36,7 +36,7 @@ groups:
                   type: query
               expression: iso
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:
@@ -73,7 +73,7 @@ groups:
                   type: query
               expression: iso
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 10m
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:
@@ -110,7 +110,7 @@ groups:
                   type: query
               expression: cmin
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 1m
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:
@@ -147,7 +147,7 @@ groups:
                   type: query
               expression: cmin
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 1m
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:
@@ -184,7 +184,7 @@ groups:
                   type: query
               expression: cmax
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 1m
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:
@@ -221,7 +221,7 @@ groups:
                   type: query
               expression: tmax
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 5m
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:
@@ -258,7 +258,7 @@ groups:
                   type: query
               expression: tmax
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 5m
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:
@@ -295,7 +295,7 @@ groups:
                   type: query
               expression: soh
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 1h
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:
@@ -332,7 +332,7 @@ groups:
                   type: query
               expression: soh
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 1h
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:
@@ -383,7 +383,7 @@ groups:
                   type: query
               expression: disq
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 15m
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:

--- a/config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-cell-health-alerts.yaml
@@ -36,7 +36,7 @@ groups:
                   type: query
               expression: spread
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:
@@ -73,7 +73,7 @@ groups:
                   type: query
               expression: spread
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 10m
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:
@@ -110,7 +110,7 @@ groups:
                   type: query
               expression: spread
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:
@@ -147,7 +147,7 @@ groups:
                   type: query
               expression: spread
         noDataState: OK
-        execErrState: Alerting
+        execErrState: OK
         for: 10m
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:

--- a/docker/automations/bots/ioniq-cell-health.js
+++ b/docker/automations/bots/ioniq-cell-health.js
@@ -8,6 +8,13 @@
 // fields inside carry their own JSON-string-encoded float arrays. Tolerate an
 // already-parsed array too (defensive, mirrors ioniq-dtc's parseCodes) so a
 // delivery quirk can't silently corrupt a segment.
+//
+// Also rejects an all-zero array: the OBD logger occasionally decodes a
+// "no data" ECU response as literal 0s instead of omitting the frame, and a
+// same-length all-zero array otherwise passes every other check here. 32
+// cell voltages or 5-7 module temps reading exactly 0.0 in unison is not a
+// real sensor state, so treat it the same as a malformed frame and keep the
+// prior segment rather than merge garbage into the spread calculation.
 function parseFloatArray (raw, expectedLen) {
   let arr = raw
   if (typeof arr === 'string') {
@@ -20,6 +27,9 @@ function parseFloatArray (raw, expectedLen) {
     return null
   }
   if (!Array.isArray(arr) || arr.length !== expectedLen || !arr.every(Number.isFinite)) {
+    return null
+  }
+  if (arr.every((n) => n === 0)) {
     return null
   }
   return arr

--- a/docker/automations/bots/ioniq-cell-health.test.js
+++ b/docker/automations/bots/ioniq-cell-health.test.js
@@ -121,7 +121,8 @@ describe('ioniq-cell-health bot — cell_spread_mv', () => {
     ['non-JSON string', 'not-json{{{'],
     ['wrong length (31)', JSON.stringify(flatSegment().slice(0, 31))],
     ['non-array', JSON.stringify({ not: 'an array' })],
-    ['NaN element', JSON.stringify([...flatSegment().slice(0, 31), null])]
+    ['NaN element', JSON.stringify([...flatSegment().slice(0, 31), null])],
+    ['all-zero array (garbage no-data frame)', JSON.stringify(new Array(32).fill(0))]
   ])('rejects a malformed cells frame (%s) and keeps the prior good segment, with no emission from the bad frame', async (_label, badCells) => {
     const seg = flatSegment()
     await mqtt._trigger(CELLS1, { cells: JSON.stringify(seg), state: 'parked', ts: 1 })
@@ -216,6 +217,24 @@ describe('ioniq-cell-health bot — module_temp_spread_c', () => {
     expect(mqtt.publish).not.toHaveBeenCalled()
 
     // retrigger with the other good topic — should use retained good moduleTemps
+    await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'parked', ts: 3 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+    expect(mqtt.publish).toHaveBeenCalledWith(MODULE_TEMP_SPREAD_OUT, expect.objectContaining({ value: 33 - 28 }))
+  })
+
+  it('rejects an all-zero module_temps frame (garbage no-data OBD frame) instead of merging it into the spread', async () => {
+    const moduleTemps = [30, 31, 29, 30, 30]
+    const moduleTemps6_12 = [30, 30, 33, 30, 30, 30, 28]
+    await mqtt._trigger(BMS2101, { module_temps: JSON.stringify(moduleTemps), state: 'parked', ts: 1 })
+    await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'parked', ts: 1 })
+    expect(mqtt.publish).toHaveBeenCalledTimes(1)
+    mqtt.publish.mockClear()
+
+    // A garbage all-zero frame must not overwrite the retained good segment
+    // or emit a bogus spread from it.
+    await mqtt._trigger(BMS2101, { module_temps: JSON.stringify([0, 0, 0, 0, 0]), state: 'parked', ts: 2 })
+    expect(mqtt.publish).not.toHaveBeenCalled()
+
     await mqtt._trigger(BMS2105, { module_temps_6_12: JSON.stringify(moduleTemps6_12), state: 'parked', ts: 3 })
     expect(mqtt.publish).toHaveBeenCalledTimes(1)
     expect(mqtt.publish).toHaveBeenCalledWith(MODULE_TEMP_SPREAD_OUT, expect.objectContaining({ value: 33 - 28 }))

--- a/docker/mqtt-influx/converters/__tests__/ioniq.test.js
+++ b/docker/mqtt-influx/converters/__tests__/ioniq.test.js
@@ -72,4 +72,20 @@ describe('ioniq converter', () => {
         expect(() => ioniq(frame)).not.toThrow()
         expect(ioniq(frame)).toHaveLength(1)
     })
+
+    it('drops a bms/2101 frame with cell_min_v and cell_max_v both 0 (garbage no-data frame)', () => {
+        const frame = {
+            _type: 'ioniq', group: 'bms/2101', state: 'parked', ts: 1720000000006,
+            hv_v: 0, aux_12v: 0, cell_min_v: 0, cell_max_v: 0, isolation_kohm: 1000,
+        }
+        expect(ioniq(frame)).toEqual([])
+    })
+
+    it('keeps a bms/2101 frame when only one of cell_min_v/cell_max_v is 0 (not the garbage signature)', () => {
+        const frame = {
+            _type: 'ioniq', group: 'bms/2101', state: 'parked', ts: 1720000000007,
+            cell_min_v: 0, cell_max_v: 3.85,
+        }
+        expect(ioniq(frame)).toHaveLength(1)
+    })
 })

--- a/docker/mqtt-influx/converters/ioniq.js
+++ b/docker/mqtt-influx/converters/ioniq.js
@@ -43,11 +43,28 @@ function addField(point, key, value) {
 }
 
 /**
+ * The OBD logger occasionally gets a "no data" response from the ECU for the
+ * primary BMS query (raw frame `6101FFFFFFFF...`) and decodes it as literal
+ * 0 instead of omitting the fields. A real pack can never read exactly 0 V
+ * on both min and max cell simultaneously (that's every cell physically
+ * destroyed/disconnected at once), so this is an unambiguous garbage-frame
+ * signature — not a real vehicle state. Dropping the whole point here stops
+ * it from tripping Grafana's raw-field thresholds (cell under-voltage, etc).
+ */
+function isGarbageBmsFrame(data) {
+    return data.group === 'bms/2101' && data.cell_min_v === 0 && data.cell_max_v === 0
+}
+
+/**
  * Converts an `ioniq` parsed telemetry payload into a single InfluxDB point.
  * Tags: group, state (low-cardinality; what dashboards filter/group by).
  * Timestamp: data.ts (epoch ms) passed straight to the ms-precision write API.
  */
 module.exports = function ioniq(data) {
+    if (isGarbageBmsFrame(data)) {
+        return []
+    }
+
     const point = new Point('ioniq')
 
     if (data.group !== undefined && data.group !== null) {


### PR DESCRIPTION
## Summary
- The OBD logger occasionally decodes a "no data" ECU response as literal `0` across most `bms/2101` fields (`hv_v`, `cell_min_v`, `cell_max_v`, `aux_12v`, `temp_max`, `soc`, `module_temps`) instead of omitting the frame. Confirmed on prod InfluxDB (3 occurrences / 30 days) and traced directly to a false 29°C module-temp-spread Telegram alert today (2026-07-20 06:05/06:06 UTC).
- `mqtt-influx/converters/ioniq.js`: drop `bms/2101` points where `cell_min_v` and `cell_max_v` are both exactly 0 — physically impossible together for a real pack, an unambiguous garbage-frame signature.
- `ioniq-cell-health.js`: `parseFloatArray` now rejects an all-zero array (a real cell-voltage/module-temp array is never uniformly exactly 0.0), instead of merging garbage into the cross-frame spread calculation.
- Flipped `execErrState: Alerting` → `OK` on the 15 Ioniq battery/cell-health/12v-ldc Grafana rules that never got the same treatment the dtc/tpms rules got in #1403 — caught a transient InfluxDB "connection refused" during a Grafana restart firing several of these as false criticals.

## Test plan
- [x] `docker/mqtt-influx` — `npx jest` full suite passes (new test: drops both-zero `bms/2101` frame, keeps a single-zero frame)
- [x] `docker/automations` — `npx jest` full suite passes, 489/489 (new tests: rejects all-zero `cells` array, rejects all-zero `module_temps` array)
- [x] Grafana alert YAML validated with `yaml.safe_load`
- [ ] Verify no false Ioniq alerts recur after deploy