### PR TITLE
docs(grafana): document that last() over a long window defeats for:, audit the 8 affected rules

### DIFF
--- a/config/grafana/CLAUDE.md
+++ b/config/grafana/CLAUDE.md
@@ -74,6 +74,7 @@ SELECT last("battery_percentage") FROM "sunseeker_power"
 - **Alert queries**: Do NOT use `$timeFilter` in Grafana 9.5+ (known issue with provisioned alerts)  
 - **Alert time filtering**: `relativeTimeRange` does NOT filter InfluxQL queries - must use explicit `WHERE time >= now() - [duration]`
 - **All alert queries need explicit time filtering** to prevent using stale data from disconnected devices
+- **`last()` over a long window is not "the current value"**: it returns the newest point in the window and keeps returning it until a newer one arrives, so `for:` cannot be relied on to filter transients -- see "`last()` Over a Long Window Defeats `for:`" under Troubleshooting
 - **Data frequency varies**: Temperature data ~15min intervals, battery data ~1-4h intervals (device-dependent)
 - **Dashboard queries**: Can use `$timeFilter` normally - works fine in dashboard context
 - Use appropriate time aggregation (`aggregateWindow` for Flux, aggregate functions for InfluxQL)
@@ -418,6 +419,37 @@ Grafana's own internal state (users, dashboard metadata, alert rule state, ngale
 - **GitHub Issues**: Known problems documented in issues #77466 and #8195
 - **Testing**: Use data source query editor to validate syntax before provisioning
 - **Verification**: Check alert instances via `/api/alertmanager/grafana/api/v2/alerts` for error details
+
+**`last()` Over a Long Window Defeats `for:`:**
+- **Symptoms**: A rule with `for: 10m` pages on a single spurious sample anyway; once firing it stays firing long after the bad sample, and only recovers when the next good sample is published (or when the spike ages out of the query window)
+- **Mechanism**: `SELECT last("value") ... WHERE time >= now() - 6h` means "the newest point in the last 6 hours", **not** "the value right now". With nothing newer published, every evaluation returns the same point. `for:` requires the condition to be *continuously true* for the given duration -- it does **not** require *fresh* data. So a spike that happens to be the last published value stays true across every evaluation in the pending window, `for:` elapses, and the rule fires. `for:` only suppresses an artefact that a corrective sample **overwrites inside the for-window**; it is not a general transient filter.
+- **Recognising an affected rule** -- all three hold:
+  1. The query collapses to a single point with `last()` (or `first()`/`mean()` over the whole range) over a window much longer than the source's publish interval
+  2. `for:` is set, and its comment or PR description describes it as filtering transients
+  3. The source can go quiet -- a sleeping vehicle, a docked battery device, a store-and-forward logger
+- **Worked example** (`ioniq-tpms-*-temp-excess`, group `interval: 1m`, `for: 10m`, `SELECT last("value") ... - 6h`):
+  ```
+  12:00  car wakes, publishes tire_rr_temp_excess = 12.3 (TPMS refresh artefact)
+  12:01  eval -> last() = 12.3 > 8  -> Pending
+  12:02  car sleeps, nothing more is published
+  12:03..12:10  eval -> last() = 12.3 (same point, still inside the 6h window) -> still Pending
+  12:11  for: 10m has elapsed with the condition continuously true -> Alerting, pages
+  18:00  the 12:00 point finally ages out of the 6h window -> NoData -> noDataState: OK -> clears
+  ```
+  Had a corrective frame arrived at 12:02, `last()` would have returned it and the rule would have resolved from Pending without paging. That is the only case `for:` covers.
+- **Practical test**: `for:` is a real transient filter only when the source reliably publishes **several** samples inside the for-window. If `for` is smaller than ~2x the publish interval, or the source can stop publishing entirely, treat `for:` as best-effort and say so in a comment on the rule.
+- **Solutions**, in order of preference:
+  1. **Shorten the query window** so `last()` cannot hold a stale point. Only safe when the source publishes reliably -- and check `noDataState` first: `NoData` will page on every quiet period, `OK` will *silently clear* a real alert instead of holding last known state.
+  2. **Aggregate in InfluxQL, not in the reducer.** For a `gt` threshold use `min()`, for an `lt` threshold use `max()`, so a lone outlier cannot drive the rule:
+     ```sql
+     ✅ SELECT max("soh") FROM "ioniq" WHERE "group"='bms/2105' AND time >= now() - 24h
+     ❌ SELECT last("soh") FROM "ioniq" WHERE "group"='bms/2105' AND time >= now() - 24h
+     ```
+     **Gotcha**: the `classic_conditions` `reducer` is applied to the *query result*, and `SELECT last(...)` has already collapsed that to a single point -- so changing `reducer: last` to `reducer: min`/`avg` does nothing. The aggregation has to happen in the query. The cost is detection latency: with `max()` over 24h a genuine step down is only reported once it dominates the whole window, so use this only for slow-moving signals.
+  3. **Add an explicit freshness gate**: a second query `SELECT count("value") ... time >= now() - 20m` with a `gt 0` condition ANDed in, so the rule can only fire on recent data. This costs persistence -- the alert clears as soon as the source sleeps, which is often exactly what the long window was there to prevent.
+  4. **Fix upstream and document it**: where the long window is deliberate (keeping an alert visible after a device sleeps), the transient filter belongs in the producer, not the alert rule. Keep `for:` as a cheap backstop, but comment on the rule that it is not a guarantee.
+- **Still worth setting `for:`**: it reliably absorbs a one-off evaluation glitch and it genuinely filters transients on fast, always-on sources (e.g. `sunseeker-battery-*`, which publish every 2-5 min while awake). The failure is specific to the combination of a long `last()` window and a source that can go silent.
+- **Reference**: issues #1417 (analysis) and #1419 (per-rule audit of the provisioned rules)
 
 **"database is locked" Errors (ngalert scheduler):**
 - **Symptoms**: Grafana logs show `database is locked` errors, alert rule evaluations silently missed

--- a/config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-battery-alerts.yaml
@@ -296,6 +296,12 @@ groups:
               expression: soh
         noDataState: OK
         execErrState: OK
+        # Formality, not a transient filter: last() over 24h keeps returning a
+        # spurious low sample for the whole window, so the pending period elapses
+        # and the rule fires anyway (issue #1419). Kept because SoH moves over
+        # months and the 24h window is needed to survive the car sleeping (~12h
+        # gaps observed); the guard against garbage frames is the all-zero drop
+        # in the mqtt-influx converter (issue #1413).
         for: 1h
         labels: { severity: warning, device: ioniq, subsystem: battery }
         annotations:
@@ -333,6 +339,8 @@ groups:
               expression: soh
         noDataState: OK
         execErrState: OK
+        # Formality, not a transient filter -- see ioniq-soh-step above and
+        # "last() Over a Long Window Defeats for:" in config/grafana/CLAUDE.md.
         for: 1h
         labels: { severity: critical, device: ioniq, subsystem: battery }
         annotations:

--- a/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
@@ -1,5 +1,15 @@
 apiVersion: 1
 
+# The 6h query window is deliberate: the car publishes TPMS only while awake
+# (~138 of any 168 hours have no samples at all), and every rule here is
+# noDataState: OK, so a short window would let the alert silently clear the
+# moment the car sleeps instead of staying visible. The cost is that
+# `SELECT last(...) ... - 6h` keeps returning the newest point for up to 6
+# hours, which means `for:` cannot be relied on as a transient filter -- see
+# "last() Over a Long Window Defeats for:" in config/grafana/CLAUDE.md
+# (issue #1419). The real artefact filter is the wheel-freshness gate in
+# docker/automations/bots/ioniq-tpms.js (issues #1415/#1416).
+
 groups:
   - orgId: 1
     name: Ioniq TPMS Alerts
@@ -150,6 +160,10 @@ groups:
         execErrState: OK
         # A dragging brake or a failing bearing produces a sustained excess; a
         # transient step is a TPMS refresh artefact, not a fault (issue #1415).
+        # Best-effort only -- see the note at the top of this file. It suppresses
+        # an artefact that a corrective frame overwrites within 10 min (all three
+        # historical cases), but not one that is the last value published before
+        # the car sleeps.
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -300,6 +314,10 @@ groups:
         execErrState: OK
         # A dragging brake or a failing bearing produces a sustained excess; a
         # transient step is a TPMS refresh artefact, not a fault (issue #1415).
+        # Best-effort only -- see the note at the top of this file. It suppresses
+        # an artefact that a corrective frame overwrites within 10 min (all three
+        # historical cases), but not one that is the last value published before
+        # the car sleeps.
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -450,6 +468,10 @@ groups:
         execErrState: OK
         # A dragging brake or a failing bearing produces a sustained excess; a
         # transient step is a TPMS refresh artefact, not a fault (issue #1415).
+        # Best-effort only -- see the note at the top of this file. It suppresses
+        # an artefact that a corrective frame overwrites within 10 min (all three
+        # historical cases), but not one that is the last value published before
+        # the car sleeps.
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
@@ -600,6 +622,10 @@ groups:
         execErrState: OK
         # A dragging brake or a failing bearing produces a sustained excess; a
         # transient step is a TPMS refresh artefact, not a fault (issue #1415).
+        # Best-effort only -- see the note at the top of this file. It suppresses
+        # an artefact that a corrective frame overwrites within 10 min (all three
+        # historical cases), but not one that is the last value published before
+        # the car sleeps.
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:

--- a/config/grafana/provisioning/alerting/sunseeker-battery-alerts.yaml
+++ b/config/grafana/provisioning/alerting/sunseeker-battery-alerts.yaml
@@ -52,6 +52,13 @@ groups:
               type: classic_conditions
         noDataState: NoData
         execErrState: Alerting
+        # Effective as a transient filter here, unlike the ioniq rules: the mower
+        # publishes every 2-5 min while awake, so several fresh samples land
+        # inside the pending window and a one-off reading is overwritten before
+        # it can fire. The 4h window only holds the last value once the mower
+        # goes silent, and "last seen critically low, now offline" is an alert
+        # worth having. See config/grafana/CLAUDE.md, "last() Over a Long Window
+        # Defeats for:" (issue #1419).
         for: 10m
         annotations:
           description: "Sunseeker lawn mower battery is critically low at {{ $values.battery.Value }}%"
@@ -108,6 +115,12 @@ groups:
               type: classic_conditions
         noDataState: NoData
         execErrState: Alerting
+        # "voltage" is only reported while the mower is on the charger, at ~2 min
+        # intervals, and the first sample of a charge session is the depleted
+        # end-of-discharge reading (7 samples under 18 V in 30 days, every one of
+        # them followed by a higher reading 2 min later). So 5m covers at least
+        # two fresh samples and does filter those -- see the note on
+        # sunseeker-battery-low above.
         for: 5m
         annotations:
           description: "Sunseeker battery voltage critically low at {{ $values.voltage.Value }}mV"


### PR DESCRIPTION
## What

Documents the `last()`-over-a-long-window vs `for:` trap in `config/grafana/CLAUDE.md`, and audits the 8 provisioned rules that combine the two.

**No rule behaviour was changed.** All three alert YAML files are byte-different but structurally identical to `master` — the edits are comments only. The audit conclusion is that every long window here is load-bearing and every `for:` is either genuinely effective or harmlessly decorative, so the honest fix is to write down which is which, next to the rule, rather than to tune working alerts.

## The mechanism

`SELECT last("value") ... WHERE time >= now() - 6h` means "the newest point in the last 6 hours", not "the value now". With nothing newer published, every evaluation returns the same point. `for:` requires the condition to be *continuously true*; it does not require *fresh* data. So a spike that happens to be the last published value stays true across the whole pending window, `for:` elapses, and the rule fires. `for:` only suppresses an artefact that a corrective sample **overwrites inside the for-window**.

Practical test, and the line the doc lands on: **`for:` is a real transient filter only when the source reliably publishes several samples inside the for-window.** If `for` is smaller than ~2× the publish interval, or the source can stop publishing, it is best-effort.

## Doc changes (`config/grafana/CLAUDE.md`)

New `**last() Over a Long Window Defeats for:**` entry in the existing "Alert Query Syntax Issues" family under Troubleshooting (same voice, same Symptoms/Mechanism/Solutions shape as the `$timeFilter` and `classic_conditions` entries), plus one cross-referencing bullet in the InfluxDB "Best Practices" list. Covers symptoms, mechanism, a three-point recognition checklist, a worked timeline example on `ioniq-tpms-*-temp-excess`, and four remedies in preference order.

One remedy is worth calling out because it is a live foot-gun: the `classic_conditions` **`reducer` is applied to the query result**, and `SELECT last(...)` has already collapsed that to a single point — so switching `reducer: last` to `reducer: min`/`avg` does *nothing*. Aggregation has to move into the InfluxQL (`SELECT max("soh") ... - 24h`). Anyone reaching for "just use a reducer over the window" will otherwise ship a no-op.

## Per-rule audit

Evidence is from production (`homy_influxdb_1` on routy, 7–90 day ranges).

| Rule | Window / `for:` / group interval | Is `for:` doing anything? | Verdict |
|---|---|---|---|
| `ioniq-soh-step` | 24h / 1h / 1m | **No** — decorative | **No change.** SoH moves over months; a spurious low sample is held by `last()` for the full 24h, so `for: 1h` cannot suppress it. The 24h window is required: `bms/2105` is silent for up to ~12h at a stretch, and `noDataState: OK` means a shorter window would *silently clear* rather than hold last known state. Field has read a constant `100` for the entire life of the series (90d min = max = 100), and the only observed source of spurious values — all-zero OBD frames — is already dropped upstream in the mqtt-influx converter (#1413). Commented as a formality. |
| `ioniq-soh-critical` | 24h / 1h / 1m | **No** — decorative | **No change.** Identical reasoning; commented with a back-reference. |
| `ioniq-tpms-fl-temp-excess` | 6h / 10m / 1m | **Partially** — best-effort | **No change.** See below. |
| `ioniq-tpms-fr-temp-excess` | 6h / 10m / 1m | **Partially** — best-effort | **No change.** |
| `ioniq-tpms-rl-temp-excess` | 6h / 10m / 1m | **Partially** — best-effort | **No change.** |
| `ioniq-tpms-rr-temp-excess` | 6h / 10m / 1m | **Partially** — best-effort | **No change.** |
| `sunseeker-battery-low` | 4h / 10m / 5m | **Yes** — effective | **No change.** The mower publishes `percentage` every 2–5 min while awake, so 2–5 fresh samples land inside the 10m pending window and a one-off reading is overwritten before it can fire. This is the regime where `for:` genuinely works. The residual trap case — mower's last value before going silent is <15% — produces a *correct* alert ("last seen critically low, now offline"), and the 4h window is needed because gaps of up to ~7h are normal with `noDataState: NoData`. Never fired in 30d (min `percentage` = 17). |
| `sunseeker-battery-voltage-low` | 4h / 5m / 5m | **Yes** — effective | **No change.** Looked marginal (`for` == group interval) until the data showed why it isn't: `voltage` is only reported *while on the charger*, at ~2 min intervals, and the first sample of a charge session is the depleted end-of-discharge reading. 7 samples under 18 V in 30 days, **every one of them** a lone dip followed 2 min later by a higher reading. So the 5m pending window always covers ≥2 fresh samples and does suppress them. Confirmed on two sessions (2026-07-22T21:14 → 17.906 V, +2 min 18.361 V; 2026-07-23T19:01 → 17.792 V, +2 min 18.356 V). |

### Why the four TPMS rules were left alone

This is the case the issue came from, and it is the one where a "fix" would do real damage:

- **Shortening the 6h window is wrong.** The car publishes TPMS only while awake — 138 of any 168 hours have no `derived/tire_rr_temp_excess` samples at all. Every rule is `noDataState: OK`, so a short window makes the alert vanish the moment the car sleeps. A dragging brake matters *after* you park; the long window is what keeps the alert visible.
- **A reducer over the window is wrong.** `min()` over 6h would mix in the parked/cold samples that dominate the window and destroy detection entirely.
- **A freshness gate is wrong for the same reason** — it buys transient rejection by throwing away exactly the persistence the 6h window exists to provide.
- **#1417's measurements say don't tune the window**: p95 inter-wheel stamp spread while moving is 11.5 min and the longest in-drive gap is 15.4 min, harmless only *because* `last()` holds the value. Shrinking would start costing genuine detections.

So `for: 10m` stays as a cheap backstop — it would have caught all three historical false alarms, where the corrective frame arrived within 1–3 min — and the real transient filter remains the wheel-freshness gate in `docker/automations/bots/ioniq-tpms.js` (#1415/#1416, hardening tracked in #1417 item 1). The existing rule comment claimed more than that and has been corrected; a header comment on the file records why the 6h window is deliberate.

`ioniq-cell-health-alerts.yaml` (30m window, `for: 10m`) is in scope for the same trap but is **not touched here** — it is being fixed upstream for #1418.

## Verification

No unit tests exist for alert YAML, so the evidence is parse + structural diff:

```
ioniq-battery-alerts: YAML parses OK; structurally identical to HEAD = True
ioniq-tpms-alerts: YAML parses OK; structurally identical to HEAD = True
sunseeker-battery-alerts: YAML parses OK; structurally identical to HEAD = True
RESULT: ALL CLEAN (comment-only changes)
```

(`yaml.safe_load` of each file, canonicalised with `json.dumps(sort_keys=True)`, compared against `git show HEAD:<path>`.) Diffstat is 79 insertions, 0 deletions, 0 modifications across 4 files. Grafana ignores YAML comments, so provisioning is unaffected and no restart is needed beyond the normal provisioning reload.

Closes #1419
Refs #1417

https://claude.ai/code/session_01N3FFkfJ11T74XCv1RonAXR
