### PR TITLE
fix(ioniq): publish TPMS pressures in bar and move alert text and thresholds to bar

### DIFF
--- a/config/automations/config.js
+++ b/config/automations/config.js
@@ -491,7 +491,7 @@ module.exports = {
       // temp_excess gating (issue #1415). The four wheel values in a frame are
       // latched independently, so they are only comparable when all of them
       // refreshed close together, and the comparison only means anything while
-      // the car is rolling. psi_cold / tire_spread_psi are unaffected.
+      // the car is rolling. The cold-pressure signals (psi and bar) are unaffected.
       speedTopics: [
         'ioniq/parsed/bms/2101',                // speed_kph while awake
         'ioniq/parsed/vmcu',                    // speed_kph alongside gear

--- a/config/grafana/dashboards/Ioniq EV/ioniq-overview.json
+++ b/config/grafana/dashboards/Ioniq EV/ioniq-overview.json
@@ -586,7 +586,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Front-left tire pressure — RAW, temperature-uncompensated (tpms \"fl.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_fl_psi_cold, approximately psi - 0.18 x (tempC - 15)), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
+      "description": "Front-left tire pressure — RAW, temperature-uncompensated (tpms \"fl.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_fl_bar_cold, approximately (psi - 0.18 x (tempC - 15)) / 14.5038), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -660,7 +660,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Front-right tire pressure — RAW, temperature-uncompensated (tpms \"fr.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_fr_psi_cold, approximately psi - 0.18 x (tempC - 15)), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
+      "description": "Front-right tire pressure — RAW, temperature-uncompensated (tpms \"fr.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_fr_bar_cold, approximately (psi - 0.18 x (tempC - 15)) / 14.5038), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -734,7 +734,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Rear-left tire pressure — RAW, temperature-uncompensated (tpms \"rl.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_rl_psi_cold, approximately psi - 0.18 x (tempC - 15)), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
+      "description": "Rear-left tire pressure — RAW, temperature-uncompensated (tpms \"rl.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_rl_bar_cold, approximately (psi - 0.18 x (tempC - 15)) / 14.5038), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -808,7 +808,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Rear-right tire pressure — RAW, temperature-uncompensated (tpms \"rr.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_rr_psi_cold, approximately psi - 0.18 x (tempC - 15)), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
+      "description": "Rear-right tire pressure — RAW, temperature-uncompensated (tpms \"rr.psi\", converted from psi to bar in-query: x0.0689476). TPMS only transmits while the wheels turn, so this stays frozen at its last reading while the car is parked — expected, not stale. The colour bands (red <1.79, orange <2.07, green 2.07-2.90, red >2.90 bar) are a rough sanity guide ONLY. The shipped TPMS alerts do NOT evaluate this value: they evaluate cold-normalised pressure (derived/tire_rr_bar_cold, approximately (psi - 0.18 x (tempC - 15)) / 14.5038), which currently runs ~0.28 bar BELOW raw. Tile colour and alert state can therefore legitimately disagree — trust the alert. Cold-normalised per-wheel pressure belongs on the Ioniq EV - Tires dashboard.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/config/grafana/dashboards/Ioniq EV/ioniq-tires.json
+++ b/config/grafana/dashboards/Ioniq EV/ioniq-tires.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": "Hyundai Ioniq Electric — tire pressure and temperature detail: per-wheel temperature-normalised cold-equivalent pressure in bar, per-wheel temperature excess, inter-wheel pressure spread, and trend history. Derived from the ioniq-tpms bot's derived/tire_* signals; the pressure panels and the shipped alerts read the bar series (derived/tire_*_bar_cold), the parallel psi series is retained for history.",
+  "description": "Hyundai Ioniq Electric — tire pressure and temperature detail: per-wheel temperature-normalised cold-equivalent pressure in bar, per-wheel temperature excess, inter-wheel pressure spread, and trend history. The pressure panels and the shipped alerts read the bar series (derived/tire_*_bar_cold, derived/tire_spread_bar) from issue #1478 onward. The parallel psi series is still written but no panel reads it, so pressure history from before that cutover is not visible here — it is still queryable as derived/tire_*_psi_cold, at 14.5038 psi per bar.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -78,7 +78,7 @@
               }
             ]
           },
-          "unit": "pressurebar"
+          "unit": "suffix: bar"
         },
         "overrides": []
       },
@@ -152,7 +152,7 @@
               }
             ]
           },
-          "unit": "pressurebar"
+          "unit": "suffix: bar"
         },
         "overrides": []
       },
@@ -226,7 +226,7 @@
               }
             ]
           },
-          "unit": "pressurebar"
+          "unit": "suffix: bar"
         },
         "overrides": []
       },
@@ -300,7 +300,7 @@
               }
             ]
           },
-          "unit": "pressurebar"
+          "unit": "suffix: bar"
         },
         "overrides": []
       },
@@ -345,7 +345,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "How much hotter the front-left tire runs than the fleet baseline (derived/tire_fl_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C (a dragging brake or under-inflation signature). Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
+      "description": "How much hotter the front-left tire runs than the mean of the other three wheels (derived/tire_fl_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C sustained for 10 min (a dragging brake, a failing bearing, or under-inflation). The bot suppresses this signal unless all four wheels refreshed within one window and the car rolled recently, so gaps are expected. Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -411,7 +411,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "How much hotter the front-right tire runs than the fleet baseline (derived/tire_fr_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C (a dragging brake or under-inflation signature). Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
+      "description": "How much hotter the front-right tire runs than the mean of the other three wheels (derived/tire_fr_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C sustained for 10 min (a dragging brake, a failing bearing, or under-inflation). The bot suppresses this signal unless all four wheels refreshed within one window and the car rolled recently, so gaps are expected. Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -477,7 +477,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "How much hotter the rear-left tire runs than the fleet baseline (derived/tire_rl_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C (a dragging brake or under-inflation signature). Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
+      "description": "How much hotter the rear-left tire runs than the mean of the other three wheels (derived/tire_rl_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C sustained for 10 min (a dragging brake, a failing bearing, or under-inflation). The bot suppresses this signal unless all four wheels refreshed within one window and the car rolled recently, so gaps are expected. Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -543,7 +543,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "How much hotter the rear-right tire runs than the fleet baseline (derived/tire_rr_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C (a dragging brake or under-inflation signature). Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
+      "description": "How much hotter the rear-right tire runs than the mean of the other three wheels (derived/tire_rr_temp_excess). Healthy near 0 °C; the \"tire hot\" alert fires above 8 °C sustained for 10 min (a dragging brake, a failing bearing, or under-inflation). The bot suppresses this signal unless all four wheels refreshed within one window and the car rolled recently, so gaps are expected. Driving-gated like the pressure tiles — last known value shown via a 30-day lookback while parked.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -668,7 +668,7 @@
               }
             ]
           },
-          "unit": "pressurebar"
+          "unit": "suffix: bar"
         },
         "overrides": []
       },
@@ -742,7 +742,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Per-wheel temperature-excess trend (derived/tire_*_temp_excess). Healthy near 0 °C; the dashed line at 8 °C is the \"tire hot\" alert threshold. One wheel diverging upward points at that corner (brake drag or low pressure). Driving-gated + fill(previous): fill(previous) only carries a value forward from within the queried window, so a fully-parked 6 h window can render this panel completely EMPTY rather than flat — that is expected, not a broken feed; the per-wheel temp-excess stat tiles above show the last known value via a 30-day lookback.",
+      "description": "Per-wheel temperature-excess trend (derived/tire_*_temp_excess) — each wheel against the mean of the other three. Healthy near 0 °C; the dashed line at 8 °C is the \"tire hot\" alert threshold. One wheel diverging upward points at that corner (brake drag or low pressure). Driving-gated + fill(previous): fill(previous) only carries a value forward from within the queried window, so a fully-parked 6 h window can render this panel completely EMPTY rather than flat — that is expected, not a broken feed; the per-wheel temp-excess stat tiles above show the last known value via a 30-day lookback.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -867,7 +867,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Largest cold-pressure difference between any two wheels (derived/tire_spread_bar). Lower is better — a healthy set sits within ~0.14-0.20 bar. The orange band at 0.21 bar IS the ioniq-tpms-spread-high alert threshold; the red band at 0.34 bar is a sanity guide only. Driving-gated + fill(previous): fill(previous) only carries a value forward from within the queried window, so a fully-parked 6 h window can render this panel completely EMPTY rather than flat — that is expected, not a broken feed.",
+      "description": "Largest cold-pressure difference between any two wheels (derived/tire_spread_bar). Lower is better — the observed healthy baseline is ~0.08 bar. The orange band at 0.21 bar IS the ioniq-tpms-spread-high alert threshold; the red band at 0.34 bar is a sanity guide only. Driving-gated + fill(previous): fill(previous) only carries a value forward from within the queried window, so a fully-parked 6 h window can render this panel completely EMPTY rather than flat — that is expected, not a broken feed.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -903,7 +903,7 @@
               "mode": "line"
             }
           },
-          "decimals": 2,
+          "decimals": 3,
           "mappings": [],
           "min": 0,
           "thresholds": {
@@ -923,7 +923,7 @@
               }
             ]
           },
-          "unit": "pressurebar"
+          "unit": "suffix: bar"
         },
         "overrides": []
       },

--- a/config/grafana/dashboards/Ioniq EV/ioniq-tires.json
+++ b/config/grafana/dashboards/Ioniq EV/ioniq-tires.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": "Hyundai Ioniq Electric — tire pressure and temperature detail: per-wheel temperature-normalised cold-equivalent pressure, per-wheel temperature excess, inter-wheel pressure spread, and trend history. Derived from PR0's derived/tire_* bot signals (deployed to prod).",
+  "description": "Hyundai Ioniq Electric — tire pressure and temperature detail: per-wheel temperature-normalised cold-equivalent pressure in bar, per-wheel temperature excess, inter-wheel pressure spread, and trend history. Derived from the ioniq-tpms bot's derived/tire_* signals; the pressure panels and the shipped alerts read the bar series (derived/tire_*_bar_cold), the parallel psi series is retained for history.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -49,13 +49,13 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Temperature-normalised cold-equivalent pressure for the front-left tire (derived/tire_fl_psi_cold) — this IS the value the shipped TPMS alerts evaluate (low <30, critical <26, over-inflated >42 psi). The 36 psi cold placard is the inflation target; the green 30-42 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
+      "description": "Temperature-normalised cold-equivalent pressure for the front-left tire (derived/tire_fl_bar_cold) — this IS the value the shipped TPMS alerts evaluate (low <2.07, critical <1.79, over-inflated >2.90 bar). The 2.5 bar cold placard is the inflation target; the green 2.07-2.90 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -66,19 +66,19 @@
               },
               {
                 "color": "orange",
-                "value": 26
+                "value": 1.79
               },
               {
                 "color": "green",
-                "value": 30
+                "value": 2.07
               },
               {
                 "color": "red",
-                "value": 42
+                "value": 2.9
               }
             ]
           },
-          "unit": "pressurepsi"
+          "unit": "pressurebar"
         },
         "overrides": []
       },
@@ -110,12 +110,12 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"fl_psi_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fl_psi_cold' AND time > now() - 30d",
+          "query": "SELECT last(\"value\") AS \"fl_bar_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fl_bar_cold' AND time > now() - 30d",
           "rawQuery": true,
           "refId": "A"
         }
       ],
-      "title": "FL psi (cold)",
+      "title": "FL bar (cold)",
       "type": "stat"
     },
     {
@@ -123,13 +123,13 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Temperature-normalised cold-equivalent pressure for the front-right tire (derived/tire_fr_psi_cold) — this IS the value the shipped TPMS alerts evaluate (low <30, critical <26, over-inflated >42 psi). The 36 psi cold placard is the inflation target; the green 30-42 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
+      "description": "Temperature-normalised cold-equivalent pressure for the front-right tire (derived/tire_fr_bar_cold) — this IS the value the shipped TPMS alerts evaluate (low <2.07, critical <1.79, over-inflated >2.90 bar). The 2.5 bar cold placard is the inflation target; the green 2.07-2.90 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -140,19 +140,19 @@
               },
               {
                 "color": "orange",
-                "value": 26
+                "value": 1.79
               },
               {
                 "color": "green",
-                "value": 30
+                "value": 2.07
               },
               {
                 "color": "red",
-                "value": 42
+                "value": 2.9
               }
             ]
           },
-          "unit": "pressurepsi"
+          "unit": "pressurebar"
         },
         "overrides": []
       },
@@ -184,12 +184,12 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"fr_psi_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fr_psi_cold' AND time > now() - 30d",
+          "query": "SELECT last(\"value\") AS \"fr_bar_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fr_bar_cold' AND time > now() - 30d",
           "rawQuery": true,
           "refId": "A"
         }
       ],
-      "title": "FR psi (cold)",
+      "title": "FR bar (cold)",
       "type": "stat"
     },
     {
@@ -197,13 +197,13 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Temperature-normalised cold-equivalent pressure for the rear-left tire (derived/tire_rl_psi_cold) — this IS the value the shipped TPMS alerts evaluate (low <30, critical <26, over-inflated >42 psi). The 36 psi cold placard is the inflation target; the green 30-42 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
+      "description": "Temperature-normalised cold-equivalent pressure for the rear-left tire (derived/tire_rl_bar_cold) — this IS the value the shipped TPMS alerts evaluate (low <2.07, critical <1.79, over-inflated >2.90 bar). The 2.5 bar cold placard is the inflation target; the green 2.07-2.90 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -214,19 +214,19 @@
               },
               {
                 "color": "orange",
-                "value": 26
+                "value": 1.79
               },
               {
                 "color": "green",
-                "value": 30
+                "value": 2.07
               },
               {
                 "color": "red",
-                "value": 42
+                "value": 2.9
               }
             ]
           },
-          "unit": "pressurepsi"
+          "unit": "pressurebar"
         },
         "overrides": []
       },
@@ -258,12 +258,12 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"rl_psi_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rl_psi_cold' AND time > now() - 30d",
+          "query": "SELECT last(\"value\") AS \"rl_bar_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rl_bar_cold' AND time > now() - 30d",
           "rawQuery": true,
           "refId": "A"
         }
       ],
-      "title": "RL psi (cold)",
+      "title": "RL bar (cold)",
       "type": "stat"
     },
     {
@@ -271,13 +271,13 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Temperature-normalised cold-equivalent pressure for the rear-right tire (derived/tire_rr_psi_cold) — this IS the value the shipped TPMS alerts evaluate (low <30, critical <26, over-inflated >42 psi). The 36 psi cold placard is the inflation target; the green 30-42 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
+      "description": "Temperature-normalised cold-equivalent pressure for the rear-right tire (derived/tire_rr_bar_cold) — this IS the value the shipped TPMS alerts evaluate (low <2.07, critical <1.79, over-inflated >2.90 bar). The 2.5 bar cold placard is the inflation target; the green 2.07-2.90 band brackets it. DRIVING-GATED: refreshes only when the pressure changes (driving/rotation), so while parked it shows the last known reading via a 30-day lookback — a frozen value is expected, not stale.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -288,19 +288,19 @@
               },
               {
                 "color": "orange",
-                "value": 26
+                "value": 1.79
               },
               {
                 "color": "green",
-                "value": 30
+                "value": 2.07
               },
               {
                 "color": "red",
-                "value": 42
+                "value": 2.9
               }
             ]
           },
-          "unit": "pressurepsi"
+          "unit": "pressurebar"
         },
         "overrides": []
       },
@@ -332,12 +332,12 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"rr_psi_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rr_psi_cold' AND time > now() - 30d",
+          "query": "SELECT last(\"value\") AS \"rr_bar_cold\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rr_bar_cold' AND time > now() - 30d",
           "rawQuery": true,
           "refId": "A"
         }
       ],
-      "title": "RR psi (cold)",
+      "title": "RR bar (cold)",
       "type": "stat"
     },
     {
@@ -609,7 +609,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Cold-equivalent pressure trend for all four wheels (derived/tire_*_psi_cold). Driving-gated: values change only when the car is driven, and fill(previous) carries the last reading across parked gaps, so long flat segments are normal. Dashed reference lines are the alert thresholds (26 critical / 30 low / 42 over-inflated); the 36 psi cold placard is the target inside the green band. However, fill(previous) only carries a value forward from within the queried window: if the window opens before the most recent sample (a fully-parked 6 h stretch with no new reading), this panel can render completely EMPTY rather than flat — that is expected, not a broken feed. The per-wheel last()+30d \"psi (cold)\" stat tiles above are the authoritative current-value source even when this panel shows nothing.",
+      "description": "Cold-equivalent pressure trend for all four wheels (derived/tire_*_bar_cold). Driving-gated: values change only when the car is driven, and fill(previous) carries the last reading across parked gaps, so long flat segments are normal. Dashed reference lines are the alert thresholds (1.79 critical / 2.07 low / 2.90 over-inflated bar); the 2.5 bar cold placard is the target inside the green band. However, fill(previous) only carries a value forward from within the queried window: if the window opens before the most recent sample (a fully-parked 6 h stretch with no new reading), this panel can render completely EMPTY rather than flat — that is expected, not a broken feed. The per-wheel last()+30d \"bar (cold)\" stat tiles above are the authoritative current-value source even when this panel shows nothing.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -645,7 +645,7 @@
               "mode": "dashed"
             }
           },
-          "decimals": 1,
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -656,19 +656,19 @@
               },
               {
                 "color": "orange",
-                "value": 26
+                "value": 1.79
               },
               {
                 "color": "green",
-                "value": 30
+                "value": 2.07
               },
               {
                 "color": "red",
-                "value": 42
+                "value": 2.9
               }
             ]
           },
-          "unit": "pressurepsi"
+          "unit": "pressurebar"
         },
         "overrides": []
       },
@@ -698,7 +698,7 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"fl\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fl_psi_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "query": "SELECT last(\"value\") AS \"fl\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fl_bar_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
           "rawQuery": true,
           "refId": "A",
           "alias": "FL"
@@ -708,7 +708,7 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"fr\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fr_psi_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "query": "SELECT last(\"value\") AS \"fr\" FROM \"ioniq\" WHERE \"group\"='derived/tire_fr_bar_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
           "rawQuery": true,
           "refId": "B",
           "alias": "FR"
@@ -718,7 +718,7 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"rl\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rl_psi_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "query": "SELECT last(\"value\") AS \"rl\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rl_bar_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
           "rawQuery": true,
           "refId": "C",
           "alias": "RL"
@@ -728,7 +728,7 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"rr\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rr_psi_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "query": "SELECT last(\"value\") AS \"rr\" FROM \"ioniq\" WHERE \"group\"='derived/tire_rr_bar_cold' AND $timeFilter GROUP BY time($__interval) fill(previous)",
           "rawQuery": true,
           "refId": "D",
           "alias": "RR"
@@ -867,7 +867,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Largest cold-pressure difference between any two wheels (derived/tire_spread_psi). Lower is better — a healthy set sits within ~2-3 psi. NOTE: there is no shipped alert on this signal; the 3/5 psi bands are a rough sanity guide only, not a mirror of an alert rule. Driving-gated + fill(previous): fill(previous) only carries a value forward from within the queried window, so a fully-parked 6 h window can render this panel completely EMPTY rather than flat — that is expected, not a broken feed.",
+      "description": "Largest cold-pressure difference between any two wheels (derived/tire_spread_bar). Lower is better — a healthy set sits within ~0.14-0.20 bar. The orange band at 0.21 bar IS the ioniq-tpms-spread-high alert threshold; the red band at 0.34 bar is a sanity guide only. Driving-gated + fill(previous): fill(previous) only carries a value forward from within the queried window, so a fully-parked 6 h window can render this panel completely EMPTY rather than flat — that is expected, not a broken feed.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -903,7 +903,7 @@
               "mode": "line"
             }
           },
-          "decimals": 1,
+          "decimals": 2,
           "mappings": [],
           "min": 0,
           "thresholds": {
@@ -915,15 +915,15 @@
               },
               {
                 "color": "orange",
-                "value": 3
+                "value": 0.21
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 0.34
               }
             ]
           },
-          "unit": "pressurepsi"
+          "unit": "pressurebar"
         },
         "overrides": []
       },
@@ -953,7 +953,7 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") AS \"tire_spread_psi\" FROM \"ioniq\" WHERE \"group\"='derived/tire_spread_psi' AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "query": "SELECT last(\"value\") AS \"tire_spread_bar\" FROM \"ioniq\" WHERE \"group\"='derived/tire_spread_bar' AND $timeFilter GROUP BY time($__interval) fill(previous)",
           "rawQuery": true,
           "refId": "A",
           "alias": "Inter-wheel spread"
@@ -967,7 +967,7 @@
         "type": "influxdb",
         "uid": "P3C6603E967DC8568"
       },
-      "description": "Age of the most recent derived tire sample (timestamp of last(tire_fl_psi_cold)). Because tire signals are driving-gated, an age of hours or days while parked is NORMAL and does NOT mean the feed is broken. Reduces the Time field with unit dateTimeFromNow and a fixed 30-day lookback (never count(), which cannot distinguish fresh from days-stale, and never $timeFilter, which would read \"No data\" the moment the window is empty).",
+      "description": "Age of the most recent derived tire sample (timestamp of last(tire_fl_bar_cold)). Because tire signals are driving-gated, an age of hours or days while parked is NORMAL and does NOT mean the feed is broken. Reduces the Time field with unit dateTimeFromNow and a fixed 30-day lookback (never count(), which cannot distinguish fresh from days-stale, and never $timeFilter, which would read \"No data\" the moment the window is empty).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1015,7 +1015,7 @@
             "type": "influxdb",
             "uid": "P3C6603E967DC8568"
           },
-          "query": "SELECT last(\"value\") FROM \"ioniq\" WHERE \"group\"='derived/tire_fl_psi_cold' AND time > now() - 30d",
+          "query": "SELECT last(\"value\") FROM \"ioniq\" WHERE \"group\"='derived/tire_fl_bar_cold' AND time > now() - 30d",
           "rawQuery": true,
           "refId": "A"
         }

--- a/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
@@ -9,6 +9,17 @@ apiVersion: 1
 # "last() Over a Long Window Defeats for:" in config/grafana/CLAUDE.md
 # (issue #1419). The real artefact filter is the wheel-freshness gate in
 # docker/automations/bots/ioniq-tpms.js (issues #1415/#1416).
+#
+# Units: the pressure rules query the *bar* series (`derived/tire_<w>_bar_cold`,
+# `derived/tire_spread_bar`) so the query, the threshold and the message text
+# are all in the unit the owner reads (issue #1478). The psi series is still
+# published and still carries the Tires dashboard's history.
+#
+# The thresholds are exact conversions of the psi ones at 1 bar = 14.5038 psi,
+# rounded to 2 decimals — 30 -> 2.07, 26 -> 1.79, 42 -> 2.90, spread 3 -> 0.21,
+# placard 36 -> 2.5. They look arbitrary because they are psi round numbers in
+# disguise; leave them until they are re-chosen in bar (issue #1479). Keeping
+# them exact is what makes the cutover a pure units change.
 
 groups:
   - orgId: 1
@@ -17,7 +28,7 @@ groups:
     interval: 1m
     rules:
       - uid: ioniq-tpms-fl-psi-low
-        title: "🚗 Ioniq Tire Low — FL"
+        title: "🚗 Ioniq Tyre Low — FL"
         condition: A
         data:
           - refId: q
@@ -26,7 +37,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_fl_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_fl_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -39,7 +50,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [30] }
+                - evaluator: { type: lt, params: [2.07] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -50,11 +61,11 @@ groups:
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FL (front-left) tire cold-pressure below 30 psi"
-          description: "Cold-normalized front-left tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+          summary: "🚗 FL (front-left) tyre cold-pressure below 2.07 bar"
+          description: "Cold-normalized front-left tyre pressure is under 2.07 bar (placard 2.5 bar). Inflate before the next drive; check for a slow leak."
 
       - uid: ioniq-tpms-fl-psi-crit
-        title: "🚗 Ioniq Tire Critical — FL"
+        title: "🚗 Ioniq Tyre Critical — FL"
         condition: A
         data:
           - refId: q
@@ -63,7 +74,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_fl_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_fl_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -76,7 +87,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [26] }
+                - evaluator: { type: lt, params: [1.79] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -87,11 +98,11 @@ groups:
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FL (front-left) tire cold-pressure below 26 psi"
-          description: "Cold-normalized front-left tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+          summary: "🚗 FL (front-left) tyre cold-pressure below 1.79 bar"
+          description: "Cold-normalized front-left tyre pressure is critically low (under 1.79 bar). Do not drive far — inflate or replace now to avoid tyre damage."
 
       - uid: ioniq-tpms-fl-overinflated
-        title: "🚗 Ioniq Tire Over-inflated — FL"
+        title: "🚗 Ioniq Tyre Over-inflated — FL"
         condition: A
         data:
           - refId: q
@@ -100,7 +111,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_fl_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_fl_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -113,7 +124,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: gt, params: [42] }
+                - evaluator: { type: gt, params: [2.90] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -124,11 +135,11 @@ groups:
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FL (front-left) tire cold-pressure above 42 psi"
-          description: "Cold-normalized front-left tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+          summary: "🚗 FL (front-left) tyre cold-pressure above 2.90 bar"
+          description: "Cold-normalized front-left tyre pressure is high (over 2.90 bar). Consider bleeding down toward the 2.5 bar placard for ride and wear."
 
       - uid: ioniq-tpms-fl-temp-excess
-        title: "🚗 Ioniq Tire Hot — FL"
+        title: "🚗 Ioniq Tyre Hot — FL"
         condition: A
         data:
           - refId: q
@@ -167,11 +178,11 @@ groups:
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FL (front-left) tire running hot vs the other wheels"
-          description: "front-left tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+          summary: "🚗 FL (front-left) tyre running hot vs the other wheels"
+          description: "front-left tyre is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
 
       - uid: ioniq-tpms-fr-psi-low
-        title: "🚗 Ioniq Tire Low — FR"
+        title: "🚗 Ioniq Tyre Low — FR"
         condition: A
         data:
           - refId: q
@@ -180,7 +191,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_fr_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_fr_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -193,7 +204,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [30] }
+                - evaluator: { type: lt, params: [2.07] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -204,11 +215,11 @@ groups:
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FR (front-right) tire cold-pressure below 30 psi"
-          description: "Cold-normalized front-right tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+          summary: "🚗 FR (front-right) tyre cold-pressure below 2.07 bar"
+          description: "Cold-normalized front-right tyre pressure is under 2.07 bar (placard 2.5 bar). Inflate before the next drive; check for a slow leak."
 
       - uid: ioniq-tpms-fr-psi-crit
-        title: "🚗 Ioniq Tire Critical — FR"
+        title: "🚗 Ioniq Tyre Critical — FR"
         condition: A
         data:
           - refId: q
@@ -217,7 +228,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_fr_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_fr_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -230,7 +241,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [26] }
+                - evaluator: { type: lt, params: [1.79] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -241,11 +252,11 @@ groups:
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FR (front-right) tire cold-pressure below 26 psi"
-          description: "Cold-normalized front-right tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+          summary: "🚗 FR (front-right) tyre cold-pressure below 1.79 bar"
+          description: "Cold-normalized front-right tyre pressure is critically low (under 1.79 bar). Do not drive far — inflate or replace now to avoid tyre damage."
 
       - uid: ioniq-tpms-fr-overinflated
-        title: "🚗 Ioniq Tire Over-inflated — FR"
+        title: "🚗 Ioniq Tyre Over-inflated — FR"
         condition: A
         data:
           - refId: q
@@ -254,7 +265,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_fr_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_fr_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -267,7 +278,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: gt, params: [42] }
+                - evaluator: { type: gt, params: [2.90] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -278,11 +289,11 @@ groups:
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FR (front-right) tire cold-pressure above 42 psi"
-          description: "Cold-normalized front-right tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+          summary: "🚗 FR (front-right) tyre cold-pressure above 2.90 bar"
+          description: "Cold-normalized front-right tyre pressure is high (over 2.90 bar). Consider bleeding down toward the 2.5 bar placard for ride and wear."
 
       - uid: ioniq-tpms-fr-temp-excess
-        title: "🚗 Ioniq Tire Hot — FR"
+        title: "🚗 Ioniq Tyre Hot — FR"
         condition: A
         data:
           - refId: q
@@ -321,11 +332,11 @@ groups:
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 FR (front-right) tire running hot vs the other wheels"
-          description: "front-right tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+          summary: "🚗 FR (front-right) tyre running hot vs the other wheels"
+          description: "front-right tyre is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
 
       - uid: ioniq-tpms-rl-psi-low
-        title: "🚗 Ioniq Tire Low — RL"
+        title: "🚗 Ioniq Tyre Low — RL"
         condition: A
         data:
           - refId: q
@@ -334,7 +345,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_rl_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_rl_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -347,7 +358,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [30] }
+                - evaluator: { type: lt, params: [2.07] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -358,11 +369,11 @@ groups:
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RL (rear-left) tire cold-pressure below 30 psi"
-          description: "Cold-normalized rear-left tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+          summary: "🚗 RL (rear-left) tyre cold-pressure below 2.07 bar"
+          description: "Cold-normalized rear-left tyre pressure is under 2.07 bar (placard 2.5 bar). Inflate before the next drive; check for a slow leak."
 
       - uid: ioniq-tpms-rl-psi-crit
-        title: "🚗 Ioniq Tire Critical — RL"
+        title: "🚗 Ioniq Tyre Critical — RL"
         condition: A
         data:
           - refId: q
@@ -371,7 +382,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_rl_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_rl_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -384,7 +395,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [26] }
+                - evaluator: { type: lt, params: [1.79] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -395,11 +406,11 @@ groups:
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RL (rear-left) tire cold-pressure below 26 psi"
-          description: "Cold-normalized rear-left tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+          summary: "🚗 RL (rear-left) tyre cold-pressure below 1.79 bar"
+          description: "Cold-normalized rear-left tyre pressure is critically low (under 1.79 bar). Do not drive far — inflate or replace now to avoid tyre damage."
 
       - uid: ioniq-tpms-rl-overinflated
-        title: "🚗 Ioniq Tire Over-inflated — RL"
+        title: "🚗 Ioniq Tyre Over-inflated — RL"
         condition: A
         data:
           - refId: q
@@ -408,7 +419,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_rl_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_rl_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -421,7 +432,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: gt, params: [42] }
+                - evaluator: { type: gt, params: [2.90] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -432,11 +443,11 @@ groups:
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RL (rear-left) tire cold-pressure above 42 psi"
-          description: "Cold-normalized rear-left tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+          summary: "🚗 RL (rear-left) tyre cold-pressure above 2.90 bar"
+          description: "Cold-normalized rear-left tyre pressure is high (over 2.90 bar). Consider bleeding down toward the 2.5 bar placard for ride and wear."
 
       - uid: ioniq-tpms-rl-temp-excess
-        title: "🚗 Ioniq Tire Hot — RL"
+        title: "🚗 Ioniq Tyre Hot — RL"
         condition: A
         data:
           - refId: q
@@ -475,11 +486,11 @@ groups:
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RL (rear-left) tire running hot vs the other wheels"
-          description: "rear-left tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+          summary: "🚗 RL (rear-left) tyre running hot vs the other wheels"
+          description: "rear-left tyre is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
 
       - uid: ioniq-tpms-rr-psi-low
-        title: "🚗 Ioniq Tire Low — RR"
+        title: "🚗 Ioniq Tyre Low — RR"
         condition: A
         data:
           - refId: q
@@ -488,7 +499,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_rr_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_rr_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -501,7 +512,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [30] }
+                - evaluator: { type: lt, params: [2.07] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -512,11 +523,11 @@ groups:
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RR (rear-right) tire cold-pressure below 30 psi"
-          description: "Cold-normalized rear-right tire pressure is under 30 psi (placard 36). Inflate before the next drive; check for a slow leak."
+          summary: "🚗 RR (rear-right) tyre cold-pressure below 2.07 bar"
+          description: "Cold-normalized rear-right tyre pressure is under 2.07 bar (placard 2.5 bar). Inflate before the next drive; check for a slow leak."
 
       - uid: ioniq-tpms-rr-psi-crit
-        title: "🚗 Ioniq Tire Critical — RR"
+        title: "🚗 Ioniq Tyre Critical — RR"
         condition: A
         data:
           - refId: q
@@ -525,7 +536,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_rr_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_rr_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -538,7 +549,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: lt, params: [26] }
+                - evaluator: { type: lt, params: [1.79] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -549,11 +560,11 @@ groups:
         for: 0s
         labels: { severity: critical, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RR (rear-right) tire cold-pressure below 26 psi"
-          description: "Cold-normalized rear-right tire pressure is critically low (under 26 psi). Do not drive far — inflate or replace now to avoid tire damage."
+          summary: "🚗 RR (rear-right) tyre cold-pressure below 1.79 bar"
+          description: "Cold-normalized rear-right tyre pressure is critically low (under 1.79 bar). Do not drive far — inflate or replace now to avoid tyre damage."
 
       - uid: ioniq-tpms-rr-overinflated
-        title: "🚗 Ioniq Tire Over-inflated — RR"
+        title: "🚗 Ioniq Tyre Over-inflated — RR"
         condition: A
         data:
           - refId: q
@@ -562,7 +573,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_rr_psi_cold' AND time >= now() - 6h
+                WHERE "group"='derived/tire_rr_bar_cold' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -575,7 +586,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: gt, params: [42] }
+                - evaluator: { type: gt, params: [2.90] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -586,11 +597,11 @@ groups:
         for: 0s
         labels: { severity: info, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RR (rear-right) tire cold-pressure above 42 psi"
-          description: "Cold-normalized rear-right tire pressure is high (over 42 psi). Consider bleeding down toward the 36 psi placard for ride and wear."
+          summary: "🚗 RR (rear-right) tyre cold-pressure above 2.90 bar"
+          description: "Cold-normalized rear-right tyre pressure is high (over 2.90 bar). Consider bleeding down toward the 2.5 bar placard for ride and wear."
 
       - uid: ioniq-tpms-rr-temp-excess
-        title: "🚗 Ioniq Tire Hot — RR"
+        title: "🚗 Ioniq Tyre Hot — RR"
         condition: A
         data:
           - refId: q
@@ -629,11 +640,11 @@ groups:
         for: 10m
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 RR (rear-right) tire running hot vs the other wheels"
-          description: "rear-right tire is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
+          summary: "🚗 RR (rear-right) tyre running hot vs the other wheels"
+          description: "rear-right tyre is more than 8 °C hotter than the mean of the other three wheels. Check for a dragging brake, low pressure, or a failing bearing."
 
       - uid: ioniq-tpms-spread-high
-        title: "🚗 Ioniq Tire Pressure Spread High"
+        title: "🚗 Ioniq Tyre Pressure Spread High"
         condition: A
         data:
           - refId: q
@@ -642,7 +653,7 @@ groups:
             model:
               query: |
                 SELECT last("value") FROM "ioniq"
-                WHERE "group"='derived/tire_spread_psi' AND time >= now() - 6h
+                WHERE "group"='derived/tire_spread_bar' AND time >= now() - 6h
               rawQuery: true
               resultFormat: time_series
           - refId: A
@@ -655,7 +666,7 @@ groups:
               refId: A
               hide: false
               conditions:
-                - evaluator: { type: gt, params: [3] }
+                - evaluator: { type: gt, params: [0.21] }
                   operator: { type: and }
                   query: { params: [q] }
                   reducer: { type: last }
@@ -666,5 +677,5 @@ groups:
         for: 0s
         labels: { severity: warning, device: ioniq, subsystem: tpms }
         annotations:
-          summary: "🚗 Tire cold-pressure spread above 3 psi across wheels"
-          description: "The cold-normalized pressures of the four tires differ by more than 3 psi. Even out inflation and check the lowest wheel for a leak."
+          summary: "🚗 Tyre cold-pressure spread above 0.21 bar across wheels"
+          description: "The cold-normalized pressures of the four tyres differ by more than 0.21 bar. Even out inflation and check the lowest wheel for a leak."

--- a/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
+++ b/config/grafana/provisioning/alerting/ioniq-tpms-alerts.yaml
@@ -13,13 +13,20 @@ apiVersion: 1
 # Units: the pressure rules query the *bar* series (`derived/tire_<w>_bar_cold`,
 # `derived/tire_spread_bar`) so the query, the threshold and the message text
 # are all in the unit the owner reads (issue #1478). The psi series is still
-# published and still carries the Tires dashboard's history.
+# published, but nothing reads it — it keeps writing only so its existing
+# InfluxDB history stays a continuous series.
 #
-# The thresholds are exact conversions of the psi ones at 1 bar = 14.5038 psi,
-# rounded to 2 decimals — 30 -> 2.07, 26 -> 1.79, 42 -> 2.90, spread 3 -> 0.21,
-# placard 36 -> 2.5. They look arbitrary because they are psi round numbers in
-# disguise; leave them until they are re-chosen in bar (issue #1479). Keeping
-# them exact is what makes the cutover a pure units change.
+# The thresholds are the psi ones converted at 1 bar = 14.5038 psi and rounded
+# to 2 decimals: 30 -> 2.07, 26 -> 1.79, 42 -> 2.90, spread 3 -> 0.21. That
+# rounding shifts each trip point by 0.02-0.07 psi (see the table in
+# docker/automations/bots/ioniq-tpms.js) — immaterial for tyre pressure, but it
+# is not exact, so this is a units change and not literally a no-op. They look
+# arbitrary because they are psi round numbers in disguise; leave them until
+# they are re-chosen in bar (issue #1479).
+#
+# The 2.5 bar placard quoted in the annotations is NOT one of these conversions
+# — 36 psi is 2.48 bar. 2.5 bar is the placard's own figure; the door label
+# carries both, and they are each rounded from 250 kPa independently.
 
 groups:
   - orgId: 1

--- a/docker/automations/bots/ioniq-tpms.js
+++ b/docker/automations/bots/ioniq-tpms.js
@@ -6,9 +6,12 @@
 // cold-normalization makes the number directly comparable.
 //
 // Each cold pressure is published in both units — `tire_<w>_psi_cold` and
-// `tire_<w>_bar_cold`, `tire_spread_psi` and `tire_spread_bar`. The alerts read
-// the bar series because the owner reads bar (issue #1478); the psi series is
-// kept because the Tires dashboard's history is in it.
+// `tire_<w>_bar_cold`, `tire_spread_psi` and `tire_spread_bar`. The alerts and
+// the Tires dashboard both read the bar series, because the owner reads bar
+// (issue #1478). Nothing reads the psi series any more: it is kept writing so
+// the years of psi points already in InfluxDB stay a continuous series rather
+// than a stub that stops on the cutover date. Retire it only together with
+// that history.
 //
 // TPMS refreshes only on wheel rotation: parked/charging samples are stale and the
 // sensor repeats its last reading verbatim. So we evaluate only fresh `active`
@@ -35,7 +38,7 @@ const stringify = require('fast-json-stable-stringify')
 const WHEELS = ['fl', 'fr', 'rl', 'rr']
 const TEMP_COEFF = 0.18 // psi per °C
 const REF_TEMP_C = 15 // cold reference temperature
-const PSI_PER_BAR = 14.5038
+const PSI_PER_BAR = 14.5038 // exact value 14.50377; the truncation is 1.8e-6 relative
 const AMBIENT_MAX_AGE_MS = 30 * 60 * 1000 // ambient older than this is not a reasonable reference
 
 // Widest allowed spread between the participating wheels' last-changed times. A
@@ -52,12 +55,26 @@ const SPEED_MAX_AGE_MS = 60 * 60 * 1000 // beyond this we no longer know whether
 
 const isFiniteNum = (x) => typeof x === 'number' && Number.isFinite(x)
 const round2 = (x) => Math.round(x * 100) / 100
-// Bar keeps one more decimal than psi so it resolves at least as finely:
-// 0.001 bar = 0.0145 psi, against 0.01 psi for the psi series. That matters
-// because the alert thresholds are exact conversions rounded to 2 decimals
-// (2.07 / 1.79 / 2.90 / 0.21 bar) — at 3 decimals each one trips within
-// ~0.02 psi of the psi rule it replaces, at 2 decimals it would drift 0.05 psi.
 const round3 = (x) => Math.round(x * 1000) / 1000
+
+// Bar is published at 3 decimals, one more than psi. This does NOT make it
+// finer than the psi series — 0.001 bar is 0.0145 psi, so it is ~45% coarser —
+// but it is fine enough not to add materially to the error that already exists
+// in the thresholds, and it stays injective on real data (raw psi arrives in
+// 0.2 psi steps and temps in whole °C, so cold pressures land on a 0.02 psi
+// lattice = 0.0014 bar apart, which 3 decimals never merges).
+//
+// Where the error actually comes from: the alert thresholds are the psi ones
+// converted and rounded to 2 decimals, and that rounding dominates. Effective
+// trip points against the psi rules they replace:
+//   low  <30 -> <2.07 bar   trips at 30.016 psi   (+0.021, fires slightly sooner)
+//   crit <26 -> <1.79 bar   trips at 25.955 psi   (-0.040, fires slightly later)
+//   over >42 -> >2.90 bar   trips at 42.068 psi   (+0.063, fires slightly later)
+//   spread >3 -> >0.21 bar  trips at  3.053 psi   (+0.048, fires slightly later)
+// Worst case ~0.07 psi, immaterial for tyre pressure. Publishing bar at only 2
+// decimals would add up to a further 0.07 psi on top; 4 decimals plus 4-decimal
+// thresholds would cut the whole thing to ~0.001 psi if exactness ever matters.
+const toBar = (psi) => round3(psi / PSI_PER_BAR)
 
 // The tpms frame nests each wheel: {"fl":{"psi":37,"c":37}, ...}. (The flat
 // "fl.psi" fields visible in InfluxDB are produced by the mqtt-influx converter
@@ -160,18 +177,19 @@ module.exports = function createIoniqTpms (name, config = {}) {
         return (Math.max(...stamps) - Math.min(...stamps)) <= wheelFreshnessWindowMs
       }
 
-      const publish = (signal, base, value, extra) => {
+      // `roundedValue` must already be rounded by the caller — this helper does
+      // not round, because psi and bar round to different precisions. Passing a
+      // raw float here ships full double precision to MQTT and InfluxDB.
+      const publish = (signal, base, roundedValue, extra) => {
         mqtt.publish(prefix + signal, {
           _type: 'ioniq',
           group: 'derived/' + signal,
           state: base.state,
           ts: base.ts,
-          value,
+          value: roundedValue,
           ...extra
         })
       }
-
-      const toBar = (psi) => round3(psi / PSI_PER_BAR)
 
       const onTpms = (payload) => {
         if (!payload || payload.state !== 'active') return
@@ -228,10 +246,10 @@ module.exports = function createIoniqTpms (name, config = {}) {
           }
         }
 
-        // Per-wheel cold pressures, in both units. The alerts and their message
-        // text read bar (the owner's unit — issue #1478); the psi series stays
-        // so the Tires dashboard keeps its trend history across the cutover.
-        // Both come off the same `cold[w]`, so they cannot drift apart.
+        // Per-wheel cold pressures, in both units. Everything downstream reads
+        // bar (the owner's unit — issue #1478); psi keeps writing only so its
+        // existing InfluxDB history stays continuous. Both are derived from the
+        // same unrounded `cold[w]` in the same frame, so they cannot drift.
         for (const w of WHEELS) {
           if (cold[w] === undefined) continue
           publish(`tire_${w}_psi_cold`, payload, round2(cold[w]), {

--- a/docker/automations/bots/ioniq-tpms.js
+++ b/docker/automations/bots/ioniq-tpms.js
@@ -1,9 +1,14 @@
 // ioniq-tpms: temperature-compensates the Ioniq's per-wheel tire pressures to a
 // 15 °C cold reference and derives cross-wheel signals (spread, per-wheel
 // temperature excess) onto ioniq/parsed/derived/* so Grafana can alert with a
-// trivial threshold. Raw psi is not comparable to the 36 psi cold placard because
-// pressure rises ~0.18 psi/°C, so a hot tire reads high; cold-normalization makes
-// the number directly comparable.
+// trivial threshold. Raw psi is not comparable to the 36 psi / 2.5 bar cold
+// placard because pressure rises ~0.18 psi/°C, so a hot tire reads high;
+// cold-normalization makes the number directly comparable.
+//
+// Each cold pressure is published in both units — `tire_<w>_psi_cold` and
+// `tire_<w>_bar_cold`, `tire_spread_psi` and `tire_spread_bar`. The alerts read
+// the bar series because the owner reads bar (issue #1478); the psi series is
+// kept because the Tires dashboard's history is in it.
 //
 // TPMS refreshes only on wheel rotation: parked/charging samples are stale and the
 // sensor repeats its last reading verbatim. So we evaluate only fresh `active`
@@ -30,6 +35,7 @@ const stringify = require('fast-json-stable-stringify')
 const WHEELS = ['fl', 'fr', 'rl', 'rr']
 const TEMP_COEFF = 0.18 // psi per °C
 const REF_TEMP_C = 15 // cold reference temperature
+const PSI_PER_BAR = 14.5038
 const AMBIENT_MAX_AGE_MS = 30 * 60 * 1000 // ambient older than this is not a reasonable reference
 
 // Widest allowed spread between the participating wheels' last-changed times. A
@@ -46,6 +52,12 @@ const SPEED_MAX_AGE_MS = 60 * 60 * 1000 // beyond this we no longer know whether
 
 const isFiniteNum = (x) => typeof x === 'number' && Number.isFinite(x)
 const round2 = (x) => Math.round(x * 100) / 100
+// Bar keeps one more decimal than psi so it resolves at least as finely:
+// 0.001 bar = 0.0145 psi, against 0.01 psi for the psi series. That matters
+// because the alert thresholds are exact conversions rounded to 2 decimals
+// (2.07 / 1.79 / 2.90 / 0.21 bar) — at 3 decimals each one trips within
+// ~0.02 psi of the psi rule it replaces, at 2 decimals it would drift 0.05 psi.
+const round3 = (x) => Math.round(x * 1000) / 1000
 
 // The tpms frame nests each wheel: {"fl":{"psi":37,"c":37}, ...}. (The flat
 // "fl.psi" fields visible in InfluxDB are produced by the mqtt-influx converter
@@ -154,10 +166,12 @@ module.exports = function createIoniqTpms (name, config = {}) {
           group: 'derived/' + signal,
           state: base.state,
           ts: base.ts,
-          value: round2(value),
+          value,
           ...extra
         })
       }
+
+      const toBar = (psi) => round3(psi / PSI_PER_BAR)
 
       const onTpms = (payload) => {
         if (!payload || payload.state !== 'active') return
@@ -214,18 +228,26 @@ module.exports = function createIoniqTpms (name, config = {}) {
           }
         }
 
-        // Per-wheel cold pressures.
+        // Per-wheel cold pressures, in both units. The alerts and their message
+        // text read bar (the owner's unit — issue #1478); the psi series stays
+        // so the Tires dashboard keeps its trend history across the cutover.
+        // Both come off the same `cold[w]`, so they cannot drift apart.
         for (const w of WHEELS) {
           if (cold[w] === undefined) continue
-          publish(`tire_${w}_psi_cold`, payload, cold[w], {
+          publish(`tire_${w}_psi_cold`, payload, round2(cold[w]), {
             psi: raw[`${w}.psi`], temp: compTemp[w]
+          })
+          publish(`tire_${w}_bar_cold`, payload, toBar(cold[w]), {
+            bar: toBar(raw[`${w}.psi`]), temp: compTemp[w]
           })
         }
 
         // Spread across all wheels that produced a cold pressure (needs >= 2).
         const coldVals = WHEELS.filter((w) => cold[w] !== undefined).map((w) => cold[w])
         if (coldVals.length >= 2) {
-          publish('tire_spread_psi', payload, Math.max(...coldVals) - Math.min(...coldVals))
+          const spread = Math.max(...coldVals) - Math.min(...coldVals)
+          publish('tire_spread_psi', payload, round2(spread))
+          publish('tire_spread_bar', payload, toBar(spread))
         }
 
         // Per-wheel temperature excess vs the mean of the OTHER wheels that have a
@@ -247,7 +269,7 @@ module.exports = function createIoniqTpms (name, config = {}) {
           const others = tempWheels.filter((o) => o !== w).map((o) => ownTemp[o])
           if (others.length === 0) continue
           const mean = others.reduce((a, b) => a + b, 0) / others.length
-          publish(`tire_${w}_temp_excess`, payload, ownTemp[w] - mean)
+          publish(`tire_${w}_temp_excess`, payload, round2(ownTemp[w] - mean))
         }
       }
 

--- a/docker/automations/bots/ioniq-tpms.test.js
+++ b/docker/automations/bots/ioniq-tpms.test.js
@@ -112,8 +112,8 @@ describe('ioniq-tpms bot', () => {
 
   // ---------------------------------------------------------------------------
   // Issue #1478: the owner reads tyre pressures in bar, so a parallel bar series
-  // is published next to the psi one and the alerts moved onto it. The psi
-  // series stays for dashboard trend continuity.
+  // is published next to the psi one and everything downstream moved onto it.
+  // The psi series keeps writing so its existing history stays continuous.
   // ---------------------------------------------------------------------------
   describe('bar output (issue #1478)', () => {
     it('emits a bar cold pressure for every wheel alongside the psi one', async () => {
@@ -141,6 +141,35 @@ describe('ioniq-tpms bot', () => {
       expect(published(mqtt, 'tire_spread_psi').value).toBe(1.58)
     })
 
+    // The fixture above is float-clean (33.0, 31.42 ... are exact), so it would
+    // still pass if psi lost its round2. These inputs do not: 35.4 - 0.18*23
+    // is 31.259999999999998 in IEEE-754. Pins that moving the rounding out of
+    // `publish` and into the call sites kept psi at 2 decimals.
+    it('still rounds the psi series to 2 decimals on values with float residue', async () => {
+      await mqtt._trigger(TPMS, sample({
+        fl: { psi: 37, c: 37 },
+        fr: { psi: 35.4, c: 38 },
+        rl: { psi: 35.8, c: 38 },
+        rr: { psi: 36.2, c: 38 }
+      }))
+      expect(published(mqtt, 'tire_fr_psi_cold').value).toBe(31.26)
+      expect(published(mqtt, 'tire_rl_psi_cold').value).toBe(31.66)
+      expect(published(mqtt, 'tire_spread_psi').value).toBe(1.78)
+    })
+
+    // The two units are derived from one unrounded figure, so the published
+    // pair must always agree to within the rounding of the coarser one.
+    it('keeps every bar value consistent with its psi twin', async () => {
+      await mqtt._trigger(TPMS, sample())
+      for (const w of ['fl', 'fr', 'rl', 'rr']) {
+        const psi = published(mqtt, `tire_${w}_psi_cold`).value
+        const bar = published(mqtt, `tire_${w}_bar_cold`).value
+        expect(bar * 14.5038).toBeCloseTo(psi, 1)
+      }
+      expect(published(mqtt, 'tire_spread_bar').value * 14.5038)
+        .toBeCloseTo(published(mqtt, 'tire_spread_psi').value, 1)
+    })
+
     it('carries the raw pressure in bar and the temperature used', async () => {
       await mqtt._trigger(TPMS, sample())
       // raw 36.6 psi / 14.5038 = 2.5235 bar
@@ -158,11 +187,9 @@ describe('ioniq-tpms bot', () => {
       }))
     })
 
-    // 3 decimals, not 2: 0.001 bar = 0.0145 psi, so the bar series resolves as
-    // finely as the 2-decimal psi one and the exact-conversion alert thresholds
-    // (2.07 / 1.79 / 2.90 / 0.21 bar) trip within ~0.02 psi of the psi rules
-    // they replace. Rounding to 2 decimals would move the 2.07 bar trip point
-    // 0.05 psi away from 30 psi.
+    // 3 decimals, not 2 — see the rounding note in the bot. At 2 decimals the
+    // bar series would quantise to 0.145 psi, adding up to 0.07 psi on top of
+    // the error the 2-decimal thresholds already carry.
     it('keeps three decimals of resolution', async () => {
       // 34.9 - 0.18*(35-15) = 31.3 psi -> 2.15807... bar
       await mqtt._trigger(TPMS, sample({ fl: { psi: 34.9, c: 35 } }))
@@ -466,6 +493,9 @@ describe('ioniq-tpms bot', () => {
       expect(excessCount(mqtt)).toBe(0)
       expect(published(mqtt, 'tire_rl_psi_cold')).toBeDefined()
       expect(published(mqtt, 'tire_spread_psi')).toBeDefined()
+      // The bar series is what the alerts read, so it must survive the gate too.
+      expect(published(mqtt, 'tire_rl_bar_cold')).toBeDefined()
+      expect(published(mqtt, 'tire_spread_bar')).toBeDefined()
     })
 
     it('resumes temp_excess once every wheel has refreshed inside the window', async () => {
@@ -524,6 +554,7 @@ describe('ioniq-tpms bot', () => {
       await mqtt._trigger(TPMS, hotFrame(Date.now()))
       expect(excessCount(mqtt)).toBe(0)
       expect(published(mqtt, 'tire_rr_psi_cold')).toBeDefined()
+      expect(published(mqtt, 'tire_rr_bar_cold')).toBeDefined()
     })
 
     it('suppresses temp_excess when the last motion is older than motionMaxAgeMs', async () => {

--- a/docker/automations/bots/ioniq-tpms.test.js
+++ b/docker/automations/bots/ioniq-tpms.test.js
@@ -110,6 +110,90 @@ describe('ioniq-tpms bot', () => {
     expect(published(mqtt, 'tire_fl_psi_cold').temp).toBe(25)
   })
 
+  // ---------------------------------------------------------------------------
+  // Issue #1478: the owner reads tyre pressures in bar, so a parallel bar series
+  // is published next to the psi one and the alerts moved onto it. The psi
+  // series stays for dashboard trend continuity.
+  // ---------------------------------------------------------------------------
+  describe('bar output (issue #1478)', () => {
+    it('emits a bar cold pressure for every wheel alongside the psi one', async () => {
+      await mqtt._trigger(TPMS, sample())
+      // 33.0 / 14.5038 = 2.2753 ; 31.42 -> 2.1663 ; 31.64 -> 2.1815 ; 32.24 -> 2.2229
+      expect(published(mqtt, 'tire_fl_bar_cold')).toEqual(expect.objectContaining({
+        _type: 'ioniq', group: 'derived/tire_fl_bar_cold', state: 'active', ts: 1000, value: 2.275
+      }))
+      expect(published(mqtt, 'tire_fr_bar_cold').value).toBe(2.166)
+      expect(published(mqtt, 'tire_rl_bar_cold').value).toBe(2.181)
+      expect(published(mqtt, 'tire_rr_bar_cold').value).toBe(2.223)
+    })
+
+    it('leaves the psi series byte-identical when the bar series is added', async () => {
+      await mqtt._trigger(TPMS, sample())
+      expect(published(mqtt, 'tire_fl_psi_cold')).toEqual({
+        _type: 'ioniq',
+        group: 'derived/tire_fl_psi_cold',
+        state: 'active',
+        ts: 1000,
+        value: 33.0,
+        psi: 36.6,
+        temp: 35
+      })
+      expect(published(mqtt, 'tire_spread_psi').value).toBe(1.58)
+    })
+
+    it('carries the raw pressure in bar and the temperature used', async () => {
+      await mqtt._trigger(TPMS, sample())
+      // raw 36.6 psi / 14.5038 = 2.5235 bar
+      expect(published(mqtt, 'tire_fl_bar_cold')).toEqual(expect.objectContaining({
+        bar: 2.523, temp: 35
+      }))
+      expect(published(mqtt, 'tire_fl_bar_cold')).not.toHaveProperty('psi')
+    })
+
+    it('emits tire_spread_bar = max - min of the cold pressures in bar', async () => {
+      await mqtt._trigger(TPMS, sample())
+      // 1.58 psi / 14.5038 = 0.1089 bar
+      expect(published(mqtt, 'tire_spread_bar')).toEqual(expect.objectContaining({
+        _type: 'ioniq', group: 'derived/tire_spread_bar', value: 0.109
+      }))
+    })
+
+    // 3 decimals, not 2: 0.001 bar = 0.0145 psi, so the bar series resolves as
+    // finely as the 2-decimal psi one and the exact-conversion alert thresholds
+    // (2.07 / 1.79 / 2.90 / 0.21 bar) trip within ~0.02 psi of the psi rules
+    // they replace. Rounding to 2 decimals would move the 2.07 bar trip point
+    // 0.05 psi away from 30 psi.
+    it('keeps three decimals of resolution', async () => {
+      // 34.9 - 0.18*(35-15) = 31.3 psi -> 2.15807... bar
+      await mqtt._trigger(TPMS, sample({ fl: { psi: 34.9, c: 35 } }))
+      expect(published(mqtt, 'tire_fl_bar_cold').value).toBe(2.158)
+    })
+
+    it('omits the bar series for a wheel with no usable pressure', async () => {
+      await mqtt._trigger(TPMS, sample({ fl: { c: 35 } }))
+      expect(published(mqtt, 'tire_fl_bar_cold')).toBeUndefined()
+      expect(published(mqtt, 'tire_fr_bar_cold')).toBeDefined()
+      // remaining cold: fr 31.42, rl 31.64, rr 32.24 -> 0.82 psi -> 0.0565 bar
+      expect(published(mqtt, 'tire_spread_bar').value).toBe(0.057)
+    })
+
+    it('does not emit tire_spread_bar when fewer than two wheels are valid', async () => {
+      await mqtt._trigger(TPMS, sample({
+        fr: { c: 36 }, rl: { c: 37 }, rr: { c: 37 }
+      }))
+      expect(published(mqtt, 'tire_fl_bar_cold')).toBeDefined()
+      expect(published(mqtt, 'tire_spread_bar')).toBeUndefined()
+    })
+
+    it('uses the ambient fallback temperature for the bar series too', async () => {
+      await mqtt._trigger(AMBIENT, { c: 25 })
+      await mqtt._trigger(TPMS, sample({ fl: { psi: 36.6 } }))
+      // 36.6 - 0.18*(25-15) = 34.8 psi -> 2.3994 bar
+      expect(published(mqtt, 'tire_fl_bar_cold').value).toBe(2.399)
+      expect(published(mqtt, 'tire_fl_bar_cold').temp).toBe(25)
+    })
+  })
+
   describe('active-only gating', () => {
     it.each(['parked', 'charging'])('emits nothing for state=%s', async (state) => {
       await mqtt._trigger(TPMS, sample({ state }))
@@ -278,10 +362,20 @@ describe('ioniq-tpms bot', () => {
       expect(published(mqtt, 'tire_rr_psi_cold').value).toBe(32.06)
     })
 
+    it('emits all four cold pressures in bar from a verbatim prod frame', async () => {
+      await mqtt._trigger(TPMS, PROD)
+      // the psi values above / 14.5038
+      expect(published(mqtt, 'tire_fl_bar_cold').value).toBe(2.278)
+      expect(published(mqtt, 'tire_fr_bar_cold').value).toBe(2.155)
+      expect(published(mqtt, 'tire_rl_bar_cold').value).toBe(2.183)
+      expect(published(mqtt, 'tire_rr_bar_cold').value).toBe(2.21)
+    })
+
     it('emits spread and temp_excess from a verbatim prod frame', async () => {
       await mqtt._trigger(TPMS, PROD)
       // max 33.04 (fl) - min 31.26 (fr) = 1.78
       expect(published(mqtt, 'tire_spread_psi').value).toBe(1.78)
+      expect(published(mqtt, 'tire_spread_bar').value).toBe(0.123)
       // fl: 37 - mean(38,38,38) = -1
       expect(published(mqtt, 'tire_fl_temp_excess').value).toBe(-1)
     })

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -216,20 +216,23 @@ because it is the sensor that fails — issue #1472)
     (`value = psi − 0.18·(temp − 15)` psi, using the wheel's own `.c` temp, falling back to
     `ambient.c`), rounded to 2 decimals. Extra fields `psi` (raw psi) and `temp` (temperature used).
     Only emitted for fresh `state='active'` samples, de-duplicated against frozen readings.
-    **No alert reads this series** — the TPMS rules moved to `derived/tire_<w>_bar_cold` in #1478;
-    it is kept for the `Ioniq EV / Tires` dashboard's trend history.
+    **Nothing reads this series any more** — both the alerts and the `Ioniq EV / Tires` dashboard
+    moved to `derived/tire_<w>_bar_cold` in #1478. It keeps writing so the psi history already in
+    InfluxDB stays a continuous series; retire it only together with that history.
   - `derived/tire_<w>_bar_cold` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — `ioniq-tpms`: the same cold-normalized
-    per-wheel pressure expressed in bar (`value` = the psi figure ÷ 14.5038), rounded to **3**
-    decimals so the series resolves at least as finely as the 2-decimal psi one (0.001 bar =
-    0.0145 psi). Extra fields `bar` (raw uncompensated pressure in bar) and `temp`. Published in the
-    same frame as, and from the same figure as, `tire_<w>_psi_cold`, so the two cannot drift apart.
-    Grafana `ioniq-tpms-*-psi-low` (`< 2.07` warn) / `-psi-crit` (`< 1.79` crit) / `-overinflated`
-    (`> 2.90` info) rules alert on it — the rule uids still say `psi` for continuity; the thresholds
-    are exact conversions of the former 30 / 26 / 42 psi ones (issue #1478).
+    per-wheel pressure expressed in bar. `value` = the **unrounded** cold pressure ÷ 14.5038,
+    rounded to 3 decimals (so it can differ from `psi_cold ÷ 14.5038` in the third decimal). 3
+    decimals is 0.0145 psi — coarser than the 2-decimal psi series, but finer than the spacing of
+    real readings. Extra fields `bar` (raw uncompensated pressure in bar) and `temp`. Published in
+    the same frame as `tire_<w>_psi_cold` and derived from the same figure, so the two cannot drift
+    apart. Grafana `ioniq-tpms-*-psi-low` (`< 2.07` warn) / `-psi-crit` (`< 1.79` crit) /
+    `-overinflated` (`> 2.90` info) rules alert on it — the rule uids still say `psi` for continuity.
+    The thresholds are the former 30 / 26 / 42 psi ones converted and rounded to 2 decimals, which
+    shifts each trip point by 0.02-0.07 psi (issue #1478).
   - `derived/tire_spread_psi` — `ioniq-tpms`: `value` = max − min of the four cold-normalized
-    pressures (psi), 2 decimals. No alert reads it; kept for dashboard history.
+    pressures (psi), 2 decimals. No reader left; kept writing for history, as above.
   - `derived/tire_spread_bar` — `ioniq-tpms`: the same spread in bar (÷ 14.5038), 3 decimals.
-    Grafana `ioniq-tpms-spread-high` alerts on `value > 0.21` (the exact conversion of 3 psi).
+    Grafana `ioniq-tpms-spread-high` alerts on `value > 0.21` (3 psi converted).
   - `derived/tire_<w>_temp_excess` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — `ioniq-tpms`: `value` = wheel
     temperature minus the mean temperature of the other three wheels (°C). Grafana
     `ioniq-tpms-<w>-temp-excess` alerts on `value > 8`.

--- a/docs/influxdb-schema.md
+++ b/docs/influxdb-schema.md
@@ -214,11 +214,22 @@ because it is the sensor that fails — issue #1472)
   - `derived/tire_<w>_psi_cold` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — bot-produced by the `ioniq-tpms`
     automations bot: per-wheel tire pressure temperature-compensated to a 15 °C cold reference
     (`value = psi − 0.18·(temp − 15)` psi, using the wheel's own `.c` temp, falling back to
-    `ambient.c`). Extra fields `psi` (raw psi) and `temp` (temperature used). Only emitted for fresh
-    `state='active'` samples, de-duplicated against frozen readings. Grafana `ioniq-tpms-*-psi-low`
-    (`< 30` warn) / `-psi-crit` (`< 26` crit) / `-overinflated` (`> 42` info) rules alert on it.
+    `ambient.c`), rounded to 2 decimals. Extra fields `psi` (raw psi) and `temp` (temperature used).
+    Only emitted for fresh `state='active'` samples, de-duplicated against frozen readings.
+    **No alert reads this series** — the TPMS rules moved to `derived/tire_<w>_bar_cold` in #1478;
+    it is kept for the `Ioniq EV / Tires` dashboard's trend history.
+  - `derived/tire_<w>_bar_cold` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — `ioniq-tpms`: the same cold-normalized
+    per-wheel pressure expressed in bar (`value` = the psi figure ÷ 14.5038), rounded to **3**
+    decimals so the series resolves at least as finely as the 2-decimal psi one (0.001 bar =
+    0.0145 psi). Extra fields `bar` (raw uncompensated pressure in bar) and `temp`. Published in the
+    same frame as, and from the same figure as, `tire_<w>_psi_cold`, so the two cannot drift apart.
+    Grafana `ioniq-tpms-*-psi-low` (`< 2.07` warn) / `-psi-crit` (`< 1.79` crit) / `-overinflated`
+    (`> 2.90` info) rules alert on it — the rule uids still say `psi` for continuity; the thresholds
+    are exact conversions of the former 30 / 26 / 42 psi ones (issue #1478).
   - `derived/tire_spread_psi` — `ioniq-tpms`: `value` = max − min of the four cold-normalized
-    pressures (psi). Grafana `ioniq-tpms-spread-high` alerts on `value > 3`.
+    pressures (psi), 2 decimals. No alert reads it; kept for dashboard history.
+  - `derived/tire_spread_bar` — `ioniq-tpms`: the same spread in bar (÷ 14.5038), 3 decimals.
+    Grafana `ioniq-tpms-spread-high` alerts on `value > 0.21` (the exact conversion of 3 psi).
   - `derived/tire_<w>_temp_excess` (`w` ∈ `fl`,`fr`,`rl`,`rr`) — `ioniq-tpms`: `value` = wheel
     temperature minus the mean temperature of the other three wheels (°C). Grafana
     `ioniq-tpms-<w>-temp-excess` alerts on `value > 8`.

--- a/docs/ioniq-monitoring-alerting-spec.md
+++ b/docs/ioniq-monitoring-alerting-spec.md
@@ -127,12 +127,14 @@ Suppress "low voltage" firing while `hv_kw` is high — 12.9 V float under heavy
 
 Cold-normalize each wheel to 15 °C before thresholding: `psi_cold = psi − 0.18·(temp − 15)`. TPMS only refreshes on wheel rotation, so evaluate on **fresh, `state=active` samples only** (dedupe parked duplicates).
 
+The bot publishes each cold pressure in **both units** — `derived/tire_<w>_psi_cold` and `derived/tire_<w>_bar_cold`, `derived/tire_spread_psi` and `derived/tire_spread_bar`. The alerts read the **bar** series and quote bar, because that is the unit the owner reads (issue #1478); the psi series is retained for dashboard trend history. Thresholds below are given in both, at `1 bar = 14.5038 psi`.
+
 | Signal | Condition | Threshold | Sev | for | Platform |
 |---|---|---|---|---|---|
-| Per-wheel `psi_cold` | under-inflation | `<30` warn / `<26` crit (placard 36; no spare → stranding risk) | warning / **critical** | — | **Bot** `ioniq-tpms` → `derived/tire_<w>_psi_cold` (+ Grafana threshold) |
-| Inter-wheel `psi_cold` | developing imbalance/leak | max−min `>3 psi` (baseline 1.2) | warning | — | **Bot** → `derived/tire_spread_psi` |
+| Per-wheel cold pressure | under-inflation | `<2.07 bar` (30 psi) warn / `<1.79 bar` (26 psi) crit (placard 2.5 bar / 36 psi; no spare → stranding risk) | warning / **critical** | — | **Bot** `ioniq-tpms` → `derived/tire_<w>_bar_cold` (+ Grafana threshold) |
+| Inter-wheel cold pressure | developing imbalance/leak | max−min `>0.21 bar` (3 psi; baseline 0.08 bar) | warning | — | **Bot** → `derived/tire_spread_bar` |
 | Per-wheel temp | brake drag / bearing | wheel `> others_mean + 8 °C`, ≥2 samples, active | warning | — | **Bot** → `derived/tire_<w>_temp_excess` |
-| Over-inflation `psi_cold` | hard ride/over-pressure | `>42 psi` | info | — | **Bot**/Grafana |
+| Over-inflation cold pressure | hard ride/over-pressure | `>2.90 bar` (42 psi) | info | — | **Bot**/Grafana |
 | TPMS freshness | dead sensor / gap | no changed TPMS value in `>72 h driving` | info | — | Grafana staleness |
 
 ### 4.4 Faults (DTC)
@@ -180,7 +182,7 @@ All bots follow the repo pattern (`module.exports = (name, config) => ({ persist
 | `ioniq-12v-ldc` | new | `…/bms/2101` | `ldc_ok` (0/1), `aux12v_drop` | Rolling window of `aux_12v`,`ignition`,`hv_kw`; flag LDC-not-charging under the low-load rule; compute drop rate. |
 | `ioniq-charge-guard` | new | `…/bms/2101`, `…/bcm` (charge_connector), `…/obc` | `soc_at_park`, `charge_stalled`, `charge_reduced_rate` | State-edge SoC capture; stalled = relay on + low power (reuse `timeout-emit` semantics); reduced-rate classifier. |
 | `ioniq-dtc` | new (thin) | `ioniq/parsed/dtc/#` | `dtc_count` (+ `codes`) | `codes.length`; pass code list through for the message. Could be a `mqtt-transform` config rather than bespoke code. |
-| `ioniq-tpms` | new | `ioniq/parsed/tpms`, `…/ambient` | `tire_<w>_psi_cold`, `tire_spread_psi`, `tire_<w>_temp_excess` | Cold-normalize; dedupe non-active/frozen; cross-wheel outliers. |
+| `ioniq-tpms` | new | `ioniq/parsed/tpms`, `…/ambient` | `tire_<w>_psi_cold` + `tire_<w>_bar_cold`, `tire_spread_psi` + `tire_spread_bar`, `tire_<w>_temp_excess` | Cold-normalize; publish psi and bar; dedupe non-active/frozen; cross-wheel outliers. |
 
 Wire them in `config/automations/config.js` alongside existing bots. Where a generic bot fits (`timeout-emit` for charge-stalled, `stateful-counter`/`mqtt-transform` for DTC), prefer configuration over new code.
 
@@ -245,7 +247,7 @@ New `Ioniq EV` dashboard family (JSON under `config/grafana/dashboards/`, provid
 | **Overview** | SoC + SoC_display gauge; pack V/A/kW; 12 V (color-banded); current DTC status; connectivity/last-seen stat; odometer; current tire pressures (4 stats); active alert list. |
 | **Battery health** | SoC & SoH trend; cell max/min/spread (derived) timeseries; 12-module temp heatmap + spread; isolation; available charge/discharge envelope; cumulative Ah/kWh + derived usable-Ah and round-trip efficiency. |
 | **12 V / LDC** | `aux_12v` timeseries banded by state; per-drive LDC on-voltage ceiling; parked resting-voltage trend (daily min/median); derived `ldc_ok`. |
-| **Tires** | Per-wheel `psi_cold` trend; inter-wheel spread; per-wheel temp vs ambient; over/under-inflation bands. |
+| **Tires** | Per-wheel cold-pressure trend (bar); inter-wheel spread (bar); per-wheel temp vs ambient; over/under-inflation bands. |
 | **Trips & charging** | State timeline (active/charging/parked); per-trip distance/energy/efficiency (kWh/100 km); regen recovery %; charge sessions (AC/DC, kWh, avg power); SoC-at-park distribution; charger-meter AC power overlay (if live). |
 
 > **Data source (2026-07-18):** this dashboard was previously **deferred** — per-trip distance/energy/

--- a/docs/ioniq-monitoring-alerting-spec.md
+++ b/docs/ioniq-monitoring-alerting-spec.md
@@ -278,8 +278,8 @@ Each rule's `annotations.description` should carry the first action. Summary tab
 | SoH step / low | Log; compare to warranty threshold (Ioniq ~ replaceable <65–70%). |
 | 12 V low at rest | Charge/replace 12 V before next lock cycle; it strands the car. |
 | LDC not charging | DC-DC converter suspect; verify with a drive; service if repeats. |
-| Tire low / outlier | Top up (FR first per baseline); if it recurs, inspect for leak/nail. |
-| Tire temp outlier | Check for dragging brake / seizing bearing on that corner. |
+| Tyre low / outlier | Top up (FR first per baseline); if it recurs, inspect for leak/nail. |
+| Tyre temp outlier | Check for dragging brake / seizing bearing on that corner. |
 | **DTC present** | Read code(s) from the message; decode; act by code. |
 | Logger offline (unexpected) | Check box power/BLE; distinguish from normal post-lock power-off. |
 | Charge stalled / reduced-rate | Check cable/EVSE; confirm target SoC reached. |


### PR DESCRIPTION
Closes #1478.

The Ioniq TPMS derived signals and all the pressure alerts were expressed in psi, so every notification needed converting before it meant anything. This publishes a parallel bar series and moves the alerts, the message text and the Tires dashboard onto it, so query, threshold and prose are all in one unit and cannot drift apart.

## What changed

| | before | after |
|---|---|---|
| per-wheel cold pressure | `derived/tire_<w>_psi_cold` | **+** `derived/tire_<w>_bar_cold` |
| cross-wheel spread | `derived/tire_spread_psi` | **+** `derived/tire_spread_bar` |

Both units come off the same unrounded cold-normalized figure in the same frame. Bar is published at 3 decimals, psi stays at 2.

- **`ioniq-tpms` bot** — publishes both units; psi output unchanged (pinned by a test using a fixture with IEEE-754 residue, mutation-verified).
- **13 alert rules** — the 12 per-wheel pressure rules + the spread rule query the bar series and threshold in bar. The 4 `temp-excess` rules are in °C and are untouched apart from wording. Rule **uids are deliberately unchanged** (they still read `-psi-low`), so all 17 rules are updated in place and none is orphaned — renaming them would need a `delete-*.yaml` and would leave stale psi rules paging in the old unit during the overlap.
- **Annotations** quote the value and the placard in bar, and say "tyre".
- **`Ioniq EV / Tires` dashboard** — six pressure panels on the bar series, bar axis unit, bands matching the rules.
- **Docs** — `docs/influxdb-schema.md` (required by the repo's InfluxDB schema rule) and the Ioniq monitoring spec.

## Thresholds

Exact conversions at 1 bar = 14.5038 psi, rounded to 2 decimals as the issue specified:

| rule | psi | bar | effective trip point | shift |
|---|---|---|---|---|
| low (warning) | 30 | 2.07 | 30.016 psi | +0.021 |
| critical | 26 | 1.79 | 25.955 psi | −0.040 |
| over-inflated | 42 | 2.90 | 42.068 psi | +0.063 |
| spread | 3 | 0.21 | 3.053 psi | +0.048 |

Worth being precise about, since the issue asked for no behaviour change: rounding the *thresholds* to 2 decimals moves each trip point by 0.02–0.07 psi. Immaterial for tyre pressure, but it is not literally a no-op — a tyre at exactly 30.00 psi cold now raises a Low warning where it previously did not. Making it exact would need 4-decimal thresholds; that belongs with #1479, which re-chooses these numbers in bar anyway.

The 2.5 bar placard is **not** one of these conversions (36 psi is 2.48 bar) — it is the placard's own figure, both roundings of 250 kPa.

## Deploy notes

- **Deploy `automations` before Grafana.** The bar series does not exist until the bot ships *and* the car is next driven (TPMS only publishes on wheel rotation). Until then the pressure rules see no rows.
- **Exposure from that gap is bounded and small**: the psi rules already self-clear ~6 h after the car sleeps (`last()` over a 6 h window, `noDataState: OK`), so this does not create a new class of silence — the first post-deploy evaluation is `NoData` rather than a held value.
- **The Tires dashboard shows no pressure history from before the cutover**, since no panel reads psi any more. The psi series keeps writing and stays queryable at 14.5038 psi/bar. Called out in the dashboard description.
- **Titles changed "Tire" → "Tyre"**, which changes the `alertname` label. Routing is unaffected (`notification-policies.yaml` matches on `device` and `severity` only), but any UI-created silence matching the old alertname will stop matching — worth a look at `/alerting/silences` before deploying.

## Verification

- `npm run validate` in `.github/scripts/validate-grafana-alerts/` — all 62 evaluators pass, 17 in this file.
- Full automations suite: 565 tests / 17 suites green; `ioniq-tpms` 55 tests.
- Grafana's `pressurebar` was checked against the value formatter in the deployed `9.5.21` image: it is SI-prefixed and renders sub-1 values as mbar, so the pressure panels use the non-scaling `suffix: bar` instead.

The last checklist item — a live alert firing once after deploy with the text reading in bar — can only be ticked on `routy` after merge.

https://claude.ai/code/session_019STrKKL3ExnRyncYFABM6n