### PR TITLE
fix(grafana): make solar circuit failure detectable, stop nightly false alarms

### DIFF
--- a/config/grafana/CLAUDE.md
+++ b/config/grafana/CLAUDE.md
@@ -250,11 +250,28 @@ is delegated to a single dedicated rule; see "Staleness / Absence Alerts" below.
   different bus
 - **Sample-count thresholds are tied to the poll rate.** Write the observed rate and the arithmetic
   into a comment on the rule so the next person knows to re-measure if the bus changes
-- **`noDataState: OK` is usually forced here**, because `count(... = true)` over a window with no
-  matching rows returns no rows rather than `0` (see above). That leaves "actuator wedged fully off,
-  self-test included" invisible to this rule — pair it with a second rule that infers the same fault
-  from its *effect* and never reads the actuator state at all (here, `boiler-solar-no-contribution`:
-  tank top never exceeded the electric cutoff while PV yield was meaningful)
+- **Gate on a time-weighted aggregate, not a bare `mean()`.** InfluxQL `mean()` averages over *points*,
+  not over time, so any source that publishes on change is over-weighted in whichever conditions make
+  it publish more. The SUN2000 inverter logs ~60-77 points/hour while generating against ~11/hour at
+  night, which biases `mean("ap")` over a 12 h window high by 30-40% — enough that a gate calibrated
+  on summer data fired on ordinary winter days. Use `GROUP BY time(1h) fill(0)` with `reducer: avg`
+  (equal weight per bucket ⇒ true time-weighted average, and `threshold × window hours` really is
+  energy), or `integral("field", 1h)` for a direct kWh figure. Validate the gate across at least one
+  full year, not one season
+- **`noDataState: OK` is usually forced here.** Be precise about *why*, because the obvious
+  explanation is wrong: a multi-condition `classic_conditions` does **not** go NoData just because one
+  input is empty. Grafana v9.5 (`pkg/expr/classic`) combines the per-condition NoData flag with the
+  same operator as the firing flag, so under `and` a single empty input among several populated ones
+  collapses NoData to false; the empty condition simply evaluates **false** and the rule reports OK.
+  Either way `count(... = true)` over a window with no matching rows returns no rows rather than `0`
+  (see above), so "actuator wedged fully off, self-test included" is invisible to this rule — pair it
+  with a second rule that infers the same fault from its *effect* and never reads the actuator state
+  at all (here, `boiler-solar-no-contribution`: tank top never exceeded the electric cutoff while PV
+  yield was meaningful)
+- **Expect the pair to double-page.** Both rules fire on most of the same days during a real fault
+  under different alertnames, so a sustained outage notifies roughly twice as often as one rule would
+  — the same accepted trade-off as the sunseeker connectivity/staleness pair above. Say so on the
+  rules rather than leaving it to be discovered
 
 **Alert Thresholds:**
 - **Battery alerts**: <15% critical, <25% warning

--- a/config/grafana/CLAUDE.md
+++ b/config/grafana/CLAUDE.md
@@ -231,6 +231,31 @@ is delegated to a single dedicated rule; see "Staleness / Absence Alerts" below.
   loss first. This is an accepted trade-off, not a bug: a real outage produces two alerts, and
   collapsing them to one needs the two-query AND that provably does not work (above)
 
+*Duty-Cycle Alerts (an actuator that must have been running):*
+- Use when the question is "did this thing actually run?" and the actuator's own state signal is
+  polluted by periodic self-test / anti-seize pulses. **Do not alert on state changes.** Alert on how
+  many samples were in the active state: `SELECT count("field") ... WHERE "field" = true AND time >=
+  now() - Nh`, thresholded well above what the pulses alone contribute
+- **Worked example** (issue #1472): the SR-04 solar controller pulses its pump for 2-3 s roughly every
+  22 minutes all day (`kick`), so `outputs.p1` toggles in every daylight hour whether or not heat is
+  moving, and holds one value all night when the pump is correctly idle. The old
+  `count(DISTINCT "outputs.p1") <= 1, for: 1h` rule was therefore exactly inverted: replayed over 107
+  days of production data it fired on **45% of all hours** — every night, all 107 days — and on **zero**
+  daylight hours through a 63-day total solar outage. The replacement counts `outputs.p1 = true`
+  samples over 6 h against a threshold ~2x the pulse contribution, and fires 0 times in 44 healthy
+  days
+- **Gate on an independent sensor, not the suspect one.** The #1472 fault *was* the collector probe
+  (`t3`) reporting ~35 °C against >110 °C actual, so any rule gated on `t3` would have stayed silent.
+  Both replacement rules gate on PV inverter output (`inverter.ap`) instead — a different device on a
+  different bus
+- **Sample-count thresholds are tied to the poll rate.** Write the observed rate and the arithmetic
+  into a comment on the rule so the next person knows to re-measure if the bus changes
+- **`noDataState: OK` is usually forced here**, because `count(... = true)` over a window with no
+  matching rows returns no rows rather than `0` (see above). That leaves "actuator wedged fully off,
+  self-test included" invisible to this rule — pair it with a second rule that infers the same fault
+  from its *effect* and never reads the actuator state at all (here, `boiler-solar-no-contribution`:
+  tank top never exceeded the electric cutoff while PV yield was meaningful)
+
 **Alert Thresholds:**
 - **Battery alerts**: <15% critical, <25% warning
 - **Temperature alerts**: >40°C high, <5°C low

--- a/config/grafana/dashboards/BOILER_CONTROLLER_README.md
+++ b/config/grafana/dashboards/BOILER_CONTROLLER_README.md
@@ -54,25 +54,73 @@ This dashboard provides comprehensive monitoring and analysis of the boiler cont
 
 ## Alert Integration
 
-The dashboard integrates with 7 automated alert rules:
+The dashboard integrates with the 7 rules provisioned in
+`config/grafana/provisioning/alerting/boiler-controller-alerts.yaml`. (An eighth, "Manual Mode
+Extended" / `boiler-controller-manual-mode-stuck`, was removed via
+`delete-boiler-manual-mode-alert.yaml` and no longer exists.)
 
 ### Critical Alerts
-1. **Boiler Overheating** - Temperature >85°C for 2+ minutes
-2. **Controller Not Responding** - No decisions for 30+ minutes
-3. **Temperature Sensor Failure** - No readings for 30+ minutes
+1. **Boiler Overheating** (`boiler-controller-overheating`) - Temperature >85°C for 2+ minutes
+2. **Controller Not Responding** (`boiler-controller-not-responding`) - No decisions for 30+ minutes
 
 ### High Priority Alerts
-4. **Emergency Heating Active** - Critical low temperature for 10+ minutes
-5. **Excessive Power** - >3kW consumption for 15+ minutes
+3. **Temperature Sensor Failure** (`boiler-temperature-sensor-failure`) - No readings for 30+ minutes
+4. **Emergency Heating Active** (`boiler-controller-emergency-heating`) - Critical low temperature for 10+ minutes
+5. **No Solar Contribution On A Sunny Day** (`boiler-solar-no-contribution`) - boiler top has not
+   exceeded the 50°C electric cutoff in 12 hours while the PV inverter averaged >1.3 kW over the same
+   window, i.e. every kWh in the tank came from the immersion heater. See "Solar circuit alert
+   thresholds" below.
 
 ### Warning Alerts
-6. **Manual Mode Extended** - Manual override for 2+ hours
-7. **Solar Circulation Stuck** - No state changes for 1+ hour
+6. **Excessive Power** (`boiler-excessive-power-consumption`) - >3kW consumption for 15+ minutes
+7. **Solar Circulation Idle While Sunny** (`boiler-solar-circulation-stuck`) - under ~2 minutes of pump
+   run time in 6 hours while the PV inverter averaged >1.5 kW and the boiler top stayed below 55°C.
+   See "Solar circuit alert thresholds" below.
+
+## Solar circuit alert thresholds
+
+The SR-04 runs a `kick` anti-seize function - a 2-3 second pump pulse roughly every 22 minutes across
+its daylight window (`kickOn: 8`, `kickOff: 20`). So `outputs.p1` toggles in **every** daylight hour
+whether or not any heat moves, and holds a single value all night when the pump is correctly idle.
+**Any rule keyed on `outputs.p1` state changes is inverted with respect to the failure it is meant to
+catch.** The original `count(DISTINCT "outputs.p1") <= 1` rule, replayed over 107 days of production
+data, fired on 45% of all hours - every night, all 107 days - and never once during the 63-day solar
+outage of 2026-06-08…2026-08-09 (issue #1472).
+
+The replacements measure *how long the pump ran* (a sample count of `outputs.p1 = true`), gate on PV
+output from the **inverter** rather than the collector probe `t3` (the probe is what failed silently in
+#1472), and suppress the legitimate "tank already hot" case using the electric cutoff at 50°C
+(`comfortMin: 47` + `hysteresis: 3`).
+
+| Rule | Window | Conditions | Verified behaviour (replay, hourly) |
+|---|---|---|---|
+| `boiler-solar-circulation-stuck` | 6 h | `count(outputs.p1=true) < 100` **and** `mean(inverter.ap) > 1.5 kW` **and** `max(t2) < 55 °C`, `for: 1h` | 0 alert days in the 44 healthy days 2026-04-25…06-07; 50 of the 63 outage days, first on 2026-06-08 (day one). Fires only 10:00Z–17:00Z. |
+| `boiler-solar-no-contribution` | 12 h | `max(t2) < 50.5 °C` **and** `mean(inverter.ap) > 1.3 kW`, `for: 1h` | 1 alert day in the same 44 healthy days (2026-05-13, itself a genuine no-contribution day); 56 of the 63 outage days, first on 2026-06-08. Fires 12:00Z–21:00Z. |
+
+Together they alerted on 59 of the 63 outage days. The four misses (2026-06-12, 2026-07-02,
+2026-07-23, and the repair day 2026-08-09) were low-yield or data-outage days.
+
+Threshold caveats:
+- **`< 100` samples is tied to the poll rate.** The solar Modbus bus polls ~every 1.27 s (~2830
+  samples/hour), so kick alone leaves ~48 samples per 6 h window while a healthy sunny morning leaves
+  ~4400. If the bus gains devices or slows, re-measure and retune.
+- **`noDataState: OK` on both rules.** InfluxQL `count()` over a range with no matching rows returns no
+  rows, not `0`, so `outputs.p1 = true` is NoData for most of every night. The cost is that a pump
+  wedged fully off - kick included - is invisible to `boiler-solar-circulation-stuck`;
+  `boiler-solar-no-contribution` covers that case because it never reads `outputs.p1`.
+- **`boiler-solar-no-contribution` is dormant in winter** by design: ~15.6 kWh inside a 12 h window is
+  not reachable, so no seasonal mute is needed.
 
 ## Data Sources
 
 ### InfluxDB Measurements
-- `automation_status` - Controller decisions and state (automation-events-processor) - **Currently unavailable due to authentication issues**
+- `automation_status` - Controller decisions and state (automation-events-processor). **Being written**;
+  verified 2026-08-09: 1101 points for `service='boilerController'` in the preceding 7 days, most
+  recent at `2026-08-09T11:39:16Z`. An earlier note here claimed the measurement was unavailable due
+  to InfluxDB authentication errors - that is no longer true. Note `reason` and `controlMode` are
+  **tags**, not fields: filter on them, but count a real field.
+- `inverter` - PV inverter output (modbus-serial-inverter → Huawei SUN2000). `ap` is instantaneous AC
+  power in kW; used as the "is the sun out" gate by both solar circuit alerts.
 - `xymd1` - Temperature sensors and relay controls (modbus-serial-monitoring)
   - Temperature data: `solar_heater` device (t1, t2, t3, t6)
   - Solar circulation pump: `solar_heater` device (outputs.p1)
@@ -81,7 +129,7 @@ The dashboard integrates with 7 automated alert rules:
 
 ### Query Patterns
 ```sql
--- Controller decisions (currently unavailable)
+-- Controller decisions (reason/controlMode are tags, so SELECT * returns them as columns)
 SELECT * FROM "automation_status" WHERE "service"='boilerController'
 
 -- Temperature monitoring (corrected device mapping)
@@ -113,8 +161,12 @@ This dashboard is part of the Water System monitoring family:
 ### Common Issues
 1. **No Data in Panels**: Check InfluxDB connectivity and service status
 2. **Missing Temperature Data**: Verify modbus-serial-monitoring service
-3. **Missing Decision Data**: automation-events-processor has authentication issues with InfluxDB
-4. **Alert Not Firing**: Some alerts disabled due to missing automation_status measurement
+3. **Missing Decision Data**: `automation_status` is being written (verified 2026-08-09). If a panel is
+   empty, check whether it selects `reason`/`controlMode` as *fields* - they are tags, and
+   `SELECT count("reason")` returns nothing
+4. **Solar Alert Not Firing**: both solar circuit rules use `noDataState: OK` and are deliberately
+   gated on PV output, so they stay silent at night, on dull days and through winter. See "Solar
+   circuit alert thresholds" above
 5. **Authorization Failed**: WHERE clauses in queries may have authentication restrictions
 
 ### Service Dependencies

--- a/config/grafana/dashboards/BOILER_CONTROLLER_README.md
+++ b/config/grafana/dashboards/BOILER_CONTROLLER_README.md
@@ -47,7 +47,9 @@ This dashboard provides comprehensive monitoring and analysis of the boiler cont
 - `emergency_heating_top_cold` - Critical low temperature
 - `emergency_heating_bottom_cold` - Bottom sensor critical
 - `solar_priority_available` - Solar heating sufficient
-- `solar_insufficient_boost_needed` - Solar heating inadequate
+- `solar_insufficient_boost_needed` - Solar heating inadequate. **Never emitted**: the branch is gated
+  on `solarDisadvantageMax`, which the live config sets to `-100`, so it is unreachable. `SHOW TAG
+  VALUES` returns the other seven reasons and not this one.
 - `temperature_sufficient` - No heating needed
 - `safety_shutoff_overheated` - Safety temperature exceeded
 - `hysteresis_zone_maintain_*` - Maintaining current state
@@ -55,9 +57,10 @@ This dashboard provides comprehensive monitoring and analysis of the boiler cont
 ## Alert Integration
 
 The dashboard integrates with the 7 rules provisioned in
-`config/grafana/provisioning/alerting/boiler-controller-alerts.yaml`. (An eighth, "Manual Mode
-Extended" / `boiler-controller-manual-mode-stuck`, was removed via
-`delete-boiler-manual-mode-alert.yaml` and no longer exists.)
+`config/grafana/provisioning/alerting/boiler-controller-alerts.yaml`. ("Manual Mode Extended" /
+`boiler-controller-manual-mode-stuck` used to be among them; it was removed in `7342ea2` via
+`delete-boiler-manual-mode-alert.yaml`, leaving six, and `boiler-solar-no-contribution` brings the
+count back to seven.)
 
 ### Critical Alerts
 1. **Boiler Overheating** (`boiler-controller-overheating`) - Temperature >85°C for 2+ minutes
@@ -79,37 +82,68 @@ Extended" / `boiler-controller-manual-mode-stuck`, was removed via
 
 ## Solar circuit alert thresholds
 
-The SR-04 runs a `kick` anti-seize function - a 2-3 second pump pulse roughly every 22 minutes across
-its daylight window (`kickOn: 8`, `kickOff: 20`). So `outputs.p1` toggles in **every** daylight hour
-whether or not any heat moves, and holds a single value all night when the pump is correctly idle.
-**Any rule keyed on `outputs.p1` state changes is inverted with respect to the failure it is meant to
-catch.** The original `count(DISTINCT "outputs.p1") <= 1` rule, replayed over 107 days of production
-data, fired on 45% of all hours - every night, all 107 days - and never once during the 63-day solar
-outage of 2026-06-08…2026-08-09 (issue #1472).
+The SR-04 runs a `kick` anti-seize function - a short pump pulse every ~15-27 minutes across its
+daylight window (`kickOn: 8`, `kickOff: 20`; the device's own `kickPause` register reads 30 and
+`kickTime` 3). So `outputs.p1` toggles in **every** daylight hour whether or not any heat moves, and
+holds a single value all night when the pump is correctly idle. **Any rule keyed on `outputs.p1` state
+changes is inverted with respect to the failure it is meant to catch.** The original
+`count(DISTINCT "outputs.p1") <= 1` rule, replayed over 107 days of production data, fired on ~45% of
+all hours - every night, all 107 days - and never once during the 63-day solar outage of
+2026-06-08…2026-08-09 (issue #1472).
 
 The replacements measure *how long the pump ran* (a sample count of `outputs.p1 = true`), gate on PV
 output from the **inverter** rather than the collector probe `t3` (the probe is what failed silently in
 #1472), and suppress the legitimate "tank already hot" case using the electric cutoff at 50°C
 (`comfortMin: 47` + `hysteresis: 3`).
 
-| Rule | Window | Conditions | Verified behaviour (replay, hourly) |
+| Rule | Window | Conditions | Verified behaviour (hourly replay, 2024-08-01…2026-08-09) |
 |---|---|---|---|
-| `boiler-solar-circulation-stuck` | 6 h | `count(outputs.p1=true) < 100` **and** `mean(inverter.ap) > 1.5 kW` **and** `max(t2) < 55 °C`, `for: 1h` | 0 alert days in the 44 healthy days 2026-04-25…06-07; 50 of the 63 outage days, first on 2026-06-08 (day one). Fires only 10:00Z–17:00Z. |
-| `boiler-solar-no-contribution` | 12 h | `max(t2) < 50.5 °C` **and** `mean(inverter.ap) > 1.3 kW`, `for: 1h` | 1 alert day in the same 44 healthy days (2026-05-13, itself a genuine no-contribution day); 56 of the 63 outage days, first on 2026-06-08. Fires 12:00Z–21:00Z. |
+| `boiler-solar-circulation-stuck` | 6 h | `count(outputs.p1=true) < 100` **and** time-weighted `mean(inverter.ap) > 1.5 kW` **and** `max(t2) < 55 °C`, `for: 1h` | **0** alert days outside the outage across two full years, neither winter included; 50 of the 63 outage days, first on 2026-06-08 (day one). Fires only 10:00Z–17:00Z. |
+| `boiler-solar-no-contribution` | 12 h | `max(t2) < 50.5 °C` **and** time-weighted `mean(inverter.ap) > 1.3 kW`, `for: 1h` | 4 alert days outside the outage across two years (2025-05-28, 2026-02-25, 2026-04-08, 2026-05-13) — all genuine no-contribution days, see below; 56 of the 63 outage days, first on 2026-06-08. Fires 12:00Z–21:00Z. |
 
-Together they alerted on 59 of the 63 outage days. The four misses (2026-06-12, 2026-07-02,
-2026-07-23, and the repair day 2026-08-09) were low-yield or data-outage days.
+Together they alerted on 59 of the 63 outage days. The four misses were 2026-06-12 and 2026-07-02 (too
+little sun to pass the PV gate), 2026-07-23 (a 7.8 h data outage — the bare `mean("ap")` reads 1.66 kW
+there against 0.42 time-weighted, which is the point-weighting bias in miniature) and 2026-08-09, the
+repair day.
 
 Threshold caveats:
-- **`< 100` samples is tied to the poll rate.** The solar Modbus bus polls ~every 1.27 s (~2830
-  samples/hour), so kick alone leaves ~48 samples per 6 h window while a healthy sunny morning leaves
-  ~4400. If the bus gains devices or slows, re-measure and retune.
-- **`noDataState: OK` on both rules.** InfluxQL `count()` over a range with no matching rows returns no
-  rows, not `0`, so `outputs.p1 = true` is NoData for most of every night. The cost is that a pump
-  wedged fully off - kick included - is invisible to `boiler-solar-circulation-stuck`;
-  `boiler-solar-no-contribution` covers that case because it never reads `outputs.p1`.
-- **`boiler-solar-no-contribution` is dormant in winter** by design: ~15.6 kWh inside a 12 h window is
-  not reachable, so no seasonal mute is needed.
+- **The PV gate must be time-weighted, and this is the single easiest thing to get wrong here.**
+  InfluxQL `mean()` averages over *points*, not over time. The inverter publishes on change
+  (`maxMsBetweenReports` 5 min), logging ~60-77 points/hour in daylight against ~11/hour at night, so
+  a bare `mean("ap")` over a 12 h window is biased high by 30-40%. Both rules therefore use
+  `GROUP BY time(1h) fill(0)` with `reducer: avg`, which averages hourly buckets and yields a true
+  time-weighted kW — so `threshold × window hours` really is kWh. Measured on 2026-01-12: bare
+  `mean("ap")` = 1.286 kW (implying 15.4 kWh) against 12.72 kWh actually generated; the bucketed form
+  gives 0.750 kW = 9.0 kWh. An earlier draft used the bare form and fired on ordinary
+  December–February days.
+- **`< 100` samples is tied to the poll rate.** The solar Modbus bus polls every ~1.28 s (2810-2814
+  samples/hour), so kick alone leaves ~38-48 samples per 6 h window. A healthy sunny *morning* can
+  leave 4000+, but that is a best case, not the norm — daily pump-on totals across healthy days range
+  70 to 6147 with a median around 1400, and quiet healthy days sit at or below the threshold for a
+  whole day. The real protection against false alarms is the PV gate, not this margin. If the bus
+  gains devices or slows, re-measure and retune.
+- **`noDataState: OK` on both rules.** The mechanism is *not* "the rule goes NoData at night":
+  Grafana's `classic_conditions` combines the per-condition NoData flag with the same `and` operator
+  as the firing flag, and `solar_kw`/`tank_top` always return rows, so the ANDed NoData collapses to
+  false. What actually happens is that InfluxQL `count()` over a range with no matching rows returns
+  no rows, and an empty input makes that condition evaluate **false** — so the rule reports OK. Same
+  outcome, and the same blind spot either way: a pump wedged fully off (kick included) is invisible to
+  `boiler-solar-circulation-stuck`. `boiler-solar-no-contribution` covers that case because it never
+  reads `outputs.p1`.
+- **`boiler-solar-no-contribution` is NOT dormant in winter**, and must not be assumed to be. With the
+  time-weighted gate the winter firings largely drop away, but 2026-02-25 still alerts. All four
+  non-outage alert days are true positives by the rule's own definition: PV yield 18.1-24.2 kWh with
+  the collector peaking at 49.2-51.8 °C against a tank held at 50.0-50.4 °C — the solar circuit really
+  did contribute nothing. Expect roughly two such alerts a year.
+- **Both rules fire on most of the same days during a real fault**, in overlapping hours, under
+  different alertnames — so a sustained outage pages roughly twice as often as one rule alone. This is
+  accepted for the same reason as the sunseeker connectivity/staleness pair: neither rule can see the
+  other's failure mode. See `config/grafana/CLAUDE.md`.
+- **`count(outputs.p1=true)` falls during poller outages, not only when the pump idles.** A long
+  `xymd1` gap inside the 6 h window can therefore satisfy the first condition on its own. Across two
+  years this never produced a non-outage alert (the PV and tank gates suppressed it), so no
+  minimum-sample condition was added; `boiler-temperature-sensor-failure` is the dedicated owner of
+  "`xymd1` has gone quiet".
 
 ## Data Sources
 
@@ -119,8 +153,10 @@ Threshold caveats:
   recent at `2026-08-09T11:39:16Z`. An earlier note here claimed the measurement was unavailable due
   to InfluxDB authentication errors - that is no longer true. Note `reason` and `controlMode` are
   **tags**, not fields: filter on them, but count a real field.
-- `inverter` - PV inverter output (modbus-serial-inverter → Huawei SUN2000). `ap` is instantaneous AC
-  power in kW; used as the "is the sun out" gate by both solar circuit alerts.
+- `inverter` - PV inverter output (compose service `inverter` → Huawei SUN2000, `device.name='main'`).
+  `ap` is instantaneous AC power in **kW** (`sun2000.js` divides the raw register by 1000); used as the
+  "is the sun out" gate by both solar circuit alerts. Published on change with `maxMsBetweenReports`
+  5 min, so its point density varies with daylight — see the time-weighting caveat above.
 - `xymd1` - Temperature sensors and relay controls (modbus-serial-monitoring)
   - Temperature data: `solar_heater` device (t1, t2, t3, t6)
   - Solar circulation pump: `solar_heater` device (outputs.p1)

--- a/config/grafana/provisioning/alerting/boiler-controller-alerts.yaml
+++ b/config/grafana/provisioning/alerting/boiler-controller-alerts.yaml
@@ -242,18 +242,91 @@ groups:
           system: boiler
           component: energy
 
+      # --- Solar circuit: why `outputs.p1` state changes cannot be alerted on ---
+      #
+      # The SR-04 solar controller runs a `kick` anti-seize function: a 2-3 second
+      # pump pulse roughly every 22 minutes through its daylight window
+      # (`kickOn: 8`, `kickOff: 20`). `outputs.p1` therefore takes BOTH values in
+      # every daylight hour whether or not any heat is being moved, and takes only
+      # ONE value all night when the pump is correctly idle. Any rule shaped like
+      # `count(DISTINCT "outputs.p1") <= 1` is exactly inverted with respect to the
+      # failure it is meant to catch. The previous version of this rule was:
+      #
+      #   SELECT count(DISTINCT "outputs.p1") FROM "xymd1"
+      #   WHERE "device.name"='solar_heater' AND time >= now() - 1h    -- lte 1, for 1h
+      #
+      # Replayed over 2026-04-25..2026-08-09 (107 days of production data) it fired
+      # on 45% of all hours - every night on all 107 days, 00:00-03:00Z and
+      # 17:00-23:00Z - and fired for ZERO daylight hours during the 63-day solar
+      # outage of 2026-06-08..2026-08-09, when the collector sensor failed and the
+      # circuit delivered no heat at all. See issue #1472.
+      #
+      # What replaces it, and why these numbers:
+      #
+      #   * Pump activity is measured as a SAMPLE COUNT of `outputs.p1 = true`, not
+      #     as state changes. The solar Modbus bus polls roughly every 1.27 s
+      #     (~2830 samples/hour), so 6 hours holds ~17000 samples. Kick alone
+      #     contributes ~8 samples/hour, i.e. ~48 per 6 h window. The `lt 100`
+      #     threshold sits at ~2x pure kick and ~40x below the ~4400 samples a
+      #     healthy sunny morning produces - a wide gap, but it IS tied to the poll
+      #     rate. If the solar bus gains devices or slows down, re-measure and
+      #     retune.
+      #   * PV output gates "the sun is actually out", using an independent sensor
+      #     (the SUN2000 inverter) rather than the collector probe `t3`, which is
+      #     the very thing that failed silently in #1472. mean(ap) > 1.5 kW over 6 h
+      #     means ~9 kWh harvested in that window - unambiguously sunny.
+      #   * `max(t2) < 55` suppresses the legitimate case "the tank is already hot,
+      #     so the controller has correctly stopped circulating". The electric
+      #     heater cuts out at 50 degC (`comfortMin: 47` + `hysteresis: 3` in
+      #     config/automations/boiler-controller-config.js), so a top temperature
+      #     below 55 means nothing but electricity has heated this tank.
+      #
+      # Verified by replay against production InfluxDB, hourly evaluation:
+      #   2026-04-25..2026-06-07 (44 healthy days): 0 alert days
+      #   2026-06-08..2026-08-09 (63 outage days): 50 alert days, first alert on
+      #     2026-06-08 - day one of the failure - in the 03:00-09:00Z window
+      #     (pump_on=38, solar_kw=1.62, tank_top=48.9)
+      #   Fires only between 10:00Z and 17:00Z; never at night.
+      #
+      # noDataState is OK, deliberately: InfluxQL `count()` over a range with no
+      # matching rows returns NO ROWS, not 0 (see config/grafana/CLAUDE.md,
+      # "Staleness / Absence Alerts"). At night `outputs.p1 = true` matches nothing,
+      # so this rule is in NoData for most of every night and `NoData`/`Alerting`
+      # would page nightly. The cost is that a pump wedged fully OFF - kick included -
+      # also produces no rows and cannot be caught here; that case is covered by
+      # `boiler-solar-no-contribution` below, which never reads `outputs.p1`.
       - uid: boiler-solar-circulation-stuck
-        title: Solar Circulation Pump Stuck
+        title: Solar Circulation Idle While Sunny
         condition: A
         data:
-          - refId: solar_state
+          - refId: pump_on
             queryType: ''
             relativeTimeRange:
-              from: 3600  # 1 hour lookback
+              from: 21600  # 6 hour lookback
               to: 0
             datasourceUid: P3C6603E967DC8568
             model:
-              query: 'SELECT count(DISTINCT "outputs.p1") FROM "xymd1" WHERE "device.name"=''solar_heater'' AND time >= now() - 1h'
+              query: 'SELECT count("outputs.p1") FROM "xymd1" WHERE "device.name"=''solar_heater'' AND "outputs.p1"=true AND time >= now() - 6h'
+              rawQuery: true
+              resultFormat: time_series
+          - refId: solar_kw
+            queryType: ''
+            relativeTimeRange:
+              from: 21600  # 6 hour lookback
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: 'SELECT mean("ap") FROM "inverter" WHERE time >= now() - 6h'
+              rawQuery: true
+              resultFormat: time_series
+          - refId: tank_top
+            queryType: ''
+            relativeTimeRange:
+              from: 21600  # 6 hour lookback
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: 'SELECT max("t2") FROM "xymd1" WHERE "device.name"=''solar_heater'' AND time >= now() - 6h'
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -264,25 +337,147 @@ groups:
             datasourceUid: __expr__
             model:
               type: classic_conditions
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: A
               conditions:
                 - evaluator:
-                    params: [1]  # Only one distinct state = stuck
-                    type: lte
+                    params: [100]  # ~2x the ~48 samples pure kick leaves in 6h
+                    type: lt
                   operator:
                     type: and
                   query:
-                    params: [solar_state]
+                    params: [pump_on]
                   reducer:
                     type: last
                   type: query
-              expression: solar_state
-        noDataState: NoData
+                - evaluator:
+                    params: [1.5]  # kW mean over 6h => ~9 kWh harvested: clearly sunny
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [solar_kw]
+                  reducer:
+                    type: last
+                  type: query
+                - evaluator:
+                    params: [55]  # electric cutoff is 50 degC; above 55 means solar did work
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [tank_top]
+                  reducer:
+                    type: last
+                  type: query
+              expression: pump_on
+        noDataState: OK
         execErrState: OK
         for: 1h
         annotations:
-          summary: "☀️ Solar Circulation Pump May Be Stuck"
-          description: "Solar circulation pump has not changed state in the last hour. Check if pump is functioning correctly."
+          summary: "☀️ Solar Circulation Idle While Sunny"
+          description: "The solar pump has run for under ~2 minutes in the last 6 hours while the PV inverter averaged over 1.5 kW and the boiler top stayed below 55°C. Only the SR-04 anti-seize kick is moving the pump. Check the collector probe (t3) against the actual collector temperature, then the pump and the SR-04 delta settings."
         labels:
           severity: warning
+          system: boiler
+          component: solar
+
+      # --- No solar contribution on a sunny day ---
+      #
+      # The strongest available signal, and independent of `outputs.p1` entirely:
+      # on a day with real PV yield, a boiler top that never rises above the
+      # electric cutoff proves 100% of the heat was electric.
+      #
+      #   * 50.0 degC is the electric cutoff (`comfortMin: 47` + `hysteresis: 3`).
+      #     Through the whole 2026-06-08..2026-08-09 outage `max(t2)` was pinned at
+      #     exactly 50.0 every single day; before it, good days reached 61-71 degC.
+      #     `lt 50.5` allows half a degree of overshoot/measurement noise.
+      #   * mean(ap) > 1.3 kW over 12 h means >= ~15.6 kWh landed inside the window.
+      #     A full solar day here is 20-26 kWh, so this can only be satisfied by a
+      #     window that covers most of one sunny day - which is what makes a 12 h
+      #     rolling window behave like a daily check without needing a fixed
+      #     evaluation time. A 24 h window was tried first and rejected: it straddles
+      #     two days, so one dull day plus the next sunny morning fired it.
+      #   * Dormant in winter by design: 15.6 kWh in 12 h is not reachable, so this
+      #     rule simply never evaluates true and does not need a seasonal mute.
+      #
+      # Verified by replay against production InfluxDB, hourly evaluation:
+      #   2026-04-25..2026-06-07 (44 healthy days): 1 alert day, 2026-05-13 - a day
+      #     that genuinely harvested 22.2 kWh of PV while the collector peaked at
+      #     51.7 degC and the tank never left 50.0. Accepted as a true positive.
+      #   2026-06-08..2026-08-09 (63 outage days): 56 alert days, first alert on
+      #     2026-06-08 - day one - in the 23:00Z(prev)-11:00Z window
+      #     (solar_kw=1.38, tank_top=49.8). Fires 12:00Z-21:00Z.
+      # Together with boiler-solar-circulation-stuck, 59 of the 63 outage days
+      # raised an alert; the four that did not were low-yield or outage days
+      # (2026-06-12, 2026-07-02, 2026-07-23 and the repair day 2026-08-09).
+      - uid: boiler-solar-no-contribution
+        title: No Solar Contribution On A Sunny Day
+        condition: A
+        data:
+          - refId: tank_top
+            queryType: ''
+            relativeTimeRange:
+              from: 43200  # 12 hour lookback
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: 'SELECT max("t2") FROM "xymd1" WHERE "device.name"=''solar_heater'' AND time >= now() - 12h'
+              rawQuery: true
+              resultFormat: time_series
+          - refId: solar_kw
+            queryType: ''
+            relativeTimeRange:
+              from: 43200  # 12 hour lookback
+              to: 0
+            datasourceUid: P3C6603E967DC8568
+            model:
+              query: 'SELECT mean("ap") FROM "inverter" WHERE time >= now() - 12h'
+              rawQuery: true
+              resultFormat: time_series
+          - refId: A
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: classic_conditions
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: A
+              conditions:
+                - evaluator:
+                    params: [50.5]  # electric cutoff 50 degC + 0.5 degC overshoot allowance
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [tank_top]
+                  reducer:
+                    type: last
+                  type: query
+                - evaluator:
+                    params: [1.3]  # kW mean over 12h => ~15.6 kWh: a genuinely sunny day
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [solar_kw]
+                  reducer:
+                    type: last
+                  type: query
+              expression: tank_top
+        noDataState: OK
+        execErrState: OK
+        for: 1h
+        annotations:
+          summary: "🔆 No Solar Contribution On A Sunny Day"
+          description: "The boiler top has not exceeded the 50°C electric cutoff in 12 hours, yet the PV inverter averaged over 1.3 kW across the same window. All of the tank's heat is coming from the immersion heater and the solar circuit is contributing nothing. Check the collector probe (t3), the pump, and the SR-04 delta settings."
+        labels:
+          severity: high
           system: boiler
           component: solar

--- a/config/grafana/provisioning/alerting/boiler-controller-alerts.yaml
+++ b/config/grafana/provisioning/alerting/boiler-controller-alerts.yaml
@@ -242,59 +242,82 @@ groups:
           system: boiler
           component: energy
 
+
       # --- Solar circuit: why `outputs.p1` state changes cannot be alerted on ---
       #
-      # The SR-04 solar controller runs a `kick` anti-seize function: a 2-3 second
-      # pump pulse roughly every 22 minutes through its daylight window
-      # (`kickOn: 8`, `kickOff: 20`). `outputs.p1` therefore takes BOTH values in
-      # every daylight hour whether or not any heat is being moved, and takes only
-      # ONE value all night when the pump is correctly idle. Any rule shaped like
+      # The SR-04 solar controller runs a `kick` anti-seize function: a short pump
+      # pulse every ~15-27 minutes through its daylight window (`kickOn: 8`,
+      # `kickOff: 20`; the device's own `kickPause` register reads 30 and
+      # `kickTime` 3). `outputs.p1` therefore takes BOTH values in every daylight
+      # hour whether or not any heat is being moved, and takes only ONE value all
+      # night when the pump is correctly idle. Any rule shaped like
       # `count(DISTINCT "outputs.p1") <= 1` is exactly inverted with respect to the
       # failure it is meant to catch. The previous version of this rule was:
       #
       #   SELECT count(DISTINCT "outputs.p1") FROM "xymd1"
       #   WHERE "device.name"='solar_heater' AND time >= now() - 1h    -- lte 1, for 1h
       #
-      # Replayed over 2026-04-25..2026-08-09 (107 days of production data) it fired
-      # on 45% of all hours - every night on all 107 days, 00:00-03:00Z and
-      # 17:00-23:00Z - and fired for ZERO daylight hours during the 63-day solar
-      # outage of 2026-06-08..2026-08-09, when the collector sensor failed and the
+      # Replayed over 2026-04-25..2026-08-09 it fired on ~45% of all hours - every
+      # night on all 107 days - and for ZERO daylight hours during the 63-day solar
+      # outage of 2026-06-08..2026-08-09, when the collector probe failed and the
       # circuit delivered no heat at all. See issue #1472.
       #
       # What replaces it, and why these numbers:
       #
       #   * Pump activity is measured as a SAMPLE COUNT of `outputs.p1 = true`, not
-      #     as state changes. The solar Modbus bus polls roughly every 1.27 s
-      #     (~2830 samples/hour), so 6 hours holds ~17000 samples. Kick alone
-      #     contributes ~8 samples/hour, i.e. ~48 per 6 h window. The `lt 100`
-      #     threshold sits at ~2x pure kick and ~40x below the ~4400 samples a
-      #     healthy sunny morning produces - a wide gap, but it IS tied to the poll
-      #     rate. If the solar bus gains devices or slows down, re-measure and
-      #     retune.
+      #     as state changes. The solar Modbus bus polls every ~1.28 s (2810-2814
+      #     samples/hour), so 6 hours holds ~16900 samples. Kick alone contributes
+      #     3-9 samples/hour, i.e. ~38-48 per 6 h window. `lt 100` sits at roughly
+      #     2x pure kick. It IS tied to the poll rate: if the solar bus gains
+      #     devices or slows down, re-measure and retune.
       #   * PV output gates "the sun is actually out", using an independent sensor
       #     (the SUN2000 inverter) rather than the collector probe `t3`, which is
-      #     the very thing that failed silently in #1472. mean(ap) > 1.5 kW over 6 h
-      #     means ~9 kWh harvested in that window - unambiguously sunny.
+      #     the very thing that failed silently in #1472.
       #   * `max(t2) < 55` suppresses the legitimate case "the tank is already hot,
       #     so the controller has correctly stopped circulating". The electric
       #     heater cuts out at 50 degC (`comfortMin: 47` + `hysteresis: 3` in
       #     config/automations/boiler-controller-config.js), so a top temperature
       #     below 55 means nothing but electricity has heated this tank.
       #
-      # Verified by replay against production InfluxDB, hourly evaluation:
-      #   2026-04-25..2026-06-07 (44 healthy days): 0 alert days
-      #   2026-06-08..2026-08-09 (63 outage days): 50 alert days, first alert on
-      #     2026-06-08 - day one of the failure - in the 03:00-09:00Z window
-      #     (pump_on=38, solar_kw=1.62, tank_top=48.9)
-      #   Fires only between 10:00Z and 17:00Z; never at night.
+      # IMPORTANT - why the PV query is `GROUP BY time(1h)` with `reducer: avg` and
+      # not a bare `mean("ap")`: InfluxQL `mean()` averages over POINTS, not over
+      # time. The inverter publishes on change (`maxMsBetweenReports` 5 min), so it
+      # logs ~60-77 points/hour in daylight against ~11/hour at night, and a bare
+      # `mean()` over a 12 h window is biased high by 30-40%. Bucketing to hourly
+      # means first and averaging those gives a true time-weighted kW, so
+      # `threshold x window hours` really is kWh. Measured on 2026-01-12: bare
+      # `mean("ap")` = 1.286 kW (implying 15.4 kWh) against 12.72 kWh actually
+      # generated; the bucketed form gives 0.75 kW = 9.0 kWh. Getting this wrong
+      # made an earlier draft of `boiler-solar-no-contribution` fire on ordinary
+      # winter days.
       #
-      # noDataState is OK, deliberately: InfluxQL `count()` over a range with no
-      # matching rows returns NO ROWS, not 0 (see config/grafana/CLAUDE.md,
-      # "Staleness / Absence Alerts"). At night `outputs.p1 = true` matches nothing,
-      # so this rule is in NoData for most of every night and `NoData`/`Alerting`
-      # would page nightly. The cost is that a pump wedged fully OFF - kick included -
-      # also produces no rows and cannot be caught here; that case is covered by
+      # Verified by replay against production InfluxDB, hourly evaluation, over the
+      # full two years 2024-08-01..2026-08-09:
+      #   0 alert days outside the outage - none in either winter
+      #   50 of the 63 outage days, first alert on 2026-06-08 - day one of the
+      #     failure - in the window ending 09:00Z (pump_on=38, solar_kw=1.62,
+      #     tank_top=48.9)
+      #   Fires only between 10:00Z and 17:00Z; never at night.
+      # The 13 outage days it misses are days when kick alone happened to exceed
+      # the threshold (across 89 outage windows the pump-on count runs 8..814,
+      # median 38) or PV was too low; `boiler-solar-no-contribution` covers most of
+      # them.
+      #
+      # noDataState is OK. Note the mechanism is NOT "the rule goes NoData at
+      # night": Grafana's classic_conditions combines the per-condition NoData flag
+      # with the SAME operator as the firing flag (v9.5 pkg/expr/classic), so with
+      # `solar_kw` and `tank_top` always returning rows the ANDed NoData collapses
+      # to false. What actually happens is that an empty `pump_on` result makes
+      # that condition evaluate FALSE, so the rule reports OK. Same outcome, and
+      # the same blind spot either way: a pump wedged fully off - kick included -
+      # produces no rows and cannot be caught here. That case is covered by
       # `boiler-solar-no-contribution` below, which never reads `outputs.p1`.
+      #
+      # Both solar rules fire on most of the same days during a real fault, in
+      # overlapping hours, under different alertnames - so a sustained outage pages
+      # roughly twice as often as one rule alone. That is accepted, for the same
+      # reason as the sunseeker connectivity/staleness pair: neither rule can see
+      # the other's failure mode. See config/grafana/CLAUDE.md.
       - uid: boiler-solar-circulation-stuck
         title: Solar Circulation Idle While Sunny
         condition: A
@@ -316,7 +339,7 @@ groups:
               to: 0
             datasourceUid: P3C6603E967DC8568
             model:
-              query: 'SELECT mean("ap") FROM "inverter" WHERE time >= now() - 6h'
+              query: 'SELECT mean("ap") FROM "inverter" WHERE "device.name"=''main'' AND time >= now() - 6h GROUP BY time(1h) fill(0)'
               rawQuery: true
               resultFormat: time_series
           - refId: tank_top
@@ -343,7 +366,7 @@ groups:
               refId: A
               conditions:
                 - evaluator:
-                    params: [100]  # ~2x the ~48 samples pure kick leaves in 6h
+                    params: [100]  # ~2x the ~38-48 samples pure kick leaves in 6h
                     type: lt
                   operator:
                     type: and
@@ -353,14 +376,14 @@ groups:
                     type: last
                   type: query
                 - evaluator:
-                    params: [1.5]  # kW mean over 6h => ~9 kWh harvested: clearly sunny
+                    params: [1.5]  # time-weighted kW over 6h => ~9 kWh harvested: clearly sunny
                     type: gt
                   operator:
                     type: and
                   query:
                     params: [solar_kw]
                   reducer:
-                    type: last
+                    type: avg  # average the hourly buckets -> time-weighted, see comment above
                   type: query
                 - evaluator:
                     params: [55]  # electric cutoff is 50 degC; above 55 means solar did work
@@ -391,28 +414,37 @@ groups:
       # electric cutoff proves 100% of the heat was electric.
       #
       #   * 50.0 degC is the electric cutoff (`comfortMin: 47` + `hysteresis: 3`).
-      #     Through the whole 2026-06-08..2026-08-09 outage `max(t2)` was pinned at
-      #     exactly 50.0 every single day; before it, good days reached 61-71 degC.
-      #     `lt 50.5` allows half a degree of overshoot/measurement noise.
-      #   * mean(ap) > 1.3 kW over 12 h means >= ~15.6 kWh landed inside the window.
-      #     A full solar day here is 20-26 kWh, so this can only be satisfied by a
-      #     window that covers most of one sunny day - which is what makes a 12 h
-      #     rolling window behave like a daily check without needing a fixed
-      #     evaluation time. A 24 h window was tried first and rejected: it straddles
-      #     two days, so one dull day plus the next sunny morning fired it.
-      #   * Dormant in winter by design: 15.6 kWh in 12 h is not reachable, so this
-      #     rule simply never evaluates true and does not need a seasonal mute.
+      #     Through the 2026-06-08..2026-08-09 outage `max(t2)` was exactly 50.0 on
+      #     51 of the 63 days and never above 50.9 except on the 2026-08-09 repair
+      #     day; before it, good days reached 61-71 degC. `lt 50.5` allows half a
+      #     degree of overshoot and measurement noise.
+      #   * `solar_kw > 1.3` is a TIME-WEIGHTED kW over 12 h (see the long note on
+      #     the rule above for why the hourly bucketing is load-bearing), so it
+      #     means ~15.6 kWh actually landed inside the window. A full solar day
+      #     here is 20-26 kWh, so this can only be satisfied by a window covering
+      #     most of one sunny day - which is what makes a 12 h rolling window
+      #     behave like a daily check without needing a fixed evaluation time. A
+      #     24 h window was tried first and rejected: it straddles two days, so one
+      #     dull day plus the next sunny morning fired it.
+      #   * NOT dormant in winter, and it must not be assumed to be. An earlier
+      #     draft used a bare `mean("ap")` and fired on ordinary December-February
+      #     days; with the time-weighted form the winter firings drop away, but
+      #     2026-02-25 still alerts and is a genuine no-contribution day.
       #
-      # Verified by replay against production InfluxDB, hourly evaluation:
-      #   2026-04-25..2026-06-07 (44 healthy days): 1 alert day, 2026-05-13 - a day
-      #     that genuinely harvested 22.2 kWh of PV while the collector peaked at
-      #     51.7 degC and the tank never left 50.0. Accepted as a true positive.
-      #   2026-06-08..2026-08-09 (63 outage days): 56 alert days, first alert on
-      #     2026-06-08 - day one - in the 23:00Z(prev)-11:00Z window
-      #     (solar_kw=1.38, tank_top=49.8). Fires 12:00Z-21:00Z.
+      # Verified by replay against production InfluxDB, hourly evaluation, over the
+      # full two years 2024-08-01..2026-08-09:
+      #   4 alert days outside the outage - 2025-05-28, 2026-02-25, 2026-04-08 and
+      #     2026-05-13. All four are true positives by this rule's own definition:
+      #     PV yield 18.1-24.2 kWh, collector peaking at 49.2-51.8 degC against a
+      #     tank held at 50.0-50.4, i.e. the solar circuit really did contribute
+      #     nothing. Expect roughly two such alerts a year.
+      #   56 of the 63 outage days, first alert on 2026-06-08 - day one - in the
+      #     window ending 11:00Z (solar_kw=1.38, tank_top=49.8). Fires 12:00Z-21:00Z.
       # Together with boiler-solar-circulation-stuck, 59 of the 63 outage days
-      # raised an alert; the four that did not were low-yield or outage days
-      # (2026-06-12, 2026-07-02, 2026-07-23 and the repair day 2026-08-09).
+      # raised an alert. The four that did not: 2026-06-12 and 2026-07-02 (too
+      # little sun to pass the gate), 2026-07-23 (a 7.8 h data outage - note the
+      # bare `mean("ap")` reads 1.66 kW there against 0.42 time-weighted, which is
+      # the point-weighting bias in miniature) and 2026-08-09 (the repair day).
       - uid: boiler-solar-no-contribution
         title: No Solar Contribution On A Sunny Day
         condition: A
@@ -434,7 +466,7 @@ groups:
               to: 0
             datasourceUid: P3C6603E967DC8568
             model:
-              query: 'SELECT mean("ap") FROM "inverter" WHERE time >= now() - 12h'
+              query: 'SELECT mean("ap") FROM "inverter" WHERE "device.name"=''main'' AND time >= now() - 12h GROUP BY time(1h) fill(0)'
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -461,14 +493,14 @@ groups:
                     type: last
                   type: query
                 - evaluator:
-                    params: [1.3]  # kW mean over 12h => ~15.6 kWh: a genuinely sunny day
+                    params: [1.3]  # time-weighted kW over 12h => ~15.6 kWh: a genuinely sunny day
                     type: gt
                   operator:
                     type: and
                   query:
                     params: [solar_kw]
                   reducer:
-                    type: last
+                    type: avg  # average the hourly buckets -> time-weighted, see comment above
                   type: query
               expression: tank_top
         noDataState: OK

--- a/docker/automation-events-processor/CLAUDE.md
+++ b/docker/automation-events-processor/CLAUDE.md
@@ -80,7 +80,8 @@ The service processes automation decision events with this structure:
 ### InfluxDB Output
 Events are transformed into InfluxDB points with:
 - **Measurement**: `automation_status`
-- **Tags**: `service` (bot name), `type` (status)
+- **Tags**: `service` (bot name), `type` (status), `reason`, `controlMode` — see the Field Type Mapping
+  note below; `reason`/`controlMode` are tags, not fields
 - **Fields**: Decision data, state data, temperature readings
 - **Timestamp**: Event timestamp from `_tz` field
 
@@ -108,11 +109,18 @@ The service validates all incoming events:
 
 | Event Field | InfluxDB Type | Format | Example |
 |-------------|---------------|---------|---------|
-| reason | stringField | `"value"` | `"comfort_heating_insufficient"` |
-| controlMode | stringField | `"value"` | `"automatic"` |
-| manualOverrideExpires | intField/stringField | `123i` or `"null"` | `1726411800000i` |
+| reason | **tag** | `key=value` | `reason=comfort_heating_insufficient` |
+| controlMode | **tag** | `key=value` | `controlMode=automatic` |
+| manualOverrideExpires | intField | `123i` (**`0i` when null**) | `1726411800000i` |
 | heaterState | booleanField | `T`/`F` | `T` |
+| solarCirculation | booleanField | `T`/`F` | `T` |
 | temperatures.* | floatField | `45.2` | `45.2` |
+
+**`reason` and `controlMode` are tags, not fields** (`processor.js` calls `.tag()`, not
+`.stringField()`). Consequences for queries: `SELECT count("reason")` returns **nothing**, so filter on
+them (`WHERE reason =~ /.*emergency.*/`) and count a real field such as `count("heaterState")`.
+`SHOW FIELD KEYS` still lists `reason`/`controlMode` as string fields — pre-#1041 residue holding no
+recent points. See `docs/influxdb-schema.md`.
 
 ## Testing
 

--- a/docker/automations/docs/boiler-controller.md
+++ b/docker/automations/docs/boiler-controller.md
@@ -61,13 +61,50 @@ homy/features/relay/solar_heater_electric_heater/status # Solar controller elect
 
 ## Automation Logic
 
-### Electric Heater Schedule (`boilerOnSchedule`)
-- **Type:** `solar-emitter`
-- **Location:** 42.1354°N, 24.7453°E
-- **Schedule:**
-  - **Turn ON:** Golden hour (sunset)
-  - **Turn OFF:** Nadir (solar midnight)
-- **Implementation:** `config.js:268-281`
+### Electric Heater Control (`boilerController`)
+
+The heater is **threshold-based, not scheduled**. The legacy `boilerOnSchedule` `solar-emitter` bot
+(ON at golden hour, OFF at nadir) was removed in `11ed714` and no longer exists.
+
+- **Type:** `boiler-controller` (`docker/automations/bots/boiler-controller.js`)
+- **Configuration:** `config/automations/boiler-controller-config.js`
+- **Inputs:** boiler top/bottom temperature, solar collector temperature, service-room ambient, and
+  the solar circulation pump state — all via `homy/features/...` topics
+- **Output:** `homy/features/relay/service_boiler_contactor/set`
+- **Status:** `homy/automation/boiler_controller/status`, forwarded to InfluxDB
+  (`automation_status`) by `automation-events-processor`
+
+**Live thresholds** (`boiler-controller-config.js`):
+
+| Setting | Value | Meaning |
+|---|---|---|
+| `maxSafe` | 85 °C | Safety shutoff |
+| `comfortMin` | 47 °C | Heat below this |
+| `hysteresis` | 3 °C | Stop at `comfortMin + hysteresis` = **50 °C** |
+| `emergencyMin` | 30 °C | Emergency heating below this |
+| `solarAdvantageMin` | 5 °C | Collector this far above tank top ⇒ defer to solar |
+| `solarDisadvantageMax` | -100 °C | Effectively disables the "solar insufficient, boost" branch |
+| `manualOverrideExpiry` | 24 h | Manual/vacation modes fall back to `automatic` after this |
+
+**Decision order** (first match wins, `makeDecision()` in the bot):
+
+1. Manual override active (`manual_on` / `manual_off` / `vacation_*`) → forced state
+2. `top >= maxSafe` → OFF, `safety_shutoff_overheated`
+3. `top < emergencyMin` → ON, `emergency_heating_top_cold`
+4. `bottom < emergencyMin` → ON, `emergency_heating_bottom_cold`
+5. `top < comfortMin` → ON, `comfort_heating_insufficient`
+6. `collector - top >= solarAdvantageMin` **and** the pump is circulating → OFF, `solar_priority_available`
+7. `collector - top <= solarDisadvantageMax` → ON, `solar_insufficient_boost_needed`
+8. `top >= comfortMin + hysteresis` → OFF, `temperature_sufficient`
+9. Otherwise hold the current state, `hysteresis_zone_maintain_{true,false}`
+
+**Control modes** (`homy/features/control_mode/boiler_controller/set`): `automatic`, `manual_on`,
+`manual_off`, `vacation_3d`, `vacation_5d`, `vacation_7d`, `vacation_10d`, `vacation_14d`.
+
+The 50 °C cutout from step 8 is what makes `max(t2)` a usable solar-contribution signal: a day whose
+top temperature never exceeds 50 °C got all of its heat from the immersion heater. That is the basis
+of the `boiler-solar-no-contribution` alert — see
+`config/grafana/dashboards/BOILER_CONTROLLER_README.md`.
 
 ### Solar System (External Controller)
 - **External solar controller** manages solar heating logic independently
@@ -98,24 +135,38 @@ homy/features/relay/solar_heater_electric_heater/status # Solar controller elect
    - Provides electric heater recommendation (not used for actual control)
    - Operates independently of home automation
 
-2. **Home Automation Electric Control:**
+2. **Home Automation Electric Control (`boilerController` bot):**
    - Controls electric heater contactor via relay
-   - Uses time-based solar schedule (sunset to midnight)
-   - Ignores external controller's electric heater recommendation
-   - Provides manual override through Home Assistant
+   - Threshold-based on the tank temperatures reported by the external controller; no time schedule
+   - Reads the pump state (`outputs.p1`) so it can defer to solar, but ignores the external
+     controller's electric heater recommendation (`outputs.p6`)
+   - Provides manual override and vacation modes through Home Assistant
 
 ### Operation Flow
 1. **Temperature monitoring:** All readings come from external solar controller
 2. **Solar heating:** External controller handles circulation automatically
-3. **Electric heating:** Home automation handles scheduling independently
+3. **Electric heating:** `boilerController` decides on every temperature update, using the thresholds
+   above — it defers to solar when the collector is at least 5 °C above the tank top *and* the pump
+   is running, and otherwise holds the top between 47 °C and 50 °C
 4. **Energy tracking:** Power consumption monitored separately via energy meter
 5. **Manual override:** Available through Home Assistant for electric heater only
 
+### Known blind spot
+
+The bot cannot tell a working solar circuit from a broken one: it only sees the collector temperature
+the external controller reports. When that probe failed in June 2026 it read ~35 °C against >110 °C
+actual, so both the SR-04 and the bot correctly concluded there was no solar advantage and the
+immersion heater carried the entire load for 63 days. Detection lives in the Grafana alerts
+(`boiler-solar-circulation-stuck`, `boiler-solar-no-contribution`), not in this bot — see issue #1472
+and `config/grafana/dashboards/BOILER_CONTROLLER_README.md`.
+
 ## Configuration Files
 
-- **Main config:** `config/automations/config.js:268-308`
+- **Bot config:** `config/automations/boiler-controller-config.js`
+- **Bot implementation:** `docker/automations/bots/boiler-controller.js`
 - **Feature mappings:** `config/automations/features.js:797-846`  
-- **HA discovery:** `config/automations/ha_discovery.js:852-924`
+- **HA discovery:** `config/automations/ha_discovery.js` — contactor switch (~:876), temperature
+  sensors (~:944-962), control-mode select (~:1017)
 
 ## Safety Features
 

--- a/docker/automations/docs/boiler-controller.md
+++ b/docker/automations/docs/boiler-controller.md
@@ -84,7 +84,7 @@ The heater is **threshold-based, not scheduled**. The legacy `boilerOnSchedule` 
 | `emergencyMin` | 30 °C | Emergency heating below this |
 | `solarAdvantageMin` | 5 °C | Collector this far above tank top ⇒ defer to solar |
 | `solarDisadvantageMax` | -100 °C | Effectively disables the "solar insufficient, boost" branch |
-| `manualOverrideExpiry` | 24 h | Manual/vacation modes fall back to `automatic` after this |
+| `manualOverrideExpiry` | 24 h | Default expiry for `manual_on`/`manual_off`; an object payload's `duration` overrides it. **Vacation modes do not use it** — they expire after `days × 24 − 6` hours (66 / 114 / 162 / 234 / 330 h) |
 
 **Decision order** (first match wins, `makeDecision()` in the bot):
 
@@ -111,7 +111,7 @@ of the `boiler-solar-no-contribution` alert — see
 - **Circulation pump** controlled directly by external controller
 - **Temperature monitoring** provided by external controller via Modbus
 - **Electric heater recommendation** provided as status (outputs.p6) but not used for control
-- **Completely independent** of home automation electric heater schedule
+- **Completely independent** of the home automation electric heater control
 
 ## Home Assistant Integration
 
@@ -154,7 +154,7 @@ of the `boiler-solar-no-contribution` alert — see
 ### Known blind spot
 
 The bot cannot tell a working solar circuit from a broken one: it only sees the collector temperature
-the external controller reports. When that probe failed in June 2026 it read ~35 °C against >110 °C
+the external controller reports. When that probe failed on 2026-06-08 it read ~35 °C against >110 °C
 actual, so both the SR-04 and the bot correctly concluded there was no solar advantage and the
 immersion heater carried the entire load for 63 days. Detection lives in the Grafana alerts
 (`boiler-solar-circulation-stuck`, `boiler-solar-no-contribution`), not in this bot — see issue #1472
@@ -166,7 +166,7 @@ and `config/grafana/dashboards/BOILER_CONTROLLER_README.md`.
 - **Bot implementation:** `docker/automations/bots/boiler-controller.js`
 - **Feature mappings:** `config/automations/features.js:797-846`  
 - **HA discovery:** `config/automations/ha_discovery.js` — contactor switch (~:876), temperature
-  sensors (~:944-962), control-mode select (~:1017)
+  sensors (~:942-989 — boiler low/high, solar panel, service room), control-mode select (~:1017)
 
 ## Safety Features
 

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -393,13 +393,27 @@ trade-off of both firing for one real outage.
 
 #### `automation_status` Measurement
 **Source**: automation-events-processor → `homy/automation/+/status` topics
-**Status**: ⚠️ **Currently not available** - Service experiencing InfluxDB authentication errors
-**Tag Structure**: `service: [controller_name]`, `type: "status"`
+**Status**: ✅ **Being written** - verified 2026-08-09: 1101 points for `service='boilerController'` in
+the preceding 7 days, most recent at `2026-08-09T11:39:16Z`. An earlier note in this file claimed the
+measurement was unavailable because of InfluxDB authentication errors; that has not been true for some
+time. The two alert rules that read it - `boiler-controller-emergency-heating` and
+`boiler-controller-not-responding` - see live data (32 points matching `reason =~ /.*emergency.*/` in
+the 30 days to 2026-08-09; 6 points in the trailing 30 minutes).
+**Tag Structure**: `service: [controller_name]`, `type: "status"`, `source`, plus `reason` and
+`controlMode` (see below)
 **Key Fields**:
 - **Controller Decisions** (Source of Truth):
-  - `reason` (string): Decision reasoning (e.g., "comfort_heating_insufficient", "solar_priority_available")
-  - `controlMode` (string): Current operation mode ("automatic", "manual_on", "manual_off", "vacation_3d", etc.)
-  - `manualOverrideExpires` (timestamp): When manual mode expires (null for automatic mode)
+  - `reason` (**tag**, not a field): Decision reasoning. Observed values: `comfort_heating_insufficient`,
+    `emergency_heating_bottom_cold`, `emergency_heating_top_cold`, `hysteresis_zone_maintain_false`,
+    `hysteresis_zone_maintain_true`, `solar_priority_available`, `temperature_sufficient`
+  - `controlMode` (**tag**, not a field): Current operation mode ("automatic", "manual_on", "manual_off", "vacation_3d", etc.)
+  - `manualOverrideExpires` (integer field): When manual mode expires (0 for automatic mode)
+
+  **Gotcha**: `reason` and `controlMode` are written as tags by
+  `docker/automation-events-processor/processor.js`, so `SELECT count("reason")` returns nothing.
+  `SHOW FIELD KEYS` still lists `reason`/`controlMode` as string fields - those are leftovers from an
+  older schema and hold no recent points. Filter on them (`WHERE reason =~ /.*emergency.*/`) and count
+  a real field (`count(*)`, `count("heaterState")`) instead.
 - **Controller View** (For Correlation):
   - `heaterState` (boolean): Controller's intended relay state
   - `solarCirculation` (boolean): Solar pump state as seen by controller

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -156,9 +156,24 @@ query this measurement's `v` field. See
 **Source**: modbus-serial-inverter → Solar PV inverter (TCP connection)
 **Tag Structure**: `bus: "inverter"`, `device: "main"`
 **Key Fields**:
+- `ap` (float): Instantaneous AC output power in **kW** (`sun2000.js` divides the raw register by 1000)
+- `daily_p` (float): Energy generated since local midnight (kWh); resets at the day boundary
 - `total_p` (float): Accumulated PV energy production (kWh)
-- Additional inverter metrics: power output, system status
-**Use Cases**: Solar PV production monitoring, grid integration analysis
+- Additional inverter metrics: `eff`, `freq`, `pf`, `rp`, `temp`, `ins`
+**Cadence**: published on change with `maxMsBetweenReports` 5 min, so point density tracks daylight —
+roughly 60-77 points/hour while generating against ~11/hour at night.
+
+**Gotcha for alerting**: because the cadence is uneven, InfluxQL `mean("ap")` (which averages over
+*points*, not over time) is biased high by 30-40% on any window spanning night. Measured on
+2026-01-12, a 12 h window gives `mean("ap")` = 1.286 kW — implying 15.4 kWh — against 12.72 kWh
+actually generated. For a time-weighted kW use `GROUP BY time(1h) fill(0)` and average the buckets
+(`reducer: avg`), which gives 0.750 kW = 9.0 kWh; or use `integral("ap", 1h)` for kWh directly. Both
+solar circuit alert rules depend on this — see
+`config/grafana/dashboards/BOILER_CONTROLLER_README.md`.
+
+**Use Cases**: Solar PV production monitoring, grid integration analysis, and as an *independent*
+"is the sun out" gate for solar thermal alerting (the collector probe `t3` cannot serve that purpose,
+because it is the sensor that fails — issue #1472)
 
 #### `switches` Measurement
 **Source**: modbus-serial-dry-switches → Digital I/O monitoring (direct InfluxDB write)
@@ -413,7 +428,8 @@ the 30 days to 2026-08-09; 6 points in the trailing 30 minutes).
   `docker/automation-events-processor/processor.js`, so `SELECT count("reason")` returns nothing.
   `SHOW FIELD KEYS` still lists `reason`/`controlMode` as string fields - those are leftovers from an
   older schema and hold no recent points. Filter on them (`WHERE reason =~ /.*emergency.*/`) and count
-  a real field (`count(*)`, `count("heaterState")`) instead.
+  a real field instead. Prefer `count("heaterState")` over `count(*)`: `count(*)` returns one column
+  per field, which in a `classic_conditions` alert becomes a multi-series frame.
 - **Controller View** (For Correlation):
   - `heaterState` (boolean): Controller's intended relay state
   - `solarCirculation` (boolean): Solar pump state as seen by controller
@@ -435,7 +451,9 @@ the 30 days to 2026-08-09; 6 points in the trailing 30 minutes).
 
 ### Data to Ignore
 - ❌ `outputs.p6` (solar_heater_electric_heater flag) - Misconfigured
-- ⚠️ Solar PV data not directly applicable to boiler heating (different electrical network)
+- ⚠️ Solar PV data does not *heat* the boiler (different electrical network), so it must not be read as
+  a boiler energy input. It is nonetheless the correct proxy for "the sun is out" when alerting on the
+  solar **thermal** circuit, and both solar circuit alert rules use it that way.
 
 ## Query Examples (Verified)
 


### PR DESCRIPTION
Fixes #1472

The solar circuit delivered zero heat from 2026-06-08 to 2026-08-09 — 63 days — without a single alert. The cause was hardware (the collector probe `t3` read ~35 °C against >110 °C actual, so the SR-04 never saw `collector >= tank_bottom + delta`). The application behaved correctly throughout. **The bug was that the monitoring could not see it.**

## The old rule was inverted

The SR-04 pulses the pump for a few seconds every ~15–27 minutes across its daylight window (`kick` anti-seize, `kickOn: 8` / `kickOff: 20`). So `count(DISTINCT "outputs.p1")` is 2 in **every** daylight hour whether or not heat is moving, and 1 all night when the pump is correctly idle.

Replayed over 107 days of production InfluxDB data, `count(DISTINCT "outputs.p1") <= 1, for: 1h` fired on **~45% of all hours** — every night on all 107 days — and on **zero** daylight hours through the entire 63-day outage.

## Replacements

Both measure *pump run time* rather than state changes, and gate on PV inverter output (`inverter.ap`, `device.name='main'`) rather than the collector probe that failed silently.

| Rule | Window | Conditions | Replay, 2024-08-01…2026-08-09 (two years, two winters) |
|---|---|---|---|
| `boiler-solar-circulation-stuck` <br>*Solar Circulation Idle While Sunny* | 6 h | `count(outputs.p1=true) < 100` **and** time-weighted `mean(inverter.ap) > 1.5 kW` **and** `max(t2) < 55 °C`, `for: 1h` | **0** alert days outside the outage across the full two years; **50** of the 63 outage days, first on **2026-06-08 — day one**. Fires only 10:00Z–17:00Z. |
| `boiler-solar-no-contribution` <br>*No Solar Contribution On A Sunny Day* (new) | 12 h | `max(t2) < 50.5 °C` **and** time-weighted `mean(inverter.ap) > 1.3 kW`, `for: 1h` | **4** alert days outside the outage across two years — all true positives, see below; **56** of the 63 outage days, first on **2026-06-08**. Fires 12:00Z–21:00Z. |

Together they alerted on **59 of the 63** outage days. The four misses: 2026-06-12 and 2026-07-02 (too little sun to pass the gate), 2026-07-23 (a 7.8 h data outage) and 2026-08-09 (the repair day).

A boiler top that never passes the 50 °C electric cutoff (`comfortMin: 47` + `hysteresis: 3`) on a day with real PV yield proves 100% of the heat was electric — the strongest available signal, and it never touches `outputs.p1`.

## The PV gate has to be time-weighted — this is the subtle part

**InfluxQL `mean()` averages over *points*, not over time.** The inverter publishes on change (`maxMsBetweenReports` 5 min), logging ~60–77 points/hour while generating against ~11/hour at night, so a bare `mean("ap")` over a 12 h window is biased high by 30–40%.

The first version of this PR used the bare form, and its claim that `boiler-solar-no-contribution` was *"dormant in winter by design"* was false — it fired on ordinary December–February days. The claim had never been tested, because the original validation window was 44 days in April–June.

Both queries now use `GROUP BY time(1h) fill(0)` with `reducer: avg`, weighting every hour equally. Measured on 2026-01-12:

| form | reading | implied kWh | actual `daily_p` |
|---|---|---|---|
| `mean("ap")` | 1.286 kW | 15.4 kWh | 12.72 kWh |
| bucketed + `avg` | 0.750 kW | 9.0 kWh | 12.72 kWh |

The bucketed form does not fire. Verified verbatim against production: mid-outage 2026-07-15 → 2.333 kW, winter 2026-01-12 → 0.750 kW, a night window → 0.083 kW.

The same bias explains 2026-07-23, which one reviewer flagged as a false miss: the bare mean reads 1.66 kW there against **0.42** time-weighted. The day had a 7.8 h data outage, so the point-mean of the few surviving daylight points looked like a sunny day.

## Design notes

- **PV output, not `t3`, is the "sun is out" gate.** `t3` is the sensor that failed; any rule gated on it stays blind. The inverter is a different device on a different bus.
- **`< 100` samples is tied to the poll rate** (~1.28 s, 2810–2814 samples/hour; kick leaves ~38–48 per 6 h). Note the healthy-day margin is *not* the safety net — daily pump-on totals across healthy days run 70 to 6147, median ~1400, so quiet healthy days sit at or below the threshold for a whole day. The PV gate is what prevents false alarms, and the two-year replay confirms it.
- **`noDataState: OK`, but not for the reason first stated.** A multi-condition `classic_conditions` does *not* go NoData when one input is empty — Grafana v9.5 combines the per-condition NoData flag with the same operator as the firing flag, so under `and` a single empty input among populated ones collapses NoData to false, and the empty condition simply evaluates **false**. Same outcome, same blind spot (a pump wedged fully off, kick included, is invisible to rule 1 — which is why rule 2 never reads `outputs.p1`), but the wrong mechanism had been copied into `config/grafana/CLAUDE.md` as a general pattern.
- **Not dormant in winter.** All four non-outage alert days (2025-05-28, 2026-02-25, 2026-04-08, 2026-05-13) are true positives by the rule's own definition: 18.1–24.2 kWh of PV with the collector peaking at 49.2–51.8 °C against a tank held at 50.0–50.4 °C. Expect roughly two a year.
- **The pair double-pages** during a sustained fault, under different alertnames — accepted for the same reason as the sunseeker connectivity/staleness pair, and now stated on the rules.

## Documentation

- `docs/influxdb-schema.md` and `BOILER_CONTROLLER_README.md` both claimed `automation_status` was unavailable due to InfluxDB authentication errors. **Not true** — verified 2026-08-09: 1101 points for `service='boilerController'` in the preceding 7 days. Corrected, plus: `reason` and `controlMode` are **tags**, not fields, so `SELECT count("reason")` returns nothing; and two rules read the measurement, not three.
- `docker/automations/docs/boiler-controller.md` still documented `boilerOnSchedule` (sunset→nadir), removed in `11ed714`. Replaced with the live threshold-based bot: config values, the 9-step decision order, control modes, and the blind spot that made this failure invisible to it.
- `docs/influxdb-schema.md` gains `ap`, `daily_p`, the inverter publish cadence and the point-vs-time-weighting gotcha.
- `docker/automation-events-processor/CLAUDE.md` still taught `reason`/`controlMode` as string fields.
- `config/grafana/CLAUDE.md` gains a *Duty-Cycle Alerts* pattern covering the anti-seize-pulse trap and the time-weighting trap.

## Done when

- [x] `boiler-solar-circulation-stuck` no longer fires on nights when the pump is correctly idle — replay confines fires to 10:00Z–17:00Z
- [x] A stuck/idle pump during daylight *does* raise an alert — verified by replaying 2026-06-08…08-09; fires on day one
- [x] An alert exists for "no solar contribution on a sunny day", keyed on tank top never exceeding the electric cutoff while PV yield is meaningful — verified against the same window
- [x] Alert thresholds documented alongside the rules, including why the `kick` pulses make naive `outputs.p1` state-change rules unusable
- [x] `docs/influxdb-schema.md` and `BOILER_CONTROLLER_README.md` corrected
- [x] `docker/automations/docs/boiler-controller.md` updated

## Verification method

Hourly aggregates for `xymd1` (`outputs.p1`, `t1`/`t2`/`t3`) and `inverter` (`ap`, `daily_p`) were pulled from production InfluxDB for **2024-08-01…2026-08-09** and each candidate rule replayed at hourly resolution, with `for: 1h` modelled as two consecutive true evaluations and data gaps handled as the live queries handle them (`max()` skips gaps, `fill(0)` zeroes them). Query forms were then re-run verbatim against InfluxDB at specific historical instants to confirm the replay matches what Grafana will actually see.

Reviewed by three independent agents (alert YAML / empirical claims / documentation); this PR includes a second commit fixing what they found.

https://claude.ai/code/session_01Sy836ZA47Gzt1pZRSdFG1S
