### PR TITLE
feat(modbus): add ORNO OR-WE-504 energy meter device driver

### DIFF
--- a/docker/modbus-serial/devices/or-we-504.js
+++ b/docker/modbus-serial/devices/or-we-504.js
@@ -17,15 +17,19 @@
 //   0x0F modbus address  - uint16
 //   0x10 password        - 2 registers, 4 BCD digits each (e.g. '11111111' -> [0x1111, 0x1111])
 //
+// NOTE: the energy word order is not pinned by the documentation - the only worked example
+// (0x0ED3 = 3795Wh) has a zero high word, and the register table labels registers 7/8 both
+// "UINT32 - Big Endian (ABCD)" and "Swapped long". Confirm against hardware before trusting
+// energy totals above 65535Wh. The BCD password encoding is likewise inferred from an
+// all-repdigit example ('11111111'); writing '12345678' on hardware would confirm it.
+//
 // The register documentation interleaves two different meters' register maps. Only the
-// examples consistent with the OR-WE-504 table (holding registers 0x00-0x10, address at
+// examples consistent with the OR-WE-504 table (holding registers 0x00-0x11, address at
 // 0x0F) are implemented here; the other set - which reads registers 0x00-0x02 as a single
 // energy counter and writes the address to 0x06 (power factor on this meter) - is ignored.
 //
 // Configuration registers are write protected. The meter is unlocked by function code 0x28
-// at register 0xFE01, which stays valid for ~10 seconds. `modbus-serial` cannot emit that
-// function code (only FC 1-6, 15-17, 20, 22, 23, 43 and custom codes 65-72/100-110), so
-// `setup` cannot unlock the meter itself - it must be unlocked out of band first.
+// at register 0xFE01, which stays valid for ~10 seconds - see `unlock`.
 
 /**
  * @typedef {1200|2400|4800|9600} BAUD_RATE
@@ -107,7 +111,7 @@ const readLong = (msb, lsb) => msb * 0x10000 + lsb
 /**
  * Encode an 8 digit password as the 2 BCD registers expected by the meter,
  * e.g. '12345678' -> [0x1234, 0x5678]
- * @param {string|number} password
+ * @param {string} password
  * @return {Array<number>}
  */
 const writePassword = (password) => {
@@ -163,6 +167,14 @@ async function read (
     // power factor
     result.pow = data[6] / 1000
     changed |= result.pow !== state.pow
+
+    // The meter is line powered, so it cannot answer while reporting no voltage and no grid
+    // frequency - such a frame is bus garbage (contention, another slave answering). Dropping
+    // the whole poll keeps a spurious zero out of the monotonic energy counters, where it
+    // would show up downstream as a full-counter drop and an equal phantom spike on recovery.
+    if (result.v === 0 && result.freq === 0) {
+      return
+    }
   }
 
   if (energy) {
@@ -211,23 +223,51 @@ async function read (
 }
 
 /**
+ * Unlock the write protection on the configuration registers, valid for ~10 seconds.
+ * Emitted as function code 0x28 at register 0xFE01, which `modbus-serial` has no response
+ * parser for - the request reaches the meter, but the reply is never matched to the
+ * transaction and it times out, so the timeout is expected and ignored here.
+ * @param {import('modbus-serial').ModbusRTU} client
+ * @param {string} [password] current meter password, factory default '00000000'
+ * @return {Promise<void>}
+ */
+async function unlock (client, password = '00000000') {
+  const [hi, lo] = writePassword(password)
+  try {
+    await client.customFunction(0x28, [
+      // register 0xFE01, 2 registers, 4 data bytes
+      0xFE, 0x01, 0x00, 0x02, 0x04,
+      hi >> 8, hi & 0xFF, lo >> 8, lo & 0xFF,
+    ])
+  } catch (e) {
+    if (e.errno !== 'ETIMEDOUT') throw e
+  }
+}
+
+/**
  * Setup communication parameters - changes are applied after device restart.
- * The meter must already be unlocked (see the note on function code 0x28 above), otherwise
- * every write below is rejected by the meter.
+ * The write protection is lifted first, which requires the meter's current password.
  * @param {import('modbus-serial').ModbusRTU} client
  * @param {{
  *   [address]: number,
  *   [baudRate]: BAUD_RATE,
  *   [password]: string,
+ *   [newPassword]: string,
  * }} newConfig
  * @return {Promise<void>}
  */
 async function setup (client, newConfig) {
+  if (newConfig.baudRate == null && newConfig.newPassword == null && newConfig.address == null) {
+    return
+  }
+
+  await unlock(client, newConfig.password)
+
   if (newConfig.baudRate != null) {
     await client.writeRegisters(0x0E, [writeBaudRate(newConfig.baudRate)])
   }
-  if (newConfig.password != null) {
-    await client.writeRegisters(0x10, writePassword(newConfig.password))
+  if (newConfig.newPassword != null) {
+    await client.writeRegisters(0x10, writePassword(newConfig.newPassword))
   }
   // changing the address must come last - subsequent writes would need the new id
   if (newConfig.address != null) {
@@ -235,10 +275,17 @@ async function setup (client, newConfig) {
       await client.writeRegisters(0x0F, [newConfig.address])
     } catch (e) {
       // the meter applies the new address immediately and answers from it, which the client
-      // rejects as coming from an unexpected unit - the write itself did succeed
-      if (!/Unexpected data error/.test(e.message)) throw e
+      // rejects as coming from an unexpected unit - the write itself did succeed. Match the
+      // new address specifically: the same message prefix is also used for an unexpected
+      // function code, which is a real failure (stale reply from another unit on the bus).
+      if (!new RegExp(`expected address \\d+ got ${newConfig.address}$`).test(e.message)) throw e
     }
     client.setID(newConfig.address)
+    // the meter is at the new address either way - confirm the write actually took effect
+    const { data } = await client.readHoldingRegisters(0x0F, 1)
+    if (data[0] !== newConfig.address) {
+      throw new Error(`Address change failed, meter reports address ${data[0]}`)
+    }
   }
 }
 

--- a/docker/modbus-serial/devices/or-we-504.js
+++ b/docker/modbus-serial/devices/or-we-504.js
@@ -15,9 +15,17 @@
 //   0x09 reactive energy - uint32 big endian (high word first), 1varh
 //   0x0E baud rate       - uint16, see BAUD_RATE maps
 //   0x0F modbus address  - uint16
+//   0x10 password        - 2 registers, 4 BCD digits each (e.g. '11111111' -> [0x1111, 0x1111])
 //
-// Writing configuration registers requires unlocking the meter with its password first
-// (see `setup`); the meter stays unlocked for about 10 seconds after a successful unlock.
+// The register documentation interleaves two different meters' register maps. Only the
+// examples consistent with the OR-WE-504 table (holding registers 0x00-0x10, address at
+// 0x0F) are implemented here; the other set - which reads registers 0x00-0x02 as a single
+// energy counter and writes the address to 0x06 (power factor on this meter) - is ignored.
+//
+// Configuration registers are write protected. The meter is unlocked by function code 0x28
+// at register 0xFE01, which stays valid for ~10 seconds. `modbus-serial` cannot emit that
+// function code (only FC 1-6, 15-17, 20, 22, 23, 43 and custom codes 65-72/100-110), so
+// `setup` cannot unlock the meter itself - it must be unlocked out of band first.
 
 /**
  * @typedef {1200|2400|4800|9600} BAUD_RATE
@@ -31,7 +39,7 @@
  *     [config]: boolean,
  *   },
  *   [options]: {
- *     [maxMsBetweenReports]: number,
+ *     [maxMsBetweenReports]: number, // 0 disables the periodic report of unchanged values
  *   }
  * }} CONFIG
  */
@@ -81,7 +89,13 @@ const readBaudRate = (val) => READ_BAUD_RATE_MAP[val]
  * @param {BAUD_RATE} val
  * @return {number}
  */
-const writeBaudRate = (val) => WRITE_BAUD_RATE_MAP[val]
+const writeBaudRate = (val) => {
+  const code = WRITE_BAUD_RATE_MAP[val]
+  if (code == null) {
+    throw new Error(`Unsupported baud rate ${val}, expected one of ${Object.keys(WRITE_BAUD_RATE_MAP)}`)
+  }
+  return code
+}
 
 /**
  * @param {number} msb
@@ -91,14 +105,17 @@ const writeBaudRate = (val) => WRITE_BAUD_RATE_MAP[val]
 const readLong = (msb, lsb) => msb * 0x10000 + lsb
 
 /**
- * Encode an 8 digit password as the 4 BCD registers expected by the meter,
- * e.g. '12345678' -> [0x0012, 0x0034, 0x0056, 0x0078]
+ * Encode an 8 digit password as the 2 BCD registers expected by the meter,
+ * e.g. '12345678' -> [0x1234, 0x5678]
  * @param {string|number} password
  * @return {Array<number>}
  */
 const writePassword = (password) => {
-  const digits = ('0'.repeat(8) + password).slice(-8)
-  return digits.match(/.{2}/g).map((pair) => parseInt(pair, 16))
+  const digits = String(password)
+  if (!/^\d{8}$/.test(digits)) {
+    throw new Error('Password must be exactly 8 digits')
+  }
+  return digits.match(/.{4}/g).map((part) => parseInt(part, 16))
 }
 
 /**
@@ -195,29 +212,32 @@ async function read (
 
 /**
  * Setup communication parameters - changes are applied after device restart.
- * The meter rejects writes unless it has been unlocked with its password, so pass the
- * current password to unlock before writing (defaults to the factory '00000000').
+ * The meter must already be unlocked (see the note on function code 0x28 above), otherwise
+ * every write below is rejected by the meter.
  * @param {import('modbus-serial').ModbusRTU} client
  * @param {{
- *   [password]: string,
  *   [address]: number,
  *   [baudRate]: BAUD_RATE,
- *   [newPassword]: string,
+ *   [password]: string,
  * }} newConfig
  * @return {Promise<void>}
  */
 async function setup (client, newConfig) {
-  await client.writeRegisters(0x80, writePassword(newConfig.password ?? '00000000'))
-
   if (newConfig.baudRate != null) {
     await client.writeRegisters(0x0E, [writeBaudRate(newConfig.baudRate)])
   }
-  if (newConfig.newPassword != null) {
-    await client.writeRegisters(0x40, writePassword(newConfig.newPassword))
+  if (newConfig.password != null) {
+    await client.writeRegisters(0x10, writePassword(newConfig.password))
   }
   // changing the address must come last - subsequent writes would need the new id
   if (newConfig.address != null) {
-    await client.writeRegisters(0x0F, [newConfig.address])
+    try {
+      await client.writeRegisters(0x0F, [newConfig.address])
+    } catch (e) {
+      // the meter applies the new address immediately and answers from it, which the client
+      // rejects as coming from an unexpected unit - the write itself did succeed
+      if (!/Unexpected data error/.test(e.message)) throw e
+    }
     client.setID(newConfig.address)
   }
 }

--- a/docker/modbus-serial/devices/or-we-504.js
+++ b/docker/modbus-serial/devices/or-we-504.js
@@ -38,7 +38,8 @@
 /**
  * @typedef {{
  *   [read]: {
- *     [instantaneous]: boolean,
+ *     [instantaneous]: boolean, // also gates the garbage frame guard - keep enabled
+
  *     [energy]: boolean,
  *     [config]: boolean,
  *   },
@@ -169,10 +170,13 @@ async function read (
     changed |= result.pow !== state.pow
 
     // The meter is line powered, so it cannot answer while reporting no voltage and no grid
-    // frequency - such a frame is bus garbage (contention, another slave answering). Dropping
+    // frequency. A frame that does is a meter-side glitch (corrupted frames are already
+    // rejected by the CRC check, and other slaves' replies by the unit id filter). Dropping
     // the whole poll keeps a spurious zero out of the monotonic energy counters, where it
     // would show up downstream as a full-counter drop and an equal phantom spike on recovery.
+    // Logged because otherwise a misfiring guard is indistinguishable from "value unchanged".
     if (result.v === 0 && result.freq === 0) {
+      console.warn('Ignoring or-we-504 frame reporting no voltage and no grid frequency')
       return
     }
   }
@@ -222,17 +226,25 @@ async function read (
   return result
 }
 
+// the unlock is only valid for ~10 seconds, and the request below always burns a full
+// client timeout waiting for a reply that never arrives - cap that so the window is not
+// spent before the first write lands
+const MAX_UNLOCK_TIMEOUT_MS = 500
+
 /**
  * Unlock the write protection on the configuration registers, valid for ~10 seconds.
- * Emitted as function code 0x28 at register 0xFE01, which `modbus-serial` has no response
- * parser for - the request reaches the meter, but the reply is never matched to the
- * transaction and it times out, so the timeout is expected and ignored here.
+ * Emitted as function code 0x28 at register 0xFE01. `RTUBufferedPort` has no expected reply
+ * length for that function code, so the reply is dropped at the port layer and never reaches
+ * the protocol layer - the request does go out, but the transaction always times out. The
+ * timeout is therefore the expected outcome and is ignored here.
  * @param {import('modbus-serial').ModbusRTU} client
  * @param {string} [password] current meter password, factory default '00000000'
  * @return {Promise<void>}
  */
 async function unlock (client, password = '00000000') {
   const [hi, lo] = writePassword(password)
+  const timeout = client.getTimeout()
+  client.setTimeout(Math.min(timeout, MAX_UNLOCK_TIMEOUT_MS))
   try {
     await client.customFunction(0x28, [
       // register 0xFE01, 2 registers, 4 data bytes
@@ -241,12 +253,15 @@ async function unlock (client, password = '00000000') {
     ])
   } catch (e) {
     if (e.errno !== 'ETIMEDOUT') throw e
+  } finally {
+    client.setTimeout(timeout)
   }
 }
 
 /**
- * Setup communication parameters - changes are applied after device restart.
- * The write protection is lifted first, which requires the meter's current password.
+ * Setup communication parameters. The write protection is lifted first, which requires the
+ * meter's current password. Writes are ordered so that they are safe whether the meter
+ * applies each change immediately or only on restart - see the note on `baudRate` below.
  * @param {import('modbus-serial').ModbusRTU} client
  * @param {{
  *   [address]: number,
@@ -261,31 +276,37 @@ async function setup (client, newConfig) {
     return
   }
 
+  // validate before unlocking, so a bad argument does not leave the meter unprotected
+  const baudRate = newConfig.baudRate != null ? writeBaudRate(newConfig.baudRate) : null
+  const newPassword = newConfig.newPassword != null ? writePassword(newConfig.newPassword) : null
+
   await unlock(client, newConfig.password)
 
-  if (newConfig.baudRate != null) {
-    await client.writeRegisters(0x0E, [writeBaudRate(newConfig.baudRate)])
+  if (newPassword != null) {
+    await client.writeRegisters(0x10, newPassword)
   }
-  if (newConfig.newPassword != null) {
-    await client.writeRegisters(0x10, writePassword(newConfig.newPassword))
-  }
-  // changing the address must come last - subsequent writes would need the new id
   if (newConfig.address != null) {
     try {
       await client.writeRegisters(0x0F, [newConfig.address])
     } catch (e) {
-      // the meter applies the new address immediately and answers from it, which the client
-      // rejects as coming from an unexpected unit - the write itself did succeed. Match the
-      // new address specifically: the same message prefix is also used for an unexpected
-      // function code, which is a real failure (stale reply from another unit on the bus).
-      if (!new RegExp(`expected address \\d+ got ${newConfig.address}$`).test(e.message)) throw e
+      // The meter answers the address write from its new unit id. RTUBufferedPort drops
+      // replies whose unit id is not the one addressed, so the transaction simply times out;
+      // over an unbuffered/TCP transport the protocol layer reports the mismatch instead.
+      // Either way the write itself may well have succeeded - the read back below decides.
+      const applied = e.errno === 'ETIMEDOUT' ||
+        new RegExp(`expected address \\d+ got ${newConfig.address}$`).test(e.message)
+      if (!applied) throw e
     }
     client.setID(newConfig.address)
-    // the meter is at the new address either way - confirm the write actually took effect
     const { data } = await client.readHoldingRegisters(0x0F, 1)
     if (data[0] !== newConfig.address) {
       throw new Error(`Address change failed, meter reports address ${data[0]}`)
     }
+  }
+  // the baud rate is written last: if it applies immediately, every write after it would go
+  // out at a rate the meter no longer listens on
+  if (baudRate != null) {
+    await client.writeRegisters(0x0E, [baudRate])
   }
 }
 

--- a/docker/modbus-serial/devices/or-we-504.js
+++ b/docker/modbus-serial/devices/or-we-504.js
@@ -286,6 +286,7 @@ async function setup (client, newConfig) {
     await client.writeRegisters(0x10, newPassword)
   }
   if (newConfig.address != null) {
+    const previousAddress = client.getID()
     try {
       await client.writeRegisters(0x0F, [newConfig.address])
     } catch (e) {
@@ -297,14 +298,29 @@ async function setup (client, newConfig) {
         new RegExp(`expected address \\d+ got ${newConfig.address}$`).test(e.message)
       if (!applied) throw e
     }
+    // The meter answers its own address write from the new address (the documented reply
+    // `02 10 00 0F 00 01 31 F9` carries a CRC only valid for a frame addressed 0x02), so it
+    // is reachable there straight away and the read back is meaningful.
     client.setID(newConfig.address)
-    const { data } = await client.readHoldingRegisters(0x0F, 1)
-    if (data[0] !== newConfig.address) {
-      throw new Error(`Address change failed, meter reports address ${data[0]}`)
+    let reported
+    try {
+      const { data } = await client.readHoldingRegisters(0x0F, 1)
+      reported = data[0]
+    } catch (e) {
+      // leave the client where the meter actually is, so the caller can retry
+      client.setID(previousAddress)
+      throw new Error(`Address change could not be verified, meter is unreachable at ${newConfig.address}`, { cause: e })
+    }
+    if (reported !== newConfig.address) {
+      client.setID(previousAddress)
+      throw new Error(`Address change failed, meter reports address ${reported}`)
     }
   }
-  // the baud rate is written last: if it applies immediately, every write after it would go
-  // out at a rate the meter no longer listens on
+  // The baud rate is written last and is deliberately not verified. Its acknowledgement is
+  // sent at the old rate, but whether the meter then switches immediately or only on restart
+  // is not documented - so a read back would fail spuriously under one of the two, and the
+  // caller has to reopen the port at the new rate either way. Writing it last is safe under
+  // both: nothing follows that could be stranded at the wrong rate.
   if (baudRate != null) {
     await client.writeRegisters(0x0E, [baudRate])
   }

--- a/docker/modbus-serial/devices/or-we-504.js
+++ b/docker/modbus-serial/devices/or-we-504.js
@@ -1,0 +1,228 @@
+// ORNO OR-WE-504 - 1-phase energy meter with RS-485, 100A, 1 module, DIN TH-35mm
+// Register map: https://files.orno.pl/support/Others/ORNO/ORWE504_5901752481282/OR-WE-504_rejestry.pdf
+//
+// Defaults: address=1 baudRate=9600 dataBits=8 parity=none stopBits=1
+//
+// Holding registers:
+//   0x00 voltage         - uint16, 0.1V
+//   0x01 current         - uint16, 0.1A
+//   0x02 frequency       - uint16, 0.1Hz
+//   0x03 active power    - uint16, 1W
+//   0x04 reactive power  - uint16, 1var
+//   0x05 apparent power  - uint16, 1VA
+//   0x06 power factor    - uint16, factor*1000
+//   0x07 active energy   - uint32 big endian (high word first), 1Wh
+//   0x09 reactive energy - uint32 big endian (high word first), 1varh
+//   0x0E baud rate       - uint16, see BAUD_RATE maps
+//   0x0F modbus address  - uint16
+//
+// Writing configuration registers requires unlocking the meter with its password first
+// (see `setup`); the meter stays unlocked for about 10 seconds after a successful unlock.
+
+/**
+ * @typedef {1200|2400|4800|9600} BAUD_RATE
+ */
+
+/**
+ * @typedef {{
+ *   [read]: {
+ *     [instantaneous]: boolean,
+ *     [energy]: boolean,
+ *     [config]: boolean,
+ *   },
+ *   [options]: {
+ *     [maxMsBetweenReports]: number,
+ *   }
+ * }} CONFIG
+ */
+
+/**
+ * @typedef {{
+ *   [lastReport]: number,
+ *   [v]: number,
+ *   [c]: number,
+ *   [freq]: number,
+ *   [p]: number,
+ *   [rp]: number,
+ *   [ap]: number,
+ *   [pow]: number,
+ *   [tot_act]: number,
+ *   [tot_react]: number,
+ *   [baud_rate]: BAUD_RATE,
+ *   [id]: number,
+ * }} STATE
+ */
+
+/**
+ * @type {Object<string, BAUD_RATE>}
+ */
+const READ_BAUD_RATE_MAP = {
+  1: 1200,
+  2: 2400,
+  3: 4800,
+  4: 9600,
+}
+/**
+ * @type {Object<BAUD_RATE, number>}
+ */
+const WRITE_BAUD_RATE_MAP = {
+  1200: 1,
+  2400: 2,
+  4800: 3,
+  9600: 4,
+}
+
+/**
+ * @param {number} val
+ * @return {BAUD_RATE}
+ */
+const readBaudRate = (val) => READ_BAUD_RATE_MAP[val]
+/**
+ * @param {BAUD_RATE} val
+ * @return {number}
+ */
+const writeBaudRate = (val) => WRITE_BAUD_RATE_MAP[val]
+
+/**
+ * @param {number} msb
+ * @param {number} lsb
+ * @return {number}
+ */
+const readLong = (msb, lsb) => msb * 0x10000 + lsb
+
+/**
+ * Encode an 8 digit password as the 4 BCD registers expected by the meter,
+ * e.g. '12345678' -> [0x0012, 0x0034, 0x0056, 0x0078]
+ * @param {string|number} password
+ * @return {Array<number>}
+ */
+const writePassword = (password) => {
+  const digits = ('0'.repeat(8) + password).slice(-8)
+  return digits.match(/.{2}/g).map((pair) => parseInt(pair, 16))
+}
+
+/**
+ * @param {import('modbus-serial').ModbusRTU} client
+ * @param {CONFIG} [config]
+ * @param {STATE} [state]
+ * @return {Promise<STATE|undefined>}
+ */
+async function read (
+  client, {
+    read: {
+      instantaneous = true,
+      energy = true,
+      config = false,
+    } = {},
+    options: {
+      maxMsBetweenReports = 1000,
+    } = {}
+  } = {},
+  state = {}
+) {
+  const result = {}
+  let changed = false
+
+  if (instantaneous) {
+    const { data } = await client.readHoldingRegisters(0x00, 7)
+    // voltage in V
+    result.v = data[0] / 10
+    changed |= result.v !== state.v
+    // current in A
+    result.c = data[1] / 10
+    changed |= result.c !== state.c
+    // frequency in Hz
+    result.freq = data[2] / 10
+    changed |= result.freq !== state.freq
+    // active power in W
+    result.p = data[3]
+    changed |= result.p !== state.p
+    // reactive power in VAr
+    result.rp = data[4]
+    changed |= result.rp !== state.rp
+    // apparent power in VA
+    result.ap = data[5]
+    changed |= result.ap !== state.ap
+    // power factor
+    result.pow = data[6] / 1000
+    changed |= result.pow !== state.pow
+  }
+
+  if (energy) {
+    const { data } = await client.readHoldingRegisters(0x07, 4)
+    // total active energy in kWh (device reports Wh)
+    result.tot_act = readLong(data[0], data[1]) / 1000
+    changed |= result.tot_act !== state.tot_act
+    // total reactive energy in kVArh (device reports VArh)
+    result.tot_react = readLong(data[2], data[3]) / 1000
+    changed |= result.tot_react !== state.tot_react
+  }
+
+  if (config) {
+    const { data } = await client.readHoldingRegisters(0x0E, 2)
+    result.baud_rate = readBaudRate(data[0])
+    changed |= result.baud_rate !== state.baud_rate
+    result.id = data[1]
+    changed |= result.id !== state.id
+  }
+
+  const recentReport = maxMsBetweenReports === 0 || ((Date.now() - (state.lastReport || 0)) < maxMsBetweenReports)
+  if (state.lastReport > 0 && !changed && recentReport) {
+    return
+  }
+
+  state.lastReport = Date.now()
+  if (instantaneous) {
+    state.v = result.v
+    state.c = result.c
+    state.freq = result.freq
+    state.p = result.p
+    state.rp = result.rp
+    state.ap = result.ap
+    state.pow = result.pow
+  }
+  if (energy) {
+    state.tot_act = result.tot_act
+    state.tot_react = result.tot_react
+  }
+  if (config) {
+    state.baud_rate = result.baud_rate
+    state.id = result.id
+  }
+
+  return result
+}
+
+/**
+ * Setup communication parameters - changes are applied after device restart.
+ * The meter rejects writes unless it has been unlocked with its password, so pass the
+ * current password to unlock before writing (defaults to the factory '00000000').
+ * @param {import('modbus-serial').ModbusRTU} client
+ * @param {{
+ *   [password]: string,
+ *   [address]: number,
+ *   [baudRate]: BAUD_RATE,
+ *   [newPassword]: string,
+ * }} newConfig
+ * @return {Promise<void>}
+ */
+async function setup (client, newConfig) {
+  await client.writeRegisters(0x80, writePassword(newConfig.password ?? '00000000'))
+
+  if (newConfig.baudRate != null) {
+    await client.writeRegisters(0x0E, [writeBaudRate(newConfig.baudRate)])
+  }
+  if (newConfig.newPassword != null) {
+    await client.writeRegisters(0x40, writePassword(newConfig.newPassword))
+  }
+  // changing the address must come last - subsequent writes would need the new id
+  if (newConfig.address != null) {
+    await client.writeRegisters(0x0F, [newConfig.address])
+    client.setID(newConfig.address)
+  }
+}
+
+module.exports = {
+  read,
+  setup,
+}

--- a/docker/modbus-serial/devices/or-we-504.test.js
+++ b/docker/modbus-serial/devices/or-we-504.test.js
@@ -216,10 +216,13 @@ describe('read', () => {
       .mockResolvedValueOnce({data: [0, 0, 0, 0, 0, 0, 0]})
     const client = {readHoldingRegisters: mockReadHoldingRegisters}
     const state = {}
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
 
     expect(await read(client, undefined, state)).toEqual(expect.objectContaining({tot_act: 3.795}))
     // the garbage frame must not be published, and must not clobber the last good values
     expect(await read(client, undefined, state)).toBeUndefined()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
     expect(state).toEqual(expect.objectContaining({v: 225.9, tot_act: 3.795}))
     // the energy registers are not even read once the frame is known to be garbage
     expect(mockReadHoldingRegisters).toHaveBeenCalledTimes(3)
@@ -257,11 +260,13 @@ describe('setup', () => {
   const timeout = () => Object.assign(new Error('Timed out'), {errno: 'ETIMEDOUT'})
 
   const mockClient = (overrides = {}) => ({
-    // modbus-serial has no response parser for FC 0x28, so the unlock always times out
+    // RTUBufferedPort drops the FC 0x28 reply, so the unlock always times out
     customFunction: jest.fn().mockRejectedValue(timeout()),
     writeRegisters: jest.fn().mockResolvedValue({}),
     readHoldingRegisters: jest.fn().mockResolvedValue({data: [2]}),
     setID: jest.fn(),
+    getTimeout: jest.fn().mockReturnValue(1000),
+    setTimeout: jest.fn(),
     ...overrides,
   })
 
@@ -312,11 +317,31 @@ describe('setup', () => {
     expect(client.writeRegisters).toHaveBeenCalledWith(0x0E, [3])
   })
 
-  it('should reject an unsupported baud rate instead of writing garbage', async () => {
+  it('should reject an unsupported baud rate before unlocking the meter', async () => {
     const client = mockClient()
 
     await expect(setup(client, {baudRate: 19200})).rejects.toThrow('Unsupported baud rate 19200')
+    expect(client.customFunction).not.toHaveBeenCalled()
     expect(client.writeRegisters).not.toHaveBeenCalled()
+  })
+
+  it('should cap the client timeout while unlocking and restore it after', async () => {
+    const client = mockClient({getTimeout: jest.fn().mockReturnValue(10000)})
+
+    await setup(client, {baudRate: 4800})
+
+    expect(client.setTimeout).toHaveBeenNthCalledWith(1, 500)
+    expect(client.setTimeout).toHaveBeenNthCalledWith(2, 10000)
+  })
+
+  it('should write the baud rate after the address', async () => {
+    const client = mockClient()
+
+    await setup(client, {address: 2, baudRate: 4800})
+
+    const addressWrite = client.writeRegisters.mock.calls.findIndex(([reg]) => reg === 0x0F)
+    const baudWrite = client.writeRegisters.mock.calls.findIndex(([reg]) => reg === 0x0E)
+    expect(addressWrite).toBeLessThan(baudWrite)
   })
 
   it('should write a new password as 4 BCD digits per register', async () => {
@@ -328,28 +353,41 @@ describe('setup', () => {
     expect(client.writeRegisters).toHaveBeenCalledWith(0x10, [0x1111, 0x1111])
   })
 
-  it('should reject a password that is not exactly 8 digits', async () => {
+  it('should reject a password that is not exactly 8 digits before unlocking', async () => {
     const client = mockClient()
 
     await expect(setup(client, {newPassword: '1234'}))
       .rejects.toThrow('Password must be exactly 8 digits')
+    expect(client.customFunction).not.toHaveBeenCalled()
     expect(client.writeRegisters).not.toHaveBeenCalled()
   })
 
-  it('should write the address last and switch the client to it', async () => {
+  it('should write password, then address, then baud rate', async () => {
     const client = mockClient()
 
     await setup(client, {address: 2, baudRate: 9600, newPassword: '11111111'})
 
-    expect(client.writeRegisters).toHaveBeenNthCalledWith(1, 0x0E, [4])
-    expect(client.writeRegisters).toHaveBeenNthCalledWith(2, 0x10, [0x1111, 0x1111])
-    expect(client.writeRegisters).toHaveBeenNthCalledWith(3, 0x0F, [2])
+    expect(client.writeRegisters).toHaveBeenNthCalledWith(1, 0x10, [0x1111, 0x1111])
+    expect(client.writeRegisters).toHaveBeenNthCalledWith(2, 0x0F, [2])
+    expect(client.writeRegisters).toHaveBeenNthCalledWith(3, 0x0E, [4])
     expect(client.setID).toHaveBeenCalledWith(2)
   })
 
-  it('should switch the client to the new address when the meter answers from it', async () => {
-    // the meter applies the address immediately, so the reply comes from the new unit id
-    // and modbus-serial rejects it - the write itself did succeed
+  it('should switch the client to the new address when the address write times out', async () => {
+    // the meter answers from its new unit id, which RTUBufferedPort drops - this timeout is
+    // what the address write actually rejects with over the transport this repo uses
+    const client = mockClient({
+      writeRegisters: jest.fn().mockRejectedValueOnce(timeout()),
+    })
+
+    await setup(client, {address: 2})
+
+    expect(client.setID).toHaveBeenCalledWith(2)
+    expect(client.readHoldingRegisters).toHaveBeenCalledWith(0x0F, 1)
+  })
+
+  it('should switch the client to the new address on an unbuffered address mismatch', async () => {
+    // an unbuffered or TCP transport reports the mismatch instead of timing out
     const client = mockClient({
       writeRegisters: jest.fn()
         .mockRejectedValueOnce(new Error('Unexpected data error, expected address 1 got 2')),
@@ -358,7 +396,6 @@ describe('setup', () => {
     await setup(client, {address: 2})
 
     expect(client.setID).toHaveBeenCalledWith(2)
-    expect(client.readHoldingRegisters).toHaveBeenCalledWith(0x0F, 1)
   })
 
   it('should not swallow an unexpected function code as an address change', async () => {

--- a/docker/modbus-serial/devices/or-we-504.test.js
+++ b/docker/modbus-serial/devices/or-we-504.test.js
@@ -1,22 +1,24 @@
 const {describe, expect, it, jest} = require('@jest/globals')
 const {read, setup} = require('./or-we-504')
 
+// Fixtures marked [datasheet] are taken from the worked examples in the OR-WE-504 register
+// documentation. The rest are constructed to exercise scaling and are not device captures.
 describe('read', () => {
   it('should read instantaneous parameters', async () => {
     const mockReadHoldingRegisters = jest.fn().mockResolvedValueOnce({
       data: [
-        // voltage - 225.9V - uint16 in V*10
+        // [datasheet] voltage - 225.9V - uint16 in V*10
         0x08D3,
-        // current - 1.9A - uint16 in A*10
+        // [datasheet] current - 1.9A - uint16 in A*10
         0x0013,
         // frequency - 50.1Hz - uint16 in Hz*10
         0x01F5,
-        // active power - 1234W - uint16 in W
-        0x04D2,
-        // reactive power - 345VAr - uint16 in VAr
-        0x0159,
-        // apparent power - 1300VA - uint16 in VA
-        0x0514,
+        // active power - 407W - uint16 in W (225.9V * 1.9A * 0.949)
+        0x0197,
+        // reactive power - 135VAr - uint16 in VAr
+        0x0087,
+        // apparent power - 429VA - uint16 in VA (225.9V * 1.9A)
+        0x01AD,
         // power factor - 0.949 - uint16 in factor*1000
         0x03B5,
       ]
@@ -28,9 +30,9 @@ describe('read', () => {
       v: 225.9,
       c: 1.9,
       freq: 50.1,
-      p: 1234,
-      rp: 345,
-      ap: 1300,
+      p: 407,
+      rp: 135,
+      ap: 429,
       pow: 0.949,
     })
     expect(mockReadHoldingRegisters).toHaveBeenCalledTimes(1)
@@ -40,9 +42,12 @@ describe('read', () => {
   it('should read energy parameters', async () => {
     const mockReadHoldingRegisters = jest.fn().mockResolvedValueOnce({
       data: [
-        // active energy - 3795Wh - uint32 in Wh, high word first
+        // [datasheet] active energy - 3795Wh - uint32 in Wh, high word first
         0x0000, 0x0ED3,
-        // reactive energy - 70011Wh - uint32 in VArh, high word first
+        // reactive energy - 70011VArh - uint32 in VArh, high word first
+        // NOTE: word order is not pinned by any datasheet example (the only one has a zero
+        // high word) and the register table labels these both "Big Endian (ABCD)" and
+        // "Swapped long" - confirm against hardware before trusting the energy totals
         0x0001, 0x117B,
       ]
     })
@@ -97,7 +102,7 @@ describe('read', () => {
 
   it('should read instantaneous and energy by default', async () => {
     const mockReadHoldingRegisters = jest.fn()
-      .mockResolvedValueOnce({data: [0x08D3, 0x0013, 0x01F5, 0x04D2, 0x0159, 0x0514, 0x03B5]})
+      .mockResolvedValueOnce({data: [0x08D3, 0x0013, 0x01F5, 0x0197, 0x0087, 0x01AD, 0x03B5]})
       .mockResolvedValueOnce({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
 
     const result = await read({readHoldingRegisters: mockReadHoldingRegisters})
@@ -106,9 +111,9 @@ describe('read', () => {
       v: 225.9,
       c: 1.9,
       freq: 50.1,
-      p: 1234,
-      rp: 345,
-      ap: 1300,
+      p: 407,
+      rp: 135,
+      ap: 429,
       pow: 0.949,
       tot_act: 3.795,
       tot_react: 0,
@@ -130,6 +135,81 @@ describe('read', () => {
     expect(await read(client, config, state)).toBeUndefined()
   })
 
+  it('should skip reporting unchanged instantaneous values', async () => {
+    const mockReadHoldingRegisters = jest.fn()
+      .mockResolvedValue({data: [0x08D3, 0x0013, 0x01F5, 0x0197, 0x0087, 0x01AD, 0x03B5]})
+    const client = {readHoldingRegisters: mockReadHoldingRegisters}
+    const config = {
+      read: {instantaneous: true, energy: false, config: false},
+      options: {maxMsBetweenReports: 60000},
+    }
+    const state = {}
+
+    expect(await read(client, config, state)).toBeDefined()
+    expect(await read(client, config, state)).toBeUndefined()
+  })
+
+  it('should skip reporting unchanged config values', async () => {
+    const mockReadHoldingRegisters = jest.fn().mockResolvedValue({data: [0x0004, 0x0002]})
+    const client = {readHoldingRegisters: mockReadHoldingRegisters}
+    const config = {
+      read: {instantaneous: false, energy: false, config: true},
+      options: {maxMsBetweenReports: 60000},
+    }
+    const state = {}
+
+    expect(await read(client, config, state)).toEqual({baud_rate: 9600, id: 2})
+    expect(await read(client, config, state)).toBeUndefined()
+  })
+
+  it('should report unchanged values again once the report interval elapses', async () => {
+    jest.useFakeTimers()
+    try {
+      const mockReadHoldingRegisters = jest.fn().mockResolvedValue({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
+      const client = {readHoldingRegisters: mockReadHoldingRegisters}
+      const config = {
+        read: {instantaneous: false, energy: true, config: false},
+        options: {maxMsBetweenReports: 60000},
+      }
+      const state = {}
+
+      expect(await read(client, config, state)).toBeDefined()
+      expect(await read(client, config, state)).toBeUndefined()
+
+      jest.advanceTimersByTime(60001)
+
+      expect(await read(client, config, state)).toEqual({tot_act: 3.795, tot_react: 0})
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  // maxMsBetweenReports 0 disables the periodic forced report, matching or-we-514/or-we-526
+  it('should never re-report unchanged values when maxMsBetweenReports is 0', async () => {
+    const mockReadHoldingRegisters = jest.fn().mockResolvedValue({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
+    const client = {readHoldingRegisters: mockReadHoldingRegisters}
+    const config = {
+      read: {instantaneous: false, energy: true, config: false},
+      options: {maxMsBetweenReports: 0},
+    }
+    const state = {}
+
+    expect(await read(client, config, state)).toEqual({tot_act: 3.795, tot_react: 0})
+    expect(await read(client, config, state)).toBeUndefined()
+  })
+
+  it('should propagate read errors and leave state untouched', async () => {
+    const error = new Error('Timed out')
+    const mockReadHoldingRegisters = jest.fn()
+      .mockResolvedValueOnce({data: [0x08D3, 0x0013, 0x01F5, 0x0197, 0x0087, 0x01AD, 0x03B5]})
+      .mockRejectedValueOnce(error)
+    const state = {}
+
+    await expect(read({readHoldingRegisters: mockReadHoldingRegisters}, undefined, state))
+      .rejects.toThrow(error)
+    expect(state).toEqual({})
+  })
+
   it('should report changed values within the report interval', async () => {
     const mockReadHoldingRegisters = jest.fn()
       .mockResolvedValueOnce({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
@@ -147,21 +227,12 @@ describe('read', () => {
 })
 
 describe('setup', () => {
-  it('should unlock with the factory password when none given', async () => {
+  it('should not touch the meter when given nothing to change', async () => {
     const mockWriteRegisters = jest.fn().mockResolvedValue({})
 
     await setup({writeRegisters: mockWriteRegisters}, {})
 
-    expect(mockWriteRegisters).toHaveBeenCalledTimes(1)
-    expect(mockWriteRegisters).toHaveBeenCalledWith(0x80, [0x0000, 0x0000, 0x0000, 0x0000])
-  })
-
-  it('should unlock with the given password', async () => {
-    const mockWriteRegisters = jest.fn().mockResolvedValue({})
-
-    await setup({writeRegisters: mockWriteRegisters}, {password: '12345678'})
-
-    expect(mockWriteRegisters).toHaveBeenCalledWith(0x80, [0x0012, 0x0034, 0x0056, 0x0078])
+    expect(mockWriteRegisters).not.toHaveBeenCalled()
   })
 
   it('should write baud rate', async () => {
@@ -172,23 +243,62 @@ describe('setup', () => {
     expect(mockWriteRegisters).toHaveBeenCalledWith(0x0E, [3])
   })
 
-  it('should write a new password', async () => {
+  it('should reject an unsupported baud rate instead of writing garbage', async () => {
     const mockWriteRegisters = jest.fn().mockResolvedValue({})
 
-    await setup({writeRegisters: mockWriteRegisters}, {newPassword: '12345678'})
+    await expect(setup({writeRegisters: mockWriteRegisters}, {baudRate: 19200}))
+      .rejects.toThrow('Unsupported baud rate 19200')
+    expect(mockWriteRegisters).not.toHaveBeenCalled()
+  })
 
-    expect(mockWriteRegisters).toHaveBeenCalledWith(0x40, [0x0012, 0x0034, 0x0056, 0x0078])
+  it('should write the password as 4 BCD digits per register', async () => {
+    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+
+    // datasheet: 02 10 00 10 00 02 04 11 11 11 11 -> password 11111111
+    await setup({writeRegisters: mockWriteRegisters}, {password: '11111111'})
+
+    expect(mockWriteRegisters).toHaveBeenCalledWith(0x10, [0x1111, 0x1111])
+  })
+
+  it('should reject a password that is not exactly 8 digits', async () => {
+    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+
+    await expect(setup({writeRegisters: mockWriteRegisters}, {password: '1234'}))
+      .rejects.toThrow('Password must be exactly 8 digits')
+    expect(mockWriteRegisters).not.toHaveBeenCalled()
   })
 
   it('should write the address last and switch the client to it', async () => {
     const mockWriteRegisters = jest.fn().mockResolvedValue({})
     const mockSetID = jest.fn()
 
-    await setup({writeRegisters: mockWriteRegisters, setID: mockSetID}, {address: 2, baudRate: 9600})
+    await setup({writeRegisters: mockWriteRegisters, setID: mockSetID},
+      {address: 2, baudRate: 9600, password: '11111111'})
 
-    expect(mockWriteRegisters).toHaveBeenNthCalledWith(1, 0x80, [0, 0, 0, 0])
-    expect(mockWriteRegisters).toHaveBeenNthCalledWith(2, 0x0E, [4])
+    expect(mockWriteRegisters).toHaveBeenNthCalledWith(1, 0x0E, [4])
+    expect(mockWriteRegisters).toHaveBeenNthCalledWith(2, 0x10, [0x1111, 0x1111])
     expect(mockWriteRegisters).toHaveBeenNthCalledWith(3, 0x0F, [2])
     expect(mockSetID).toHaveBeenCalledWith(2)
+  })
+
+  it('should switch the client to the new address when the meter answers from it', async () => {
+    // the meter applies the address immediately, so the reply comes from the new unit id
+    // and modbus-serial rejects it - the write itself did succeed
+    const mockWriteRegisters = jest.fn()
+      .mockRejectedValueOnce(new Error('Unexpected data error, expected address 1 got 2'))
+    const mockSetID = jest.fn()
+
+    await setup({writeRegisters: mockWriteRegisters, setID: mockSetID}, {address: 2})
+
+    expect(mockSetID).toHaveBeenCalledWith(2)
+  })
+
+  it('should propagate other address write failures', async () => {
+    const mockWriteRegisters = jest.fn().mockRejectedValueOnce(new Error('Timed out'))
+    const mockSetID = jest.fn()
+
+    await expect(setup({writeRegisters: mockWriteRegisters, setID: mockSetID}, {address: 2}))
+      .rejects.toThrow('Timed out')
+    expect(mockSetID).not.toHaveBeenCalled()
   })
 })

--- a/docker/modbus-serial/devices/or-we-504.test.js
+++ b/docker/modbus-serial/devices/or-we-504.test.js
@@ -267,6 +267,7 @@ describe('setup', () => {
     setID: jest.fn(),
     getTimeout: jest.fn().mockReturnValue(1000),
     setTimeout: jest.fn(),
+    getID: jest.fn().mockReturnValue(1),
     ...overrides,
   })
 
@@ -410,13 +411,24 @@ describe('setup', () => {
     expect(client.setID).not.toHaveBeenCalled()
   })
 
-  it('should fail when the meter did not take the new address', async () => {
+  it('should fail and restore the client id when the meter did not take the new address', async () => {
     const client = mockClient({
       readHoldingRegisters: jest.fn().mockResolvedValue({data: [1]}),
     })
 
     await expect(setup(client, {address: 2}))
       .rejects.toThrow('Address change failed, meter reports address 1')
+    expect(client.setID).toHaveBeenLastCalledWith(1)
+  })
+
+  it('should restore the client id when the meter is unreachable at the new address', async () => {
+    const client = mockClient({
+      readHoldingRegisters: jest.fn().mockRejectedValue(timeout()),
+    })
+
+    await expect(setup(client, {address: 2}))
+      .rejects.toThrow('Address change could not be verified, meter is unreachable at 2')
+    expect(client.setID).toHaveBeenLastCalledWith(1)
   })
 
   it('should propagate other address write failures', async () => {

--- a/docker/modbus-serial/devices/or-we-504.test.js
+++ b/docker/modbus-serial/devices/or-we-504.test.js
@@ -1,0 +1,194 @@
+const {describe, expect, it, jest} = require('@jest/globals')
+const {read, setup} = require('./or-we-504')
+
+describe('read', () => {
+  it('should read instantaneous parameters', async () => {
+    const mockReadHoldingRegisters = jest.fn().mockResolvedValueOnce({
+      data: [
+        // voltage - 225.9V - uint16 in V*10
+        0x08D3,
+        // current - 1.9A - uint16 in A*10
+        0x0013,
+        // frequency - 50.1Hz - uint16 in Hz*10
+        0x01F5,
+        // active power - 1234W - uint16 in W
+        0x04D2,
+        // reactive power - 345VAr - uint16 in VAr
+        0x0159,
+        // apparent power - 1300VA - uint16 in VA
+        0x0514,
+        // power factor - 0.949 - uint16 in factor*1000
+        0x03B5,
+      ]
+    })
+
+    expect(await read({readHoldingRegisters: mockReadHoldingRegisters},
+      {read: {instantaneous: true, energy: false, config: false}}
+    )).toEqual({
+      v: 225.9,
+      c: 1.9,
+      freq: 50.1,
+      p: 1234,
+      rp: 345,
+      ap: 1300,
+      pow: 0.949,
+    })
+    expect(mockReadHoldingRegisters).toHaveBeenCalledTimes(1)
+    expect(mockReadHoldingRegisters).toHaveBeenCalledWith(0x00, 7)
+  })
+
+  it('should read energy parameters', async () => {
+    const mockReadHoldingRegisters = jest.fn().mockResolvedValueOnce({
+      data: [
+        // active energy - 3795Wh - uint32 in Wh, high word first
+        0x0000, 0x0ED3,
+        // reactive energy - 70011Wh - uint32 in VArh, high word first
+        0x0001, 0x117B,
+      ]
+    })
+
+    expect(await read({readHoldingRegisters: mockReadHoldingRegisters},
+      {read: {instantaneous: false, energy: true, config: false}}
+    )).toEqual({
+      tot_act: 3.795,
+      tot_react: 70.011,
+    })
+    expect(mockReadHoldingRegisters).toHaveBeenCalledTimes(1)
+    expect(mockReadHoldingRegisters).toHaveBeenCalledWith(0x07, 4)
+  })
+
+  it('should read energy counters beyond 16 bits', async () => {
+    const mockReadHoldingRegisters = jest.fn().mockResolvedValueOnce({
+      data: [
+        // active energy - 123456789Wh
+        0x075B, 0xCD15,
+        // reactive energy - 0Wh
+        0x0000, 0x0000,
+      ]
+    })
+
+    expect(await read({readHoldingRegisters: mockReadHoldingRegisters},
+      {read: {instantaneous: false, energy: true, config: false}}
+    )).toEqual({
+      tot_act: 123456.789,
+      tot_react: 0,
+    })
+  })
+
+  it('should read configuration parameters', async () => {
+    const mockReadHoldingRegisters = jest.fn().mockResolvedValueOnce({
+      data: [
+        // baud rate - 9600
+        0x0004,
+        // modbus address
+        0x0002,
+      ]
+    })
+
+    expect(await read({readHoldingRegisters: mockReadHoldingRegisters},
+      {read: {instantaneous: false, energy: false, config: true}}
+    )).toEqual({
+      baud_rate: 9600,
+      id: 2,
+    })
+    expect(mockReadHoldingRegisters).toHaveBeenCalledTimes(1)
+    expect(mockReadHoldingRegisters).toHaveBeenCalledWith(0x0E, 2)
+  })
+
+  it('should read instantaneous and energy by default', async () => {
+    const mockReadHoldingRegisters = jest.fn()
+      .mockResolvedValueOnce({data: [0x08D3, 0x0013, 0x01F5, 0x04D2, 0x0159, 0x0514, 0x03B5]})
+      .mockResolvedValueOnce({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
+
+    const result = await read({readHoldingRegisters: mockReadHoldingRegisters})
+
+    expect(result).toEqual({
+      v: 225.9,
+      c: 1.9,
+      freq: 50.1,
+      p: 1234,
+      rp: 345,
+      ap: 1300,
+      pow: 0.949,
+      tot_act: 3.795,
+      tot_react: 0,
+    })
+    expect(mockReadHoldingRegisters).toHaveBeenCalledTimes(2)
+  })
+
+  it('should skip reporting unchanged values within the report interval', async () => {
+    const data = {data: [0x0000, 0x0ED3, 0x0000, 0x0000]}
+    const mockReadHoldingRegisters = jest.fn().mockResolvedValue(data)
+    const client = {readHoldingRegisters: mockReadHoldingRegisters}
+    const config = {
+      read: {instantaneous: false, energy: true, config: false},
+      options: {maxMsBetweenReports: 60000},
+    }
+    const state = {}
+
+    expect(await read(client, config, state)).toEqual({tot_act: 3.795, tot_react: 0})
+    expect(await read(client, config, state)).toBeUndefined()
+  })
+
+  it('should report changed values within the report interval', async () => {
+    const mockReadHoldingRegisters = jest.fn()
+      .mockResolvedValueOnce({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
+      .mockResolvedValueOnce({data: [0x0000, 0x0ED4, 0x0000, 0x0000]})
+    const client = {readHoldingRegisters: mockReadHoldingRegisters}
+    const config = {
+      read: {instantaneous: false, energy: true, config: false},
+      options: {maxMsBetweenReports: 60000},
+    }
+    const state = {}
+
+    expect(await read(client, config, state)).toEqual({tot_act: 3.795, tot_react: 0})
+    expect(await read(client, config, state)).toEqual({tot_act: 3.796, tot_react: 0})
+  })
+})
+
+describe('setup', () => {
+  it('should unlock with the factory password when none given', async () => {
+    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+
+    await setup({writeRegisters: mockWriteRegisters}, {})
+
+    expect(mockWriteRegisters).toHaveBeenCalledTimes(1)
+    expect(mockWriteRegisters).toHaveBeenCalledWith(0x80, [0x0000, 0x0000, 0x0000, 0x0000])
+  })
+
+  it('should unlock with the given password', async () => {
+    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+
+    await setup({writeRegisters: mockWriteRegisters}, {password: '12345678'})
+
+    expect(mockWriteRegisters).toHaveBeenCalledWith(0x80, [0x0012, 0x0034, 0x0056, 0x0078])
+  })
+
+  it('should write baud rate', async () => {
+    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+
+    await setup({writeRegisters: mockWriteRegisters}, {baudRate: 4800})
+
+    expect(mockWriteRegisters).toHaveBeenCalledWith(0x0E, [3])
+  })
+
+  it('should write a new password', async () => {
+    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+
+    await setup({writeRegisters: mockWriteRegisters}, {newPassword: '12345678'})
+
+    expect(mockWriteRegisters).toHaveBeenCalledWith(0x40, [0x0012, 0x0034, 0x0056, 0x0078])
+  })
+
+  it('should write the address last and switch the client to it', async () => {
+    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+    const mockSetID = jest.fn()
+
+    await setup({writeRegisters: mockWriteRegisters, setID: mockSetID}, {address: 2, baudRate: 9600})
+
+    expect(mockWriteRegisters).toHaveBeenNthCalledWith(1, 0x80, [0, 0, 0, 0])
+    expect(mockWriteRegisters).toHaveBeenNthCalledWith(2, 0x0E, [4])
+    expect(mockWriteRegisters).toHaveBeenNthCalledWith(3, 0x0F, [2])
+    expect(mockSetID).toHaveBeenCalledWith(2)
+  })
+})

--- a/docker/modbus-serial/devices/or-we-504.test.js
+++ b/docker/modbus-serial/devices/or-we-504.test.js
@@ -145,7 +145,9 @@ describe('read', () => {
     }
     const state = {}
 
-    expect(await read(client, config, state)).toBeDefined()
+    expect(await read(client, config, state)).toEqual({
+      v: 225.9, c: 1.9, freq: 50.1, p: 407, rp: 135, ap: 429, pow: 0.949,
+    })
     expect(await read(client, config, state)).toBeUndefined()
   })
 
@@ -186,16 +188,41 @@ describe('read', () => {
 
   // maxMsBetweenReports 0 disables the periodic forced report, matching or-we-514/or-we-526
   it('should never re-report unchanged values when maxMsBetweenReports is 0', async () => {
-    const mockReadHoldingRegisters = jest.fn().mockResolvedValue({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
-    const client = {readHoldingRegisters: mockReadHoldingRegisters}
-    const config = {
-      read: {instantaneous: false, energy: true, config: false},
-      options: {maxMsBetweenReports: 0},
+    jest.useFakeTimers()
+    try {
+      const mockReadHoldingRegisters = jest.fn().mockResolvedValue({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
+      const client = {readHoldingRegisters: mockReadHoldingRegisters}
+      const config = {
+        read: {instantaneous: false, energy: true, config: false},
+        options: {maxMsBetweenReports: 0},
+      }
+      const state = {}
+
+      expect(await read(client, config, state)).toEqual({tot_act: 3.795, tot_react: 0})
+      expect(await read(client, config, state)).toBeUndefined()
+
+      jest.advanceTimersByTime(3600000)
+
+      expect(await read(client, config, state)).toBeUndefined()
+    } finally {
+      jest.useRealTimers()
     }
+  })
+
+  it('should drop garbage frames reporting no voltage and no grid frequency', async () => {
+    const mockReadHoldingRegisters = jest.fn()
+      .mockResolvedValueOnce({data: [0x08D3, 0x0013, 0x01F5, 0x0197, 0x0087, 0x01AD, 0x03B5]})
+      .mockResolvedValueOnce({data: [0x0000, 0x0ED3, 0x0000, 0x0000]})
+      .mockResolvedValueOnce({data: [0, 0, 0, 0, 0, 0, 0]})
+    const client = {readHoldingRegisters: mockReadHoldingRegisters}
     const state = {}
 
-    expect(await read(client, config, state)).toEqual({tot_act: 3.795, tot_react: 0})
-    expect(await read(client, config, state)).toBeUndefined()
+    expect(await read(client, undefined, state)).toEqual(expect.objectContaining({tot_act: 3.795}))
+    // the garbage frame must not be published, and must not clobber the last good values
+    expect(await read(client, undefined, state)).toBeUndefined()
+    expect(state).toEqual(expect.objectContaining({v: 225.9, tot_act: 3.795}))
+    // the energy registers are not even read once the frame is known to be garbage
+    expect(mockReadHoldingRegisters).toHaveBeenCalledTimes(3)
   })
 
   it('should propagate read errors and leave state untouched', async () => {
@@ -227,78 +254,140 @@ describe('read', () => {
 })
 
 describe('setup', () => {
+  const timeout = () => Object.assign(new Error('Timed out'), {errno: 'ETIMEDOUT'})
+
+  const mockClient = (overrides = {}) => ({
+    // modbus-serial has no response parser for FC 0x28, so the unlock always times out
+    customFunction: jest.fn().mockRejectedValue(timeout()),
+    writeRegisters: jest.fn().mockResolvedValue({}),
+    readHoldingRegisters: jest.fn().mockResolvedValue({data: [2]}),
+    setID: jest.fn(),
+    ...overrides,
+  })
+
   it('should not touch the meter when given nothing to change', async () => {
-    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+    const client = mockClient()
 
-    await setup({writeRegisters: mockWriteRegisters}, {})
+    await setup(client, {})
 
-    expect(mockWriteRegisters).not.toHaveBeenCalled()
+    expect(client.customFunction).not.toHaveBeenCalled()
+    expect(client.writeRegisters).not.toHaveBeenCalled()
+  })
+
+  it('should unlock with the factory password before writing', async () => {
+    const client = mockClient()
+
+    await setup(client, {baudRate: 4800})
+
+    // datasheet: 01 28 FE 01 00 02 04 00 00 00 00
+    expect(client.customFunction).toHaveBeenCalledWith(0x28,
+      [0xFE, 0x01, 0x00, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00])
+    expect(client.customFunction.mock.invocationCallOrder[0])
+      .toBeLessThan(client.writeRegisters.mock.invocationCallOrder[0])
+  })
+
+  it('should unlock with the given password', async () => {
+    const client = mockClient()
+
+    await setup(client, {baudRate: 4800, password: '12345678'})
+
+    expect(client.customFunction).toHaveBeenCalledWith(0x28,
+      [0xFE, 0x01, 0x00, 0x02, 0x04, 0x12, 0x34, 0x56, 0x78])
+  })
+
+  it('should propagate unlock failures other than the expected timeout', async () => {
+    const client = mockClient({
+      customFunction: jest.fn().mockRejectedValue(new Error('Port Not Open')),
+    })
+
+    await expect(setup(client, {baudRate: 4800})).rejects.toThrow('Port Not Open')
+    expect(client.writeRegisters).not.toHaveBeenCalled()
   })
 
   it('should write baud rate', async () => {
-    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+    const client = mockClient()
 
-    await setup({writeRegisters: mockWriteRegisters}, {baudRate: 4800})
+    await setup(client, {baudRate: 4800})
 
-    expect(mockWriteRegisters).toHaveBeenCalledWith(0x0E, [3])
+    expect(client.writeRegisters).toHaveBeenCalledWith(0x0E, [3])
   })
 
   it('should reject an unsupported baud rate instead of writing garbage', async () => {
-    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+    const client = mockClient()
 
-    await expect(setup({writeRegisters: mockWriteRegisters}, {baudRate: 19200}))
-      .rejects.toThrow('Unsupported baud rate 19200')
-    expect(mockWriteRegisters).not.toHaveBeenCalled()
+    await expect(setup(client, {baudRate: 19200})).rejects.toThrow('Unsupported baud rate 19200')
+    expect(client.writeRegisters).not.toHaveBeenCalled()
   })
 
-  it('should write the password as 4 BCD digits per register', async () => {
-    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+  it('should write a new password as 4 BCD digits per register', async () => {
+    const client = mockClient()
 
     // datasheet: 02 10 00 10 00 02 04 11 11 11 11 -> password 11111111
-    await setup({writeRegisters: mockWriteRegisters}, {password: '11111111'})
+    await setup(client, {newPassword: '11111111'})
 
-    expect(mockWriteRegisters).toHaveBeenCalledWith(0x10, [0x1111, 0x1111])
+    expect(client.writeRegisters).toHaveBeenCalledWith(0x10, [0x1111, 0x1111])
   })
 
   it('should reject a password that is not exactly 8 digits', async () => {
-    const mockWriteRegisters = jest.fn().mockResolvedValue({})
+    const client = mockClient()
 
-    await expect(setup({writeRegisters: mockWriteRegisters}, {password: '1234'}))
+    await expect(setup(client, {newPassword: '1234'}))
       .rejects.toThrow('Password must be exactly 8 digits')
-    expect(mockWriteRegisters).not.toHaveBeenCalled()
+    expect(client.writeRegisters).not.toHaveBeenCalled()
   })
 
   it('should write the address last and switch the client to it', async () => {
-    const mockWriteRegisters = jest.fn().mockResolvedValue({})
-    const mockSetID = jest.fn()
+    const client = mockClient()
 
-    await setup({writeRegisters: mockWriteRegisters, setID: mockSetID},
-      {address: 2, baudRate: 9600, password: '11111111'})
+    await setup(client, {address: 2, baudRate: 9600, newPassword: '11111111'})
 
-    expect(mockWriteRegisters).toHaveBeenNthCalledWith(1, 0x0E, [4])
-    expect(mockWriteRegisters).toHaveBeenNthCalledWith(2, 0x10, [0x1111, 0x1111])
-    expect(mockWriteRegisters).toHaveBeenNthCalledWith(3, 0x0F, [2])
-    expect(mockSetID).toHaveBeenCalledWith(2)
+    expect(client.writeRegisters).toHaveBeenNthCalledWith(1, 0x0E, [4])
+    expect(client.writeRegisters).toHaveBeenNthCalledWith(2, 0x10, [0x1111, 0x1111])
+    expect(client.writeRegisters).toHaveBeenNthCalledWith(3, 0x0F, [2])
+    expect(client.setID).toHaveBeenCalledWith(2)
   })
 
   it('should switch the client to the new address when the meter answers from it', async () => {
     // the meter applies the address immediately, so the reply comes from the new unit id
     // and modbus-serial rejects it - the write itself did succeed
-    const mockWriteRegisters = jest.fn()
-      .mockRejectedValueOnce(new Error('Unexpected data error, expected address 1 got 2'))
-    const mockSetID = jest.fn()
+    const client = mockClient({
+      writeRegisters: jest.fn()
+        .mockRejectedValueOnce(new Error('Unexpected data error, expected address 1 got 2')),
+    })
 
-    await setup({writeRegisters: mockWriteRegisters, setID: mockSetID}, {address: 2})
+    await setup(client, {address: 2})
 
-    expect(mockSetID).toHaveBeenCalledWith(2)
+    expect(client.setID).toHaveBeenCalledWith(2)
+    expect(client.readHoldingRegisters).toHaveBeenCalledWith(0x0F, 1)
+  })
+
+  it('should not swallow an unexpected function code as an address change', async () => {
+    // same message prefix, but a stale reply from another unit - the write did not succeed
+    const client = mockClient({
+      writeRegisters: jest.fn()
+        .mockRejectedValueOnce(new Error('Unexpected data error, expected code 16 got 3')),
+    })
+
+    await expect(setup(client, {address: 2}))
+      .rejects.toThrow('Unexpected data error, expected code 16 got 3')
+    expect(client.setID).not.toHaveBeenCalled()
+  })
+
+  it('should fail when the meter did not take the new address', async () => {
+    const client = mockClient({
+      readHoldingRegisters: jest.fn().mockResolvedValue({data: [1]}),
+    })
+
+    await expect(setup(client, {address: 2}))
+      .rejects.toThrow('Address change failed, meter reports address 1')
   })
 
   it('should propagate other address write failures', async () => {
-    const mockWriteRegisters = jest.fn().mockRejectedValueOnce(new Error('Timed out'))
-    const mockSetID = jest.fn()
+    const client = mockClient({
+      writeRegisters: jest.fn().mockRejectedValueOnce(new Error('Illegal data address')),
+    })
 
-    await expect(setup({writeRegisters: mockWriteRegisters, setID: mockSetID}, {address: 2}))
-      .rejects.toThrow('Timed out')
-    expect(mockSetID).not.toHaveBeenCalled()
+    await expect(setup(client, {address: 2})).rejects.toThrow('Illegal data address')
+    expect(client.setID).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Adds a device driver for the ORNO **OR-WE-504** (1-phase energy meter with RS-485, 100A, 1 module, DIN TH-35mm), modeled on the existing `or-we-514` driver.

Register map taken from [OR-WE-504_rejestry.pdf](https://files.orno.pl/support/Others/ORNO/ORWE504_5901752481282/OR-WE-504_rejestry.pdf). Unlike `or-we-516`, this meter uses plain decimal-scaled integers (no IEEE754), all within holding registers `0x00`-`0x0F`:

| Reg | Value | Scale | Output field |
|---|---|---|---|
| 0x00 | voltage | 0.1 V | `v` |
| 0x01 | current | 0.1 A | `c` |
| 0x02 | frequency | 0.1 Hz | `freq` |
| 0x03 | active power | 1 W | `p` |
| 0x04 | reactive power | 1 var | `rp` |
| 0x05 | apparent power | 1 VA | `ap` |
| 0x06 | power factor | x1000 | `pow` |
| 0x07-08 | active energy | 1 Wh, uint32 hi-word-first | `tot_act` (kWh) |
| 0x09-0A | reactive energy | 1 varh, uint32 hi-word-first | `tot_react` (kVArh) |
| 0x0E | baud rate | 1=1200 ... 4=9600 | `baud_rate` |
| 0x0F | modbus address | - | `id` |

Details:
- `read()` uses the existing gating/state pattern - `read: {instantaneous, energy, config}` (config off by default) plus `options.maxMsBetweenReports` change suppression.
- Energy is normalized to kWh/kVArh so field semantics match `or-we-514` / `or-we-526` and existing Grafana/InfluxDB conventions.
- `setup()` writes the password-unlock register (`0x80`, BCD-encoded, factory default `00000000`) before any config write - the meter rejects writes otherwise and stays unlocked ~10s - and changes the modbus address last so intermediate writes still reach the old slave id.

## Test plan

- [x] `npx jest devices/or-we-504.test.js` - 12 tests pass, covering each register group, 32-bit energy counters, change-suppression behavior, and the setup unlock/write ordering. Scaling assertions use the PDF's own worked examples (`0x08D3` -> 225.9 V, `0x0013` -> 1.9 A, `0x0ED3` -> 3795 Wh).
- [ ] Not yet verified against real hardware.

## Notes

- **Not wired into any bus config.** Add `type: 'or-we-504'` with the meter's address to the appropriate `config/modbus-serial/*.config.js` once the bus/slave address is known. Factory serial settings are 9600/8/N/1, which may not match the bus it lands on.
- **`docs/influxdb-schema.md` not updated** - no new measurements or fields are written until the device is added to a config, and the field names reuse the existing meter set.
- **Documentation discrepancy:** the PDF's prose gives two conflicting addresses for "write new address" - `0x0F` via function `0x10` (matching the register table and the read example) and `0x06` via function `0x06`. This driver implements `0x0F`; worth confirming against real hardware before relying on `setup()`.