### PR TITLE
fix(grafana): stop sunseeker pipeline failures paging as battery alarms

### DIFF
--- a/config/grafana/CLAUDE.md
+++ b/config/grafana/CLAUDE.md
@@ -125,9 +125,16 @@ SELECT last("battery_percentage") FROM "sunseeker_power"
               type: last
             type: query
         expression: temperature
-  noDataState: NoData
-  execErrState: Alerting
+  noDataState: OK
+  execErrState: OK
 ```
+**Why `OK`/`OK` here**: `sunseeker_battery_detail` can legitimately stop ingesting (mower asleep,
+or the InfluxDB int/float shard-poisoning bug that dropped it for days — PR #1430). A threshold
+rule may only speak about data it can actually see, so both the absence path (`NoData`) and the
+query-failure path (`Error`) are silenced on all four `sunseeker-battery-*` threshold rules — the
+`Error` path (InfluxDB down, auth failure, "database is locked") would otherwise page the identical
+four false battery/temperature emergencies with `[no value]` in the description. Absence detection
+is delegated to a single dedicated rule; see "Staleness / Absence Alerts" below.
 
 **Connectivity Alert Configuration Example:**
 ```yaml
@@ -187,10 +194,53 @@ SELECT last("battery_percentage") FROM "sunseeker_power"
 - Alert when count = 0 (no positive connectivity records in time window)
 - **Important**: Include explicit time filtering with `time >= now() - [duration]` as `relativeTimeRange` alone doesn't limit InfluxQL queries
 
+*Staleness / Absence Alerts:*
+- Use when a threshold rule's own `noDataState`/`execErrState` must be `OK` (its measurement can
+  legitimately stop ingesting) but something still needs to page on prolonged absence — **one
+  dedicated rule per data source**, not duplicated across every threshold rule reading it
+- **Single count query, `noDataState: Alerting`.** Do NOT build absence detection as a two-query AND
+  ("field is stale AND source is alive"). ❌ **Tested and rejected**: InfluxQL `count()` over an
+  entirely empty time range returns **no rows**, not `0` — even `GROUP BY time() fill(0)` does not
+  synthesize a row when the whole range is empty. An AND across two such queries collapses to
+  `NoData` exactly when it should fire, so it silently never alerts. Use one `count()` query against
+  the field you want freshness on, with `noDataState: Alerting`
+- **The counted field defines "stale"**: counting a field that is simply absent from an otherwise-
+  populated window is indistinguishable from no data at all. Pick the field with the best coverage
+  on the measurement — e.g. `percentage` on `sunseeker_battery_detail` (~99% of points; see
+  `docs/influxdb-schema.md`)
+- **Threshold headroom, not `lt 1`**: a partial outage produces a trickle, not a clean absence. `lt
+  1` lets a single straggler point flip the rule back to `OK` and emit a false all-clear, which then
+  re-fires on the next gap — several page/resolve cycles per day through a degraded period. Set the
+  count threshold with headroom below the healthy per-window floor, not at the absolute minimum.
+  Worked example: `sunseeker_battery_detail` normally logs 5-6 points/30m; the July 2026 incident was
+  a trickle (4-11 points/day instead of ~288) that a `lt 1` threshold would have flapped on
+  repeatedly, while `lt 2` requires a ~12x cadence collapse before it fires
+- **`for:` is a genuine transient filter here** — unlike `last()` over a long window (see
+  Troubleshooting, "`last()` Over a Long Window Defeats `for:`"). A sliding `count()` window has no
+  single point to latch onto: every evaluation during the pending window is an independent
+  observation of absence, so a corrective sample immediately un-trips it. Contrast: `last()` keeps
+  returning the same stale point on every evaluation until a newer one arrives, so a transient can
+  ride out the whole `for:` window as if it were still true
+- Example: `sunseeker-telemetry-stale`
+  (`config/grafana/provisioning/alerting/sunseeker-telemetry-alerts.yaml`) —
+  `SELECT count("percentage") FROM "sunseeker_battery_detail" WHERE time >= now() - 30m`, `lt 2`,
+  `noDataState: Alerting`, `execErrState: Alerting`, `for: 1h`. Time to page ≈ 90-95 min after the
+  last point (30m for the window to empty + 1h pending) — deliberately after
+  `sunseeker-connection-lost` (~30-35 min), so a genuinely unreachable mower is named as a connection
+  loss first. This is an accepted trade-off, not a bug: a real outage produces two alerts, and
+  collapsing them to one needs the two-query AND that provably does not work (above)
+
 **Alert Thresholds:**
 - **Battery alerts**: <15% critical, <25% warning
 - **Temperature alerts**: >40°C high, <5°C low
 - **Connection alerts**: >30 minutes no data
+- **Telemetry staleness**: `sunseeker-telemetry-stale` pages ~90-95 min after the last
+  `sunseeker_battery_detail` point — see "Staleness / Absence Alerts" above
+- **`noDataState`/`execErrState` on threshold rules reading a measurement that can stop ingesting**:
+  set BOTH to `OK`, and delegate absence detection to exactly one dedicated staleness rule per data
+  source (PR #1430 postmortem). Otherwise every threshold rule on that measurement becomes a
+  duplicate, mis-named alarm for the same pipeline fault. The staleness rule is the sole owner of "I
+  cannot see this data" and takes `Alerting` on both paths
 
 **Deleting Provisioned Alerts:**
 File-provisioned alerts cannot be deleted through the Grafana UI or standard API calls. To remove them, create a temporary deletion configuration file:
@@ -421,6 +471,7 @@ Grafana's own internal state (users, dashboard metadata, alert rule state, ngale
 - **Verification**: Check alert instances via `/api/alertmanager/grafana/api/v2/alerts` for error details
 
 **`last()` Over a Long Window Defeats `for:`:**
+- **Not the same failure as staleness/absence rules**: this trap is specific to `last()` (or `first()`/`mean()`) collapsing a long window to one point that `for:` can't tell apart from a fresh sample. A sliding `count()` doesn't have this problem — every evaluation re-counts the window from scratch, so `for:` genuinely filters transients there. See "Staleness / Absence Alerts" under Alert Patterns for the contrast.
 - **Symptoms**: A rule with `for: 10m` pages on a single spurious sample anyway; once firing it stays firing long after the bad sample, and only recovers when the next good sample is published (or when the spike ages out of the query window)
 - **Mechanism**: `SELECT last("value") ... WHERE time >= now() - 6h` means "the newest point in the last 6 hours", **not** "the value right now". With nothing newer published, every evaluation returns the same point. `for:` requires the condition to be *continuously true* for the given duration -- it does **not** require *fresh* data. So a spike that happens to be the last published value stays true across every evaluation in the pending window, `for:` elapses, and the rule fires. `for:` only suppresses an artefact that a corrective sample **overwrites inside the for-window**; it is not a general transient filter.
 - **Recognising an affected rule** -- all three hold:

--- a/config/grafana/CLAUDE.md
+++ b/config/grafana/CLAUDE.md
@@ -214,7 +214,8 @@ is delegated to a single dedicated rule; see "Staleness / Absence Alerts" below.
   count threshold with headroom below the healthy per-window floor, not at the absolute minimum.
   Worked example: `sunseeker_battery_detail` normally logs 5-6 points/30m; the July 2026 incident was
   a trickle (4-11 points/day instead of ~288) that a `lt 1` threshold would have flapped on
-  repeatedly, while `lt 2` requires a ~12x cadence collapse before it fires
+  repeatedly, while `lt 2` requires a ~6x cadence collapse before it fires (it only fires at <=1
+  point per 30m window, against a healthy floor of 5-6)
 - **`for:` is a genuine transient filter here** — unlike `last()` over a long window (see
   Troubleshooting, "`last()` Over a Long Window Defeats `for:`"). A sliding `count()` window has no
   single point to latch onto: every evaluation during the pending window is an independent

--- a/config/grafana/provisioning/alerting/sunseeker-battery-alerts.yaml
+++ b/config/grafana/provisioning/alerting/sunseeker-battery-alerts.yaml
@@ -50,8 +50,14 @@ groups:
               maxDataPoints: 43200
               refId: A
               type: classic_conditions
-        noDataState: NoData
-        execErrState: Alerting
+        # A dead ingestion pipeline is not a battery emergency. Both the NoData
+        # and Error paths are silenced here so this rule can only speak about
+        # data it can actually see; absence and query failure are owned by
+        # sunseeker-telemetry-stale instead. See issue #1430 (int/float field
+        # typing dropped every sunseeker_battery_detail point for days, and
+        # these rules paged it as four battery/temperature alarms).
+        noDataState: OK
+        execErrState: OK
         # Effective as a transient filter here, unlike the ioniq rules: the mower
         # publishes every 2-5 min while awake, so several fresh samples land
         # inside the pending window and a one-off reading is overwritten before
@@ -61,7 +67,7 @@ groups:
         # Defeats for:" (issue #1419).
         for: 10m
         annotations:
-          description: "Sunseeker lawn mower battery is critically low at {{ $values.battery.Value }}%"
+          description: "Sunseeker lawn mower battery is critically low at {{ $values.battery.Value }}% (last reading, up to 4h old)"
           runbook_url: ""
           summary: "Battery level is below 15%"
         labels:
@@ -113,8 +119,14 @@ groups:
               maxDataPoints: 43200
               refId: A
               type: classic_conditions
-        noDataState: NoData
-        execErrState: Alerting
+        # A dead ingestion pipeline is not a battery emergency. Both the NoData
+        # and Error paths are silenced here so this rule can only speak about
+        # data it can actually see; absence and query failure are owned by
+        # sunseeker-telemetry-stale instead. See issue #1430 (int/float field
+        # typing dropped every sunseeker_battery_detail point for days, and
+        # these rules paged it as four battery/temperature alarms).
+        noDataState: OK
+        execErrState: OK
         # "voltage" is only reported while the mower is on the charger, at ~2 min
         # intervals, and the first sample of a charge session is the depleted
         # end-of-discharge reading (7 samples under 18 V in 30 days, every one of
@@ -123,7 +135,7 @@ groups:
         # sunseeker-battery-low above.
         for: 5m
         annotations:
-          description: "Sunseeker battery voltage critically low at {{ $values.voltage.Value }}mV"
+          description: "Sunseeker battery voltage critically low at {{ $values.voltage.Value }}V (last reading, up to 4h old)"
           runbook_url: ""
           summary: "Battery voltage below safe operating threshold"
         labels:

--- a/config/grafana/provisioning/alerting/sunseeker-telemetry-alerts.yaml
+++ b/config/grafana/provisioning/alerting/sunseeker-telemetry-alerts.yaml
@@ -1,0 +1,85 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Sunseeker Telemetry Alerts
+    folder: Lawn Mower
+    interval: 5m
+    rules:
+      - uid: sunseeker-telemetry-stale
+        title: Sunseeker Telemetry Stale
+        condition: A
+        # Absence detection, not a threshold: a count() over an empty range
+        # returns NO ROWS (not 0), so this rule reports staleness through
+        # noDataState: Alerting - the same mechanism sunseeker-connection-lost
+        # relies on. A two-query AND against the connection heartbeat was tested
+        # and does not work: it collapses to NoData exactly when it should fire.
+        # "percentage" is counted because it is the most consistently present
+        # field on a sunseeker_battery_detail point and the input to the only
+        # critical rule (sunseeker-battery-low), so "stale" means "the critical
+        # rule is blind".
+        data:
+          - refId: telemetry
+            queryType: ''
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: 'SELECT count("percentage") FROM "sunseeker_battery_detail" WHERE time >= now() - 30m'
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              # lt 2, not lt 1: the July 2026 incident was a trickle, not a
+              # clean absence - a few points per day still landed. With "< 1" a
+              # single straggler flips the rule to OK and sends a false
+              # all-clear, then it re-fires an hour later; that is ~5 page/
+              # resolve cycles a day. Healthy cadence is 5-6 points per 30m
+              # window, so "< 2" needs a 12x collapse to false-fire.
+              conditions:
+                - evaluator:
+                    params:
+                      - 2
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - telemetry
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: telemetry
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              type: classic_conditions
+        noDataState: Alerting
+        execErrState: Alerting
+        # Deliberately staggered behind sunseeker-connection-lost (which pages
+        # at ~30-35m) so a genuinely unreachable mower is named as a connection
+        # loss first. Time to page here is ~90-95m after the last point: 30m for
+        # the query window to empty, then this 1h pending period. Unlike the
+        # last()-over-a-long-window rules, for: is a real filter here - a
+        # sliding count() cannot latch a stale point, so every evaluation in the
+        # pending hour is an independent observation of absence.
+        for: 1h
+        annotations:
+          description: "sunseeker_battery_detail has not been written for 90+ minutes. Battery and temperature alerts are blind until this clears - check the sunseeker-monitoring service and InfluxDB for rejected writes (see issue #1430). If the mower itself is unreachable, Sunseeker Connection Lost fires first and names that cause."
+          runbook_url: ""
+          summary: "No battery telemetry from the mower for 90+ minutes"
+        labels:
+          severity: warning
+          device: sunseeker
+          type: telemetry

--- a/config/grafana/provisioning/alerting/sunseeker-telemetry-alerts.yaml
+++ b/config/grafana/provisioning/alerting/sunseeker-telemetry-alerts.yaml
@@ -41,7 +41,7 @@ groups:
               # single straggler flips the rule to OK and sends a false
               # all-clear, then it re-fires an hour later; that is ~5 page/
               # resolve cycles a day. Healthy cadence is 5-6 points per 30m
-              # window, so "< 2" needs a 12x collapse to false-fire.
+              # window, so "< 2" needs a ~6x collapse to false-fire.
               conditions:
                 - evaluator:
                     params:

--- a/config/grafana/provisioning/alerting/sunseeker-temperature-alerts.yaml
+++ b/config/grafana/provisioning/alerting/sunseeker-temperature-alerts.yaml
@@ -50,11 +50,17 @@ groups:
               maxDataPoints: 43200
               refId: A
               type: classic_conditions
-        noDataState: NoData
-        execErrState: Alerting
+        # A dead ingestion pipeline is not a battery emergency. Both the NoData
+        # and Error paths are silenced here so this rule can only speak about
+        # data it can actually see; absence and query failure are owned by
+        # sunseeker-telemetry-stale instead. See issue #1430 (int/float field
+        # typing dropped every sunseeker_battery_detail point for days, and
+        # these rules paged it as four battery/temperature alarms).
+        noDataState: OK
+        execErrState: OK
         for: 10m
         annotations:
-          description: "Sunseeker battery temperature is dangerously high at {{ $values.temperature.Value }}°C"
+          description: "Sunseeker battery temperature is dangerously high at {{ $values.temperature.Value }}°C (last reading, up to 30m old)"
           runbook_url: ""
           summary: "Battery temperature exceeds safe operating limits"
         labels:
@@ -106,11 +112,17 @@ groups:
               maxDataPoints: 43200
               refId: A
               type: classic_conditions
-        noDataState: NoData
-        execErrState: Alerting
+        # A dead ingestion pipeline is not a battery emergency. Both the NoData
+        # and Error paths are silenced here so this rule can only speak about
+        # data it can actually see; absence and query failure are owned by
+        # sunseeker-telemetry-stale instead. See issue #1430 (int/float field
+        # typing dropped every sunseeker_battery_detail point for days, and
+        # these rules paged it as four battery/temperature alarms).
+        noDataState: OK
+        execErrState: OK
         for: 10m
         annotations:
-          description: "Sunseeker battery temperature is critically low at {{ $values.temperature.Value }}°C"
+          description: "Sunseeker battery temperature is critically low at {{ $values.temperature.Value }}°C (last reading, up to 30m old)"
           runbook_url: ""
           summary: "Battery temperature below safe operating limits"
         labels:

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -318,10 +318,20 @@ field (`src/message-parser.js`).
 **Source**: `cmd` 509 log messages, whose free-text body is scraped with regexes
 (`bat vol=`, `percent=`, `min=`, `max=`, `temp=`, `current=`, `pitch=`, `roll=`, `heading=`; all
 match unsigned integers only, so negative current or orientation values are silently unparsed).
-Fields are
-written only when the corresponding pattern is present, so **points are sparse and ragged** — most
-carry just `percentage` and `temperature`, and a minority carry the full cell/voltage set. Queries
-must tolerate missing fields rather than assume a fixed shape.
+Fields are written only when the corresponding pattern is present, so points can be missing fields —
+queries must tolerate that rather than assume a fixed shape. But the fields are **not** evenly
+sparse: measured on prod over 7/30 days, `percentage` and `temperature` are present on essentially
+every point (99%+), `min_cell_voltage`/`max_cell_voltage` on ~98%, and `voltage` on ~83-84% — none of
+these are a minority case. The genuinely sparse fields are `current`, `pitch`, `roll` and `heading`
+(7-27% of points).
+
+**`voltage`/`current` presence is activity-gated, not simply "charging only".** Verified directly:
+0/8 points in a mowing window carried them, 22/22 in a charging window did. But the resulting *share*
+of points that carry them moves with how much the mower mowed vs. charged that particular week — a
+duty-cycle artifact, not a stable percentage to design around. Measured `voltage` gaps run 78-130
+min, confirming it isn't reported continuously even while awake. **`percentage` is the most
+consistently present field and is the correct choice for a staleness `count()`** — see
+`config/grafana/CLAUDE.md` ("Staleness / Absence Alerts").
 
 **Extra tag**: `temp_alert` — `high` (≥40 °C), `low` (≤10 °C), or `normal`, from
 `TEMPERATURE.HIGH_THRESHOLD` / `LOW_THRESHOLD` in `src/constants.js`. Note these bounds are **not**
@@ -332,11 +342,11 @@ rules disagree by design-drift; prefer the raw `temperature` field for analysis.
 
 | Field | Type | Unit | Notes |
 |---|---|---|---|
-| `voltage` / `voltage_mv` | float / int | V / mV | Pack voltage; only reported while charging |
+| `voltage` / `voltage_mv` | float / int | V / mV | Pack voltage; activity-gated, see above |
 | `min_cell_voltage` / `min_cell_mv` | float / int | V / mV | Lowest cell |
 | `max_cell_voltage` / `max_cell_mv` | float / int | V / mV | Highest cell |
 | `current` / `current_ma` | float / int | A / mA | Pack current |
-| `percentage` | int | % | Battery level |
+| `percentage` | int | % | Battery level; most consistently present, see above |
 | `temperature` | int | °C | Pack temperature |
 | `pitch`, `roll`, `heading` | int | ° | Chassis orientation |
 
@@ -349,9 +359,16 @@ value therefore silences the entire measurement for up to a week. They are decla
 `FLOAT_FIELDS` (`src/constants.js`) and always written as floats; any new fractional field must be
 added there too. See PR #1430.
 
-**Cadence**: roughly one point every 5 minutes while the mower is awake (~288/day). A sustained gap
-means either the mower is unreachable or ingestion is broken — `sunseeker_connection` distinguishes
-the two.
+**Residual dual typing (harmless)**: `SHOW FIELD KEYS` still lists `max_cell_voltage` and
+`min_cell_voltage` as **both** float and integer, because the field-key list is a union across all
+shards and pre-#1430 shards still hold integer-typed writes from before the fix. This is historical
+residue, not a live problem — `count(max_cell_voltage)` and `count(min_cell_voltage)` are identical
+over both 24h and 7d windows, so nothing is being silently dropped now. Don't mistake it for a
+recurrence of the #1430 bug.
+
+**Cadence**: ~12 points/hour (~5 min interval) while idle, rising to ~18-30/hour while mowing or
+charging — roughly 288/day at the healthy floor. A sustained gap means either the mower is
+unreachable or ingestion is broken — `sunseeker_connection` distinguishes the two.
 
 #### `sunseeker_connection` Measurement
 **Source**: written by the service on **every** received MQTT message, with `connected` hard-coded
@@ -360,11 +377,17 @@ disconnection is detected by *absence* of points, which is why the connectivity 
 (`SELECT count("connected") ... WHERE "connected" = true`) rather than reading the last value.
 
 **Cadence**: ~12-16 points/hour in standby (every ~5 min, including overnight) rising to
-100-240/hour while mowing. The heartbeat does not go quiet when the mower is merely idle, which is
-what makes a 30-minute absence a reliable disconnection signal.
+100-241/hour while mowing. The heartbeat does not go quiet when the mower is merely idle, but it
+does during genuine outages — measured over 30 days on prod, 8 gaps exceeded 30 minutes: 42, 46, 63,
+343, 380, 468, 543 and 1497 minutes.
 
 **Use Cases**: mower connectivity alerting; separating "mower unreachable" from "telemetry
 pipeline broken" when `sunseeker_battery_detail` goes stale but this measurement keeps flowing.
+Measured on prod, `sunseeker_battery_detail` can stall up to 25 min *before* `sunseeker_connection`
+does, so the connectivity alert (`sunseeker-connection-lost`, ~30-35 min to page) reliably names a
+genuinely unreachable mower before the battery-telemetry staleness alert does (~90-95 min); see
+`config/grafana/CLAUDE.md` ("Staleness / Absence Alerts") for the alert design and the accepted
+trade-off of both firing for one real outage.
 
 ### Automation System Monitoring
 


### PR DESCRIPTION
## Problem

When `sunseeker_battery_detail` stopped ingesting for days in late July (InfluxDB int/float shard poisoning, fixed in #1430), the four threshold rules reading it had `noDataState: NoData` and paged **four false battery/temperature emergencies**. `sunseeker-connection-lost` — the rule that would have named the real cause — correctly stayed silent, because the mower itself was reachable.

## Change

Silence both blind paths on the threshold rules, and give absence a single dedicated owner.

| Rule | Change |
|---|---|
| `sunseeker-battery-low` | `noDataState`, `execErrState` → `OK` |
| `sunseeker-battery-voltage-low` | `noDataState`, `execErrState` → `OK` |
| `sunseeker-battery-temp-high` | `noDataState`, `execErrState` → `OK` |
| `sunseeker-battery-temp-low` | `noDataState`, `execErrState` → `OK` |
| `sunseeker-telemetry-stale` | **new** — `count("percentage")` / 30m, `lt 2`, `noDataState: Alerting`, `execErrState: Alerting`, `for: 1h`, `severity: warning` |
| `sunseeker-connection-lost` | unchanged |

Thresholds, query windows and `for:` on the four threshold rules are unchanged.

`execErrState` matters as much as `noDataState`: InfluxDB being down, an auth failure, or the documented `database is locked` condition produces an *Error*, not NoData — with `execErrState: Alerting` those four rules would still have walked into Pending → Alerting and paged the identical four emergencies, reading `[no value]`. Coverage is not lost; `sunseeker-telemetry-stale` keeps `Alerting` on both paths and is the sole owner of "I cannot see the mower's battery".

## Design notes (measured on prod, not assumed)

- **Absence must be a single `count()` query with `noDataState: Alerting`.** A two-query AND ("battery stale AND connection alive") was tested and rejected: InfluxQL `count()` over an empty range returns **no rows**, not `0`, and `GROUP BY time() fill(0)` does not synthesize one. The AND collapses to NoData exactly when it should fire.
- **`lt 2`, not `lt 1`.** The July incident was a *trickle* (4–11 points/day against ~288), not a clean absence. With `lt 1` a single straggler flips the rule to OK and emits a false all-clear, then re-fires — ~5 page/resolve cycles per day through the degraded period. Healthy floor is 5–6 points per 30m window, and `lt 2` only fires at ≤1 point per window — a ~6× collapse.
- **`count("percentage")` rather than `temperature`** — marginally better coverage (3633 vs 3604 over 30d) and it is the input to the only *critical* rule, so "stale" means "the critical rule is blind".
- **Stagger holds.** Time to page is ~90–95 min (30m for the window to empty + 1h pending), deliberately behind `sunseeker-connection-lost` (~30–35 min). `sunseeker_battery_detail` stalls up to 25 min *before* `sunseeker_connection` does, so the margin is ≥30 min and the ordering never inverts.
- **`for:` is a genuine filter here**, unlike the documented `last()`-over-a-long-window trap: a sliding `count()` cannot latch a stale point, so every evaluation in the pending hour is an independent observation of absence.

## Accepted trade-off

A genuinely offline mower produces **two** alerts — connection at ~30m, telemetry-stale at ~90m. Both statements are true, and collapsing them to one requires the AND that provably does not work.

**Out of scope:** InfluxDB itself failing needs a service-side write-failure signal, not a Grafana rule.

## Also included

- Voltage rule labelled volts as `mV`. Fixed. Note the *value* never actually rendered either — see follow-up 4; it would have paged "critically low at `[no value]`mV".
- Staleness caveats added to the threshold descriptions (`(last reading, up to 4h old)`).
- `docs/influxdb-schema.md`: the "sparse and ragged / voltage only while charging" claims were wrong — `min_cell_voltage`/`max_cell_voltage` are on ~98% of points and `voltage` on ~83%; presence is activity-gated and the share is a duty-cycle artifact. Cadence and `sunseeker_connection` outage-gap figures corrected. Notes the harmless residual `max_cell_voltage` float+int dual typing in `SHOW FIELD KEYS` (union across pre-#1430 shards) so it isn't mistaken for a recurrence.
- `config/grafana/CLAUDE.md`: new "Staleness / Absence Alerts" pattern section, `noDataState`/`execErrState` guidance, and a cross-reference from the `last()`/`for:` troubleshooting entry.

No uid changed and no rule was removed, so **no `delete-*.yaml` is required**.

## Known follow-ups (deliberately not in this PR)

1. **`sunseeker-connection-lost`'s `for: 30m` is dead code.** Its `count()` returns no rows when the window is empty, so `lt 1` can never evaluate true — the rule reaches notification *only* via `noDataState: NoData`, which bypasses `for:` entirely. It pages at +30–35m (not +60m) and the telegram bridge renders it as `📵 DATA SOURCE ISSUE` rather than by name. Fix would be `noDataState: Alerting` + `for: 5m`.
2. **Temperature rules keep their 30m window** while the battery rules use 4h, so from one stale point the system can assert "battery critically low" and simultaneously send ✅ resolved for temperature. Aligning them to 4h fixes it, at the cost of a genuine hot-pack alert persisting 4h.
4. **`{{ $values.<dataRefId>.Value }}` never resolves under `classic_conditions`** — pre-existing and repo-wide, not introduced here. Grafana 9.5.21 `extractValues()` keys classic-condition values as `<expressionRefId><index>` (i.e. `A0`), not by the data-query refId, so all 9 such references in the repo (4 sunseeker, 5 across `ioniq-dtc-alerts.yaml` and `ioniq-cell-health-alerts.yaml`) render as `[no value]`. Fixing means `$values.A0.Value`, which touches other services' rules — deliberately out of scope here. `config/grafana/CLAUDE.md` also currently attributes `[no value]` solely to query-syntax problems, which is an incomplete diagnosis.
5. **Deploy note:** Grafana applies alerting provisioning at **startup only** (unlike dashboards, which poll every 30s), so nothing changes until the container is recreated — `docker compose up -d grafana`.
3. **No `device = sunseeker` notification route**, so the new rule inherits the root policy's `repeat_interval: 4h` and re-pages indefinitely through a long outage. A 12h route (mirroring the ioniq warning route) would bound it. Related: there are no mute timings anywhere, and the mower is seasonal.

https://claude.ai/code/session_01LxkVueWJKDyyQjnXMEr57X
