### PR TITLE
fix(sunseeker): always write voltage/current fields as InfluxDB floats

### DIFF
--- a/docker/sunseeker-monitoring/src/constants.js
+++ b/docker/sunseeker-monitoring/src/constants.js
@@ -65,6 +65,22 @@ export const MEASUREMENTS = {
   COMMANDS: 'sunseeker_commands'
 };
 
+// Fields that must always be written to InfluxDB as floats.
+//
+// InfluxDB 1.x fixes a field's type per shard group from the first write of
+// that field in that shard. These fields are derived by dividing a raw
+// milli-unit reading by 1000, so they periodically land on a round value
+// (4000mV / 1000 === 4) that is indistinguishable from an integer at runtime.
+// Letting such a value select the integer type registers the field as an
+// integer for the rest of the shard, after which every fractional write is
+// rejected with a 400 field type conflict and the entire point is dropped.
+export const FLOAT_FIELDS = new Set([
+  'voltage',
+  'min_cell_voltage',
+  'max_cell_voltage',
+  'current'
+]);
+
 // Message command types
 export const COMMAND_TYPES = {
   STATUS_UPDATE: 501,

--- a/docker/sunseeker-monitoring/src/mqtt-influx-service.js
+++ b/docker/sunseeker-monitoring/src/mqtt-influx-service.js
@@ -5,7 +5,7 @@
 import mqtt from 'mqtt';
 import { InfluxDB, Point } from '@influxdata/influxdb-client';
 import { SunseekerMessageParser } from './message-parser.js';
-import { MQTT, HEALTH_CHECK } from './constants.js';
+import { MQTT, HEALTH_CHECK, FLOAT_FIELDS } from './constants.js';
 import { validateConfig, generateClientId, isTimestampRecent, createError } from './utils.js';
 import { logger } from './logger.js';
 
@@ -239,10 +239,13 @@ export class SunseekerMqttInfluxService {
     // Add fields
     Object.entries(dataPoint.fields).forEach(([key, value]) => {
       if (typeof value === 'number') {
-        if (Number.isInteger(value)) {
-          point.intField(key, value);
-        } else {
+        // Type from the field schema, never from the runtime value: a float
+        // field that happens to hold a round value must still be written as a
+        // float, or it pins the field to integer for the whole InfluxDB shard.
+        if (FLOAT_FIELDS.has(key) || !Number.isInteger(value)) {
           point.floatField(key, value);
+        } else {
+          point.intField(key, value);
         }
       } else if (typeof value === 'boolean') {
         point.booleanField(key, value);

--- a/docker/sunseeker-monitoring/src/mqtt-influx-service.test.js
+++ b/docker/sunseeker-monitoring/src/mqtt-influx-service.test.js
@@ -1,0 +1,157 @@
+/**
+ * Tests for InfluxDB point construction, in particular field typing.
+ *
+ * InfluxDB 1.x fixes a field's type per shard group from the first write of
+ * that field. Typing a float field as an integer because its runtime value
+ * happened to be round poisons the whole shard: every later float write is
+ * rejected with a 400 field type conflict and InfluxDB drops the entire point.
+ */
+
+import { SunseekerMqttInfluxService } from './mqtt-influx-service.js';
+import { MEASUREMENTS } from './constants.js';
+
+const TEST_DEVICE_ID = 'TEST_DEVICE_0000000000000';
+
+const TEST_CONFIG = {
+  mqtt: {
+    url: 'mqtt://mqtt-broker.test:1883',
+    username: 'test-user',
+    password: 'test-password',
+    deviceId: TEST_DEVICE_ID,
+    appId: 'test-app-id'
+  },
+  influx: {
+    url: 'http://influxdb.test:8086',
+    token: 'test-token',
+    bucket: 'test-bucket',
+    org: 'test-org'
+  }
+};
+
+/** Parse `key=value` pairs out of the field section of a line protocol string. */
+function fieldsOf(point) {
+  const line = point.toLineProtocol();
+  const fieldSection = line.slice(line.indexOf(' ') + 1, line.lastIndexOf(' '));
+
+  return Object.fromEntries(
+    fieldSection.split(',').map((pair) => {
+      const separator = pair.indexOf('=');
+      return [pair.slice(0, separator), pair.slice(separator + 1)];
+    })
+  );
+}
+
+describe('SunseekerMqttInfluxService._createInfluxPoint', () => {
+  let service;
+
+  beforeEach(() => {
+    service = new SunseekerMqttInfluxService(TEST_CONFIG);
+  });
+
+  const batteryDetailPoint = (fields) =>
+    service._createInfluxPoint({
+      measurement: MEASUREMENTS.BATTERY_DETAIL,
+      device_id: TEST_DEVICE_ID,
+      fields,
+      tags: {},
+      timestamp: new Date('2026-07-29T12:00:00Z')
+    });
+
+  describe('float fields with round values', () => {
+    // 4000mV / 1000 === 4 in JavaScript - indistinguishable from an integer at
+    // runtime, but semantically still a float field.
+    it.each([
+      ['max_cell_voltage', 4],
+      ['min_cell_voltage', 4],
+      ['voltage', 20],
+      ['current', 1]
+    ])('writes %s=%d as a float', (field, value) => {
+      const fields = fieldsOf(batteryDetailPoint({ [field]: value }));
+
+      expect(fields[field]).toBe(String(value));
+      expect(fields[field]).not.toMatch(/i$/);
+    });
+
+    it('keeps float typing consistent across round and fractional values', () => {
+      const round = fieldsOf(batteryDetailPoint({ max_cell_voltage: 4 }));
+      const fractional = fieldsOf(batteryDetailPoint({ max_cell_voltage: 4.041 }));
+
+      expect(round.max_cell_voltage).not.toMatch(/i$/);
+      expect(fractional.max_cell_voltage).not.toMatch(/i$/);
+    });
+
+    it('writes every float field of a full battery detail point as a float', () => {
+      const fields = fieldsOf(
+        batteryDetailPoint({
+          voltage: 20,
+          voltage_mv: 20000,
+          max_cell_voltage: 4,
+          max_cell_mv: 4000,
+          min_cell_voltage: 4,
+          min_cell_mv: 4000,
+          current: 2,
+          current_ma: 2000,
+          temperature: 30,
+          percentage: 98
+        })
+      );
+
+      for (const field of ['voltage', 'max_cell_voltage', 'min_cell_voltage', 'current']) {
+        expect(fields[field]).not.toMatch(/i$/);
+      }
+    });
+  });
+
+  describe('integer fields', () => {
+    it.each([
+      ['voltage_mv', 20151],
+      ['max_cell_mv', 4000],
+      ['min_cell_mv', 3989],
+      ['current_ma', 2000],
+      ['temperature', 30],
+      ['percentage', 98],
+      ['pitch', 1],
+      ['roll', 2],
+      ['heading', 180]
+    ])('writes %s=%d as an integer', (field, value) => {
+      const fields = fieldsOf(batteryDetailPoint({ [field]: value }));
+
+      expect(fields[field]).toBe(`${value}i`);
+    });
+  });
+
+  describe('non-numeric fields', () => {
+    it('writes booleans as booleans', () => {
+      const point = service._createInfluxPoint({
+        measurement: MEASUREMENTS.STATION,
+        device_id: TEST_DEVICE_ID,
+        fields: { at_station: true },
+        tags: {},
+        timestamp: new Date('2026-07-29T12:00:00Z')
+      });
+
+      expect(fieldsOf(point).at_station).toBe('T');
+    });
+
+    it('writes strings as quoted strings', () => {
+      const point = service._createInfluxPoint({
+        measurement: MEASUREMENTS.MODE,
+        device_id: TEST_DEVICE_ID,
+        fields: { mode: 1, mode_text: 'mowing' },
+        tags: {},
+        timestamp: new Date('2026-07-29T12:00:00Z')
+      });
+
+      const fields = fieldsOf(point);
+      expect(fields.mode).toBe('1i');
+      expect(fields.mode_text).toBe('"mowing"');
+    });
+  });
+
+  describe('tags', () => {
+    it('applies device_id and extra tags', () => {
+      const point = batteryDetailPoint({ temperature: 30 });
+      expect(point.toLineProtocol()).toContain(`device_id=${TEST_DEVICE_ID}`);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Four Grafana rules (`sunseeker-battery-low`, `sunseeker-battery-voltage-low`, `sunseeker-battery-temp-high`, `sunseeker-battery-temp-low`) have been paging continuously since 2026-07-27 while the mower was working normally — `sunseeker_mode` showed `mowing` and `sunseeker_connection` was healthy throughout.

All four query `sunseeker_battery_detail`, and that measurement had stopped receiving data. The service logs a 400 on nearly every message:

```
partial write: field type conflict: input field "max_cell_voltage"
on measurement "sunseeker_battery_detail" is type float,
already exists as type integer dropped=1
```

## Root cause

InfluxDB 1.x fixes a field's type **per shard group** from the first write of that field in the shard. `_createInfluxPoint` chose the type from the runtime value:

```js
if (Number.isInteger(value)) point.intField(key, value)
else                         point.floatField(key, value)
```

`max_cell_voltage` is `millivolts / 1000`, so a 4000mV reading yields exactly `4`. On `2026-07-27T03:52:21Z` that was the first `max_cell_voltage` write of shard 2330 (`2026-07-27` → `2026-08-03`), registering the field as an integer for the whole week. Every later fractional value was rejected, and InfluxDB **drops the entire point** — not just the offending field — so temperature, percentage and voltage went down with it.

`SHOW FIELD KEYS FROM sunseeker_battery_detail` shows the split:

```
max_cell_voltage  float
max_cell_voltage  integer
```

The bug is recurring and self-healing at each shard boundary, which is why it comes and goes. Daily point counts:

```
Jul 20 → 294   Jul 24 → 314   Jul 27 → 7    ← shard 2330 flips to integer
Jul 21 → 326   Jul 25 → 325   Jul 28 → 8
Jul 22 → 318   Jul 26 → 248   Jul 29 → 1
```

The weeks of `2026-07-06` and `2026-07-13` were broken the same way. The week of `2026-07-20` survived only because its first value happened to be `4.041`.

## Fix

Type numeric fields from the field schema, never from the runtime value. `FLOAT_FIELDS` in `constants.js` declares the four derived unit conversions that must always be floats: `voltage`, `min_cell_voltage`, `max_cell_voltage`, `current`. All other numeric fields (`*_mv`, `*_ma`, `temperature`, `percentage`, `pitch`, `roll`, `heading`, …) remain genuine integers.

## Tests

New `src/mqtt-influx-service.test.js` covers point construction, asserting on emitted line protocol:

- each float field with a round value (`4`, `20`, `1`) is written without the `i` suffix
- typing stays consistent across round and fractional values of the same field
- integer fields keep the `i` suffix
- booleans and strings are unaffected

Red before the change (6 failures), green after. Full suite: **61 passed**, including the testcontainers integration test.

## Follow-up on prod

The already-written integer points keep shard 2330 poisoned until it rotates on 2026-08-03. Verified on prod (influx 1.12.3) with a throwaway measurement that a time-scoped `DELETE` resets the field type for that shard only, leaving older shards intact:

```sql
DELETE FROM sunseeker_battery_detail
WHERE time >= '2026-07-27T00:00:00Z' AND time < '2026-08-03T00:00:00Z'
```

That discards 16 points and lets data resume immediately once this is deployed.

Note: `docs/influxdb-schema.md` does not document sunseeker measurement fields, so there is no field-type table to correct there.

https://claude.ai/code/session_01LxkVueWJKDyyQjnXMEr57X